### PR TITLE
qtile: fix Flameshot timeout and stabilize Picom

### DIFF
--- a/.config/flameshot/flameshot.ini
+++ b/.config/flameshot/flameshot.ini
@@ -1,0 +1,2 @@
+[General]
+useX11LegacyScreenshot=true

--- a/.config/picom/picom.conf
+++ b/.config/picom/picom.conf
@@ -1,329 +1,45 @@
-#################################
-#
-# Backend
-#
-#################################
+backend = "xrender";
+vsync = true;
+use-damage = true;
 
-# Backend to use: "xrender" or "glx".
-# GLX backend is typically much faster but depends on a sane driver.
-
-# backend = "xrender";
-# backend = "xr_glx_hybrid";
-backend = "glx";
-
-#################################
-#
-# GLX backend
-#
-#################################
-
-glx-no-stencil = true;
-
-# GLX backend: Copy unmodified regions from front buffer instead of redrawing them all.
-# My tests with nvidia-drivers show a 10% decrease in performance when the whole screen is modified,
-# but a 20% increase when only 1/4 is.
-# My tests on nouveau show terrible slowdown.
-# Useful with --glx-swap-method, as well.
-glx-copy-from-front = false;
-
-# GLX backend: Use MESA_copy_sub_buffer to do partial screen update.
-# My tests on nouveau shows a 200% performance boost when only 1/4 of the screen is updated.
-# May break VSync and is not available on some drivers.
-# Overrides --glx-copy-from-front.
-# glx-use-copysubbuffermesa = true;
-
-# GLX backend: Avoid rebinding pixmap on window damage.
-# Probably could improve performance on rapid window content changes, but is known to break things on some drivers (LLVMpipe).
-# Recommended if it works.
-
-glx-no-rebind-pixmap = true;
-
-
-use-damage = false;
-
-# Disabled to avoid artifacts painting under blur transparent windows.
-
-#################################
-#
-# Shadows
-#
-#################################
-
-# Enabled client-side shadows on windows.
 shadow = true;
+shadow-radius = 7;
+shadow-offset-x = -7;
+shadow-offset-y = -7;
+shadow-opacity = 0.75;
 
