### PR TITLE
emacs: open to org agenda on startup

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -269,6 +269,11 @@ The optional argument NEW-WINDOW is not used."
                   :todo ("DONE"))
            )))
 
+(setq initial-buffer-choice
+      (lambda ()
+        (org-agenda nil "a")
+        (get-buffer "*Org Agenda*")))
+
 (map! :leader
       :desc "Tangle a file"
       "b t" #'org-babel-tangle)

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -564,7 +564,14 @@ I prefer being able to have different views within org agenda, so i can see what
            (:name "✅ Done"
                   :todo ("DONE"))
            )))
-
+#+end_src
+**** Open to agenda on startup
+By default doom opens to the =*scratch*= buffer. I want emacs to boot straight into my (super) agenda so the first thing I see is what needs doing today.
+#+begin_src emacs-lisp
+(setq initial-buffer-choice
+      (lambda ()
+        (org-agenda nil "a")
+        (get-buffer "*Org Agenda*")))
 #+end_src
 *** Babel
 Tangle a file


### PR DESCRIPTION
Opens emacs to the org agenda (with `org-super-agenda` groups already applied) instead of the `*scratch*` buffer, by setting `initial-buffer-choice`.

Changes the literate `config.org` (and re-tangled `config.el`).

Bench (`.doom.d/bench-startup.sh`):
- RUN 1: real 2.49s
- RUN 2: real 1.97s