### PR TITLE
Add date-based Logos release tag helper

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b
+      - name: Check shell scripts
+        run: bash -n scripts/*.sh
 
   logos:
     needs: workflows

--- a/nix/nixos/hosts/logos/README.md
+++ b/nix/nixos/hosts/logos/README.md
@@ -14,19 +14,35 @@ The installer ISO is written under `result/iso/`.
 
 ## Publish an installer release
 
-After this configuration is merged, push a tag beginning with `logos-`:
+After this configuration is merged, run the release helper from anywhere inside
+the repository:
 
 ```sh
-git tag logos-2026.07.1
-git push origin logos-2026.07.1
+./scripts/tag-logos-release.sh
 ```
 
-The **Publish Logos ISO** workflow automatically builds the installer and creates
-or updates the matching GitHub Release. The release contains directly
-downloadable assets, not an Actions ZIP:
+It fetches remote tags, requires a clean working tree, and creates the next
+available date-based tag:
 
-- `logos-nixos-2026.07.1.iso`
-- `logos-nixos-2026.07.1.iso.sha256`
+```text
+logos-2026.07.17
+logos-2026.07.17.2
+logos-2026.07.17.3
+```
+
+Use `--dry-run` to preview the next tag or `--yes` to skip confirmation:
+
+```sh
+./scripts/tag-logos-release.sh --dry-run
+./scripts/tag-logos-release.sh --yes
+```
+
+Pushing the tag starts the **Publish Logos ISO** workflow, which creates or
+updates the matching GitHub Release. The release contains directly downloadable
+assets, not an Actions ZIP:
+
+- `logos-nixos-2026.07.17.iso`
+- `logos-nixos-2026.07.17.iso.sha256`
 
 The workflow can also be run manually from GitHub Actions with a `logos-*`
 release tag.

--- a/scripts/tag-logos-release.sh
+++ b/scripts/tag-logos-release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: tag-logos-release.sh [--yes] [--dry-run] [--remote NAME]
+
+Creates and pushes the next available date-based Logos release tag:
+  logos-YYYY.MM.DD
+  logos-YYYY.MM.DD.2
+  logos-YYYY.MM.DD.3
+
+Environment:
+  LOGOS_RELEASE_DATE=YYYY.MM.DD  Override the date, mainly for testing.
+EOF
+}
+
+remote="origin"
+assume_yes=false
+dry_run=false
+
+while (($#)); do
+  case "$1" in
+    --yes|-y)
+      assume_yes=true
+      ;;
+    --dry-run|-n)
+      dry_run=true
+      ;;
+    --remote)
+      shift
+      [[ $# -gt 0 ]] || { echo "--remote requires a value" >&2; exit 2; }
+      remote="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Run this inside the dotfiles Git repository." >&2
+  exit 1
+}
+cd "$repo_root"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is not clean. Commit or stash changes before releasing." >&2
+  exit 1
+fi
+
+git remote get-url "$remote" >/dev/null 2>&1 || {
+  echo "Git remote '$remote' does not exist." >&2
+  exit 1
+}
+
+git fetch --quiet --tags "$remote"
+
+release_date="${LOGOS_RELEASE_DATE:-$(date +%Y.%m.%d)}"
+[[ "$release_date" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]] || {
+  echo "Invalid release date '$release_date'; expected YYYY.MM.DD." >&2
+  exit 1
+}
+
+base_tag="logos-${release_date}"
+tag="$base_tag"
+sequence=2
+
+while git rev-parse --quiet --verify "refs/tags/$tag" >/dev/null; do
+  tag="${base_tag}.${sequence}"
+  sequence=$((sequence + 1))
+done
+
+commit="$(git rev-parse HEAD)"
+printf 'Release tag: %s\nCommit:      %s\nRemote:      %s\n' "$tag" "$commit" "$remote"
+
+if $dry_run; then
+  exit 0
+fi
+
+if ! $assume_yes; then
+  read -r -p "Create and push this tag? [y/N] " answer
+  [[ "$answer" =~ ^[Yy]$ ]] || {
+    echo "Cancelled."
+    exit 1
+  }
+fi
+
+git tag --annotate "$tag" --message "Logos NixOS installer release $tag"
+git push "$remote" "refs/tags/$tag"
+
+echo "Pushed $tag. GitHub Actions will build and publish the ISO under Releases."


### PR DESCRIPTION
## Summary

Add an executable helper that creates and pushes the next unused date-based Logos release tag.

## Usage

```sh
./scripts/tag-logos-release.sh
```

Generated tags use:

```text
logos-YYYY.MM.DD
logos-YYYY.MM.DD.2
logos-YYYY.MM.DD.3
```

## Behavior

- works from anywhere inside the repository
- requires a clean working tree
- fetches tags from the selected remote before choosing a name
- creates an annotated tag for the current commit
- asks before pushing unless `--yes` is supplied
- supports `--dry-run` and `--remote NAME`
- pushing the tag starts the existing ISO Release workflow
- CI runs `bash -n` across repository shell scripts

## Authorship

This pull request and its implementation were produced by GPT at the repository owner's request.