-
-# The blur radius for shadows. (default 12)
-shadow-radius = 35;
-# The left offset for shadows. (default -15)
-shadow-offset-x = -35;
-# The top offset for shadows. (default -15)
-shadow-offset-y = -35;
-# The translucency for shadows. (default .75)
-shadow-opacity = 0.8;
-
-# Set if you want different colour shadows
-# shadow-red = 0.0;
-# shadow-green = 0.0;
-# shadow-blue = 0.0;
-
-
-
-# shadow-exclude-reg = "x10+0+0";
-# xinerama-shadow-crop = true;
-
-
-# The shadow exclude options are helpful if you have shadows enabled. Due to the way compton draws its shadows, certain applications will have visual glitches
-# (most applications are fine, only apps that do weird things with xshapes or argb are affected).
-# This list includes all the affected apps I found in my testing. The "! name~=''" part excludes
-# shadows on any "Unknown" windows, this prevents a visual glitch with the XFWM alt tab switcher.
-
-# shadow-exclude = "n:e:Notification";
-
-shadow-exclude = [
-	"_GTK_FRAME_EXTENTS@:c",
-	# Removed to avoid no-shadow in modal dialog windows.
-	# "! name~=''",
-    "name = 'Notification'",
-    "name = 'Plank'",
-    "name = 'Docky'",
-    "name = 'Kupfer'",
-	"name = 'Pensela'",
-	"name = 'Drawing Board'",
-	#
-	# Workaround for VirtualBox empty window at launching
-	"name = 'VirtualBox'",
-	"name = 'VirtualBoxVM'",
-	#
-	# Avoid shadow in Negatron popups
-	"name = 'Negatron v0.100.1' && argb",
-	#
-	# Avoid shadow for the XFCE alt tab TaskSwitcher
-    "name ?= 'xfwm4' && argb",
-	#
-    # "name *= 'compton'",
-    "class_g = 'Conky'",
-    "class_g = 'Kupfer'",
-    "class_g = 'Synapse'",
-    "class_g ?= 'Notify-osd'",
-    "class_g ?= 'Cairo-dock'",
-	"class_g = 'Cairo-clock'",
-    "class_g ?= 'Xfce4-notifyd'",
-	#
-	# Exclude special Firefox/Firefox-esr/Thunderbird dropdowns.
-  	# Ref: https://github.com/chjj/compton/issues/247
-	 "class_g = 'Thunderbird' && argb",
-	 "class_g = 'Telegram' && argb",
-	 "name ?= 'Thunderbird' && (window_type = 'utility' || window_type = 'popup_menu')",
-	#
-	# Exclude some special popup menu shadows, but Modal Windows.
-	# These are more finetuning thant previous ones:
-	"class_g ?= 'Thunderbird' && class_i = 'Popup' && argb",
-	"class_g = 'firefox' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'Firefox' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'firefox-esr' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'Firefox-esr' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'Tor Browser' && (window_type = 'utility') && argb",
-	"class_g = 'Navegador Tor' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'Thunderbird' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-	"class_g = 'Mozilla Thunderbird' && (window_type = 'utility' || window_type = 'popup_menu') && argb",
-    "class_g ?= 'Xfce4-power-manager'",
-	#
-	# Exclude Vokoscreen and VokoscreenNG area selector
-	#
-	"class_g ?= 'vokoscreen' && argb",
-	"name = 'Área'",
-	"name *= 'Cuenta regresiva'",
-	"_NET_WM_WINDOW_TYPE:a *= '_KDE_NET_WM_WINDOW_TYPE_OVERRIDE'"
-#	"override_redirect = true"
-];
-# Avoid drawing shadow on all shaped windows (see also: --detect-rounded-corners)
-#  Deprecated, use --shadow-exclude 'bounding_shaped' or --shadow-exclude 'bounding_shaped && !rounded_corners' instead.
-shadow-ignore-shaped = false;
-
-
-
-
-#################################
-#
-# Opacity
-#
-#################################
-
-
-inactive-opacity = 1;
-active-opacity = 1;
-frame-opacity = 1;
+fading = false;
+inactive-opacity = 1.0;
+active-opacity = 1.0;
+frame-opacity = 1.0;
 inactive-opacity-override = false;
-
-
-# Desaturate and darken the inactive windows
-# Dim inactive windows. (0.0 - 1.0)
-
-#inactive-dim = 0.2;
-#inactive-dim-fixed = true;
-
-
-
-
-# Do not let dimness adjust based on window opacity.
-# inactive-dim-fixed = true;
-
-
-# Blur background of transparent windows. Bad performance with X Render backend. GLX backend is preferred.
-
-blur-background = true;
-
-
-blur-method = "kernel";
-#blur-size = 50;
-#blur-deviation = 5.0;
-
-
-
-# Blur background of opaque windows with transparent frames as well.
-# blur-background-frame = true;
-# Do not let blur radius adjust based on window opacity.
-#blur-background-fixed = true;
-
-# blur-kern = "3x3box";
-# blur-kern = "5x5box";
-# blur-kern = "5x5gaussian"
-blur-kern = "9x9gaussian"
-
-blur-background-exclude = [
-    "class_g = 'Peek'",
-	"class_g = 'Pensela'",
-	"name = 'Drawing Board'",
-    "window_type = 'dock'",
-	"window_type = 'dropdown_menu'",
-	"window_type = 'combo'",
-	"window_type = 'popup_menu'",
-	"window_type = 'utility'",
-    "window_type = 'desktop'",
-	"_GTK_FRAME_EXTENTS@:c"
-];
-opacity-exclude = [
-    "name = 'Stratagus'"
-];
-
-
-#################################
-#
-# Fading
-#
-#################################
-
-fading = true;
-# fade-delta = 30;
-#fade-in-step = 0.03;
-#fade-out-step = 0.03;
-fade-in-step = 0.07;
-fade-out-step = 0.07;
-# no-fading-openclose = true;
-# no-fading-destroyed-argb = true;
-fade-exclude = [ ];
-
-
-
-#################################
-#
-# OTHER CONFIG
-#
-#################################
-
-log-level = "warn";
-# log-file = "/path/to/your/log/file";
-
 
 mark-wmwin-focused = true;
 mark-ovredir-focused = true;
-# use-ewmh-active-win = true;
 detect-rounded-corners = true;
 detect-client-opacity = true;
-refresh-rate = 0;
-
-
-#vsync = true;
-
-
-# sw-opti = true;
-# unredir-if-possible = true;
-# unredir-if-possible-delay = 5000;
-# unredir-if-possible-exclude = [ ];
-
-focus-exclude = [ "class_g = 'Cairo-clock'" ];
-
 detect-transient = true;
 detect-client-leader = true;
-invert-color-include = [ ];
+unredir-if-possible = false;
 
-resize-damage = 2;
+opacity-rule = [
+  "80:class_g = 'Emacs'"
+];
 
+shadow-exclude = [
+  "window_type = 'dock'",
+  "window_type = 'desktop'",
+  "class_g = 'Conky'",
+  "class_g = 'flameshot'",
+  "name = 'flameshot'",
+  "_GTK_FRAME_EXTENTS@:c"
+];
 
-
-
-
-#################################
-#
-# Window type settings
-#
-#################################
 wintypes:
 {
-	dock = { shadow = true; }
-	dnd = { shadow = false; }
-	popup_menu = { opacity = 1; }
-	dropdown_menu = { opacity = 1; }
-
-	# This avoid problems with transparent windows while use-damage = true;.
-	# normal = { full-shadow = true;};
-
-#   tooltip = { fade = true; shadow = true; opacity = 0.75; focus = true; full-shadow = false; };
-
-
-
+  tooltip = { fade = true; shadow = true; opacity = 0.9; focus = true; full-shadow = false; };
+  dock = { shadow = false; opacity = 1.0; };
+  dnd = { shadow = false; };
+  popup_menu = { opacity = 0.9; };
+  dropdown_menu = { opacity = 0.9; };
 };
-
-
-
-#################################
-#
-# Deprecated
-#
-#################################
-
-
-# Avoid drawing shadows on dock/panel windows.
-# This option is deprecated, you should use the wintypes option in your config file instead.
-# no-dock-shadow = false;
-
-
-# Don't draw shadows on DND windows.
-# This option is deprecated, you should use the wintypes option in your config file instead.
-# no-dnd-shadow = false;
-
-# Option `menu-opacity` is deprecated, and will be removed.Please use the wintype option `opacity` of `popup_menu` and `dropdown_menu` instead.
-# menu-opacity = 1;
-
-# GLX backend: GLX buffer swap method we assume.
-# Could be undefined (0), copy (1), exchange (2), 3-6, or buffer-age (-1).
-# undefined is the slowest and the safest, and the default value.
-# copy is fastest, but may fail on some drivers,
-# 2-6 are gradually slower but safer (6 is still faster than 0).
-# Usually, double buffer means 2, triple buffer means 3.
-# buffer-age means auto-detect using GLX_EXT_buffer_age, supported by some drivers.
-# Useless with --glx-use-copysubbuffermesa.
-# Partially breaks --resize-damage.
-# Defaults to undefined.
-# glx-swap-method has been deprecated since v6, your setting "undefined" should be replaced by `use-damage = true`
-# glx-swap-method = "undefined";
-
-
-# Zero the part of the shadow's mask behind the window. Fix some weirdness with ARGB windows.
-# "clear-shadow" is removed as an option, and is always enabled now. Consider removing it from your config file
-# clear-shadow = true;
-
-# "alpha-step" has been removed, compton now tries to make use of all alpha values
-# alpha-step = 0.06;
-opacity-rule = [ "80:class_g = 'Emacs'"];

--- a/.config/picom/picom.conf
+++ b/.config/picom/picom.conf
@@ -32,7 +32,7 @@ shadow-exclude = [
   "class_g = 'Conky'",
   "class_g = 'flameshot'",
   "name = 'flameshot'",
-  "_GTK_FRAME_EXTENTS@:c"
+  "_GTK_FRAME_EXTENTS"
 ];
 
 wintypes:

--- a/.config/qtile/picom-toggle.sh
+++ b/.config/qtile/picom-toggle.sh
@@ -1,1 +1,8 @@
-scripts/picom-toggle.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+if pgrep -x picom >/dev/null; then
+    pkill -x picom
+else
+    picom -b --config "$HOME/.config/picom/picom.conf"
+fi

--- a/.config/qtile/picom-toggle.sh
+++ b/.config/qtile/picom-toggle.sh
@@ -1,8 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-if pgrep -x picom >/dev/null; then
-    pkill -x picom
-else
-    picom -b --config "$HOME/.config/picom/picom.conf"
-fi
+scripts/picom-toggle.sh

--- a/.config/qtile/scripts/picom-toggle.sh
+++ b/.config/qtile/scripts/picom-toggle.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
-if pgrep -x "picom" > /dev/null
-then
-	killall picom
+#!/usr/bin/env bash
+set -euo pipefail
+
+if pgrep -x picom >/dev/null; then
+    pkill -x picom
 else
-	picom -b --config ~/.config/qtile/scripts/picom.conf
+    picom -b --config "$HOME/.config/picom/picom.conf"
 fi

--- a/.config/qtile/sxhkd/sxhkdrc
+++ b/.config/qtile/sxhkd/sxhkdrc
@@ -14,10 +14,10 @@ super + shift + v
 #################################################################
 
 super + F1
-	brave
+ 	brave
 
 super + F2
-	emacs
+ 	emacs
 
 super + F3
     inkscape
@@ -77,7 +77,7 @@ super + Escape
 
 #File-Manager
 super + shift + Return
-	thunar
+ 	thunar
 
 #Keyboard dependent
 #File-Manager
@@ -86,10 +86,10 @@ super + shift + Return
 
 #j4-dmenu
 super + d
-	j4-dmenu-desktop
+ 	j4-dmenu-desktop
 #reload sxhkd:
 super + shift + s
-	pkill -USR1 -x sxhkd
+ 	pkill -USR1 -x sxhkd
 
 #Keyboard dependent
 #super + shift + KP_Enter
@@ -188,9 +188,12 @@ alt + shift + u
 #     SCREENSHOTS
 #################################################################
 
-#Scrot
-alt + Print       exec flameshot full -p "~/Pictures/screenshots"
-alt + shift + Print exec flameshot gui -p "~/Pictures/screenshots"
+# Flameshot
+alt + Print
+    flameshot full -p "$HOME/Pictures/screenshots"
+
+alt + shift + Print
+    flameshot gui -p "$HOME/Pictures/screenshots"
 
 #screeenshooter
 ctrl + Print


### PR DESCRIPTION
## What changed

- force Flameshot to use its legacy X11 capture backend under Qtile instead of timing out through `xdg-desktop-portal`
- repair the malformed `sxhkd` Flameshot bindings
- replace the old GLX/blur-heavy Picom configuration with a smaller stable XRender configuration
- make both Picom toggle scripts use the canonical `~/.config/picom/picom.conf`
- exclude Flameshot windows from Picom shadows

## Root cause

Current Flameshot versions prefer the desktop screenshot portal. Minimal Qtile/X11 sessions commonly lack a compatible screenshot portal, so capture waits for the portal and times out. Picom was not the direct cause, but the repository had three divergent Picom config paths and an aggressive legacy GLX configuration.

## Validation

- `bash -n` passed for the updated toggle script
- Picom v12.5 parsed the replacement config successfully under Xvfb with `--diagnostics`
- branch diff reviewed against `master`
