### PR TITLE
Overhaul Emacs gptel and agent tooling

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -1,0 +1,45 @@
+;;; llm.el --- Doom autoloads for the local gptel stack -*- lexical-binding: t; -*-
+
+;;;###autoload
+(with-eval-after-load 'gptel
+  (require 'ai)
+  (require 'ai-agent))
+
+;;;###autoload
+(defun +llm/load ()
+  "Load the complete local LLM configuration."
+  (interactive)
+  (require 'ai-init)
+  (ai/llm-apply-defaults)
+  (message "LLM stack loaded: %s / %s" ai/llm-provider ai/llm-model))
+
+;;;###autoload
+(defun +llm/chat ()
+  "Open a persistent Org gptel agent chat."
+  (interactive)
+  (require 'chat)
+  (call-interactively #'ai/chat))
+
+;;;###autoload
+(defun +llm/use-glm-5.2 (&optional local)
+  "Switch to Z.AI GLM-5.2."
+  (interactive "P")
+  (require 'ai)
+  (ai/llm-use-glm-5.2 local))
+
+;;;###autoload
+(defun +llm/use-gpt-5.6-sol (&optional local)
+  "Switch to OpenAI GPT-5.6 Sol."
+  (interactive "P")
+  (require 'ai)
+  (ai/llm-use-gpt-5.6-sol local))
+
+;;;###autoload
+(defun +llm/agent-context ()
+  "Toggle project instruction files in gptel context."
+  (interactive)
+  (require 'ai-agent)
+  (ai/agent-context-mode 'toggle))
+
+(provide '+llm-autoloads)
+;;; llm.el ends here

--- a/lisp/llm/agent-core.el
+++ b/lisp/llm/agent-core.el
@@ -1,0 +1,702 @@
+;;; agent-core.el --- Claude Code-style gptel agent core -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'gptel)
+(require 'json)
+(require 'project)
+(require 'seq)
+(require 'subr-x)
+(require 'url)
+(require 'url-http)
+(require 'ai)
+
+(defgroup ai/agent nil
+  "Project-aware tools for gptel coding agents."
+  :group 'ai/llm
+  :prefix "ai/agent-")
+
+(defcustom ai/agent-restrict-to-project t
+  "When non-nil, filesystem tools reject paths outside the project root."
+  :type 'boolean
+  :group 'ai/agent)
+
+(defcustom ai/agent-max-read-bytes 262144
+  "Maximum number of bytes returned by a single read operation."
+  :type 'integer
+  :group 'ai/agent)
+
+(defcustom ai/agent-max-output-bytes 262144
+  "Maximum number of bytes returned by commands, diffs, and HTTP requests."
+  :type 'integer
+  :group 'ai/agent)
+
+(defcustom ai/agent-max-search-results 200
+  "Maximum number of results returned by search tools."
+  :type 'integer
+  :group 'ai/agent)
+
+(defcustom ai/agent-command-timeout 120
+  "Default timeout in seconds for the Bash tool."
+  :type 'integer
+  :group 'ai/agent)
+
+(defcustom ai/agent-ignored-directories
+  '(".git" ".direnv" ".cache" ".venv" "node_modules" "dist" "build" "target")
+  "Directory names excluded from recursive fallback searches."
+  :type '(repeat string)
+  :group 'ai/agent)
+
+(defcustom ai/agent-context-files '("AGENTS.md" "CLAUDE.md")
+  "Project instruction files added by `ai/agent-context-mode'."
+  :type '(repeat string)
+  :group 'ai/agent)
+
+(defvar ai/agent-tools nil
+  "Names of tools registered for the agent preset.")
+
+(defun ai/agent--object (&rest pairs)
+  "Return an alist from alternating string keys and values in PAIRS."
+  (let (result)
+    (while pairs
+      (push (cons (pop pairs) (pop pairs)) result))
+    (nreverse result)))
+
+(defun ai/agent--json (&rest pairs)
+  "Serialize alternating string keys and values in PAIRS as JSON."
+  (json-serialize (apply #'ai/agent--object pairs)
+                  :null-object nil
+                  :false-object :json-false))
+
+(defun ai/agent--json-error (message &optional details)
+  "Return a structured JSON error with MESSAGE and optional DETAILS."
+  (ai/agent--json "ok" :json-false "error" message "details" details))
+
+(defun ai/agent--truncate (string &optional limit)
+  "Truncate STRING to LIMIT bytes and return (TEXT . TRUNCATED-P)."
+  (let* ((limit (or limit ai/agent-max-output-bytes))
+         (bytes (string-bytes string)))
+    (if (<= bytes limit)
+        (cons string nil)
+      (let ((end (min (length string) limit)))
+        (while (and (> end 0)
+                    (> (string-bytes (substring string 0 end)) limit))
+          (setq end (- end (max 1 (/ end 20)))))
+        (cons (concat (substring string 0 end)
+                      (format "\n... truncated at %d bytes ..." limit))
+              t)))))
+
+(defun ai/agent--arg (object key &optional default)
+  "Read KEY from OBJECT, accepting plists and alists."
+  (let* ((name (substring (symbol-name key) 1))
+         (symbol (intern name)))
+    (cond
+     ((and (listp object) (keywordp (car object)))
+      (if (plist-member object key) (plist-get object key) default))
+     ((listp object)
+      (let ((cell (or (assoc key object)
+                      (assoc symbol object)
+                      (assoc name object))))
+        (if cell (cdr cell) default)))
+     (t default))))
+
+(defun ai/agent--project-root ()
+  "Return the current project root as an absolute directory name."
+  (file-name-as-directory
+   (expand-file-name
+    (or (when-let ((project (project-current nil)))
+          (project-root project))
+        (locate-dominating-file default-directory ".git")
+        default-directory))))
+
+(defun ai/agent--nearest-existing-parent (path)
+  "Return the nearest existing ancestor of PATH."
+  (let ((candidate (expand-file-name path)))
+    (while (and candidate (not (file-exists-p candidate)))
+      (let ((parent (file-name-directory (directory-file-name candidate))))
+        (setq candidate
+              (unless (or (null parent) (equal parent candidate)) parent))))
+    candidate))
+
+(defun ai/agent--inside-p (path root)
+  "Return non-nil when PATH resolves inside ROOT."
+  (let* ((root-real (file-name-as-directory (file-truename root)))
+         (existing (or (ai/agent--nearest-existing-parent path) root))
+         (existing-real (file-name-as-directory
+                         (if (file-directory-p existing)
+                             (file-truename existing)
+                           (file-name-directory (file-truename existing))))))
+    (string-prefix-p root-real existing-real)))
+
+(defun ai/agent--resolve-path (path &optional allow-outside)
+  "Resolve PATH relative to the project and enforce project confinement."
+  (unless (and (stringp path) (not (string-empty-p path)))
+    (error "Path must be a non-empty string"))
+  (let* ((root (ai/agent--project-root))
+         (expanded (expand-file-name path root)))
+    (when (and ai/agent-restrict-to-project
+               (not allow-outside)
+               (not (ai/agent--inside-p expanded root)))
+      (error "Path escapes project root: %s" path))
+    expanded))
+
+(defun ai/agent--relative-path (path)
+  "Return PATH relative to the current project root."
+  (file-relative-name path (ai/agent--project-root)))
+
+(defun ai/agent--ensure-parent (path)
+  "Create PATH's parent directory when necessary."
+  (let ((parent (file-name-directory path)))
+    (unless (file-directory-p parent)
+      (make-directory parent t))))
+
+(defun ai/agent--atomic-write (path content)
+  "Atomically write CONTENT to PATH, preserving existing file modes."
+  (ai/agent--ensure-parent path)
+  (let* ((directory (file-name-directory path))
+         (temporary (make-temp-file (expand-file-name ".ai-agent-" directory)))
+         (modes (and (file-exists-p path) (file-modes path))))
+    (unwind-protect
+        (progn
+          (with-temp-file temporary
+            (insert content))
+          (when modes (set-file-modes temporary modes))
+          (rename-file temporary path t))
+      (when (file-exists-p temporary)
+        (delete-file temporary)))))
+
+(defun ai/agent--read-string (path)
+  "Read PATH as text without properties."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (buffer-substring-no-properties (point-min) (point-max))))
+
+(defun ai/agent--count-occurrences (needle haystack)
+  "Count non-overlapping occurrences of NEEDLE in HAYSTACK."
+  (when (string-empty-p needle)
+    (error "old_text must not be empty"))
+  (let ((start 0) (count 0))
+    (while (string-match (regexp-quote needle) haystack start)
+      (setq count (1+ count)
+            start (match-end 0)))
+    count))
+
+(defun ai/agent--replace-exact (content old-text new-text replace-all)
+  "Replace OLD-TEXT with NEW-TEXT in CONTENT.
+Require exactly one match unless REPLACE-ALL is non-nil."
+  (let ((count (ai/agent--count-occurrences old-text content)))
+    (cond
+     ((zerop count)
+      (error "old_text was not found"))
+     ((and (> count 1) (not replace-all))
+      (error "old_text matched %d times; provide more context or set replace_all" count))
+     (replace-all
+      (cons (replace-regexp-in-string (regexp-quote old-text) new-text content t t)
+            count))
+     (t
+      (let ((position (string-match (regexp-quote old-text) content)))
+        (cons (concat (substring content 0 position)
+                      new-text
+                      (substring content (+ position (length old-text))))
+              1))))))
+
+(defun ai/agent--diff-strings (path old-content new-content)
+  "Return a unified diff for PATH between OLD-CONTENT and NEW-CONTENT."
+  (let ((old-file (make-temp-file "ai-agent-old-"))
+        (new-file (make-temp-file "ai-agent-new-")))
+    (unwind-protect
+        (progn
+          (with-temp-file old-file (insert old-content))
+          (with-temp-file new-file (insert new-content))
+          (with-temp-buffer
+            (let ((status (call-process "diff" nil t nil "-u"
+                                        "--label" (concat "a/" (ai/agent--relative-path path))
+                                        "--label" (concat "b/" (ai/agent--relative-path path))
+                                        old-file new-file)))
+              (unless (memq status '(0 1))
+                (error "diff failed: %s" (string-trim (buffer-string))))
+              (buffer-string))))
+      (delete-file old-file)
+      (delete-file new-file))))
+
+(defun ai/agent-read-file (path &optional offset limit)
+  "Read PATH starting at one-based line OFFSET for LIMIT lines."
+  (let* ((file (ai/agent--resolve-path path))
+         (offset (max 1 (or offset 1)))
+         (limit (max 1 (or limit 300))))
+    (unless (file-regular-p file)
+      (error "Not a regular file: %s" path))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (let ((total-lines (line-number-at-pos (point-max)))
+            start end)
+        (goto-char (point-min))
+        (forward-line (1- offset))
+        (setq start (point))
+        (forward-line limit)
+        (setq end (min (point) (point-max)))
+        (let* ((raw (buffer-substring-no-properties start end))
+               (truncated (ai/agent--truncate raw ai/agent-max-read-bytes)))
+          (ai/agent--json
+           "ok" t
+           "path" (ai/agent--relative-path file)
+           "start_line" offset
+           "end_line" (min total-lines (+ offset limit -1))
+           "total_lines" total-lines
+           "truncated" (if (cdr truncated) t :json-false)
+           "content" (car truncated)))))))
+
+(defun ai/agent-file-stat (path)
+  "Return metadata for PATH."
+  (let* ((file (ai/agent--resolve-path path))
+         (attributes (file-attributes file 'string)))
+    (unless attributes (error "Path does not exist: %s" path))
+    (ai/agent--json
+     "ok" t
+     "path" (ai/agent--relative-path file)
+     "type" (cond ((file-directory-p file) "directory")
+                  ((file-symlink-p file) "symlink")
+                  (t "file"))
+     "size" (file-attribute-size attributes)
+     "modified" (format-time-string "%FT%T%z" (file-attribute-modification-time attributes))
+     "modes" (file-attribute-modes attributes))))
+
+(defun ai/agent-list-directory (&optional path depth)
+  "List PATH recursively to DEPTH levels."
+  (let* ((directory (ai/agent--resolve-path (or path ".")))
+         (depth (max 1 (min 8 (or depth 2))))
+         (root directory)
+         (results nil))
+    (unless (file-directory-p directory)
+      (error "Not a directory: %s" path))
+    (cl-labels ((walk (dir level)
+                  (when (<= level depth)
+                    (dolist (entry (directory-files dir t directory-files-no-dot-files-regexp t))
+                      (unless (member (file-name-nondirectory entry) ai/agent-ignored-directories)
+                        (push (ai/agent--object
+                               "path" (file-relative-name entry root)
+                               "type" (if (file-directory-p entry) "directory" "file"))
+                              results)
+                        (when (file-directory-p entry)
+                          (walk entry (1+ level))))))))
+      (walk directory 1))
+    (ai/agent--json "ok" t "root" (ai/agent--relative-path root)
+                    "entries" (vconcat (nreverse results)))))
+
+(defun ai/agent-glob (pattern &optional path max-results)
+  "Find files below PATH whose relative names match glob PATTERN."
+  (let* ((directory (ai/agent--resolve-path (or path ".")))
+         (regexp (wildcard-to-regexp pattern))
+         (max-results (or max-results ai/agent-max-search-results))
+         (results nil))
+    (unless (file-directory-p directory)
+      (error "Not a directory: %s" path))
+    (catch 'done
+      (dolist (file (directory-files-recursively
+                     directory "." nil
+                     (lambda (candidate)
+                       (not (member (file-name-nondirectory candidate)
+                                    ai/agent-ignored-directories)))))
+        (let ((relative (file-relative-name file directory)))
+          (when (and (file-regular-p file) (string-match-p regexp relative))
+            (push (ai/agent--relative-path file) results)
+            (when (>= (length results) max-results)
+              (throw 'done nil))))))
+    (ai/agent--json "ok" t "pattern" pattern
+                    "matches" (vconcat (nreverse results))
+                    "limited" (if (>= (length results) max-results) t :json-false))))
+
+(defun ai/agent--grep-with-rg (pattern directory glob case-sensitive max-results)
+  "Search with ripgrep and return structured match objects."
+  (let ((arguments (append '("--line-number" "--column" "--no-heading" "--color" "never")
+                           (unless case-sensitive '("--ignore-case"))
+                           (when (and glob (not (string-empty-p glob)))
+                             (list "--glob" glob))
+                           (list "--max-count" (number-to-string max-results)
+                                 "--" pattern directory)))
+        results)
+    (with-temp-buffer
+      (let ((status (apply #'process-file "rg" nil t nil arguments)))
+        (unless (memq status '(0 1))
+          (error "rg failed: %s" (string-trim (buffer-string))))
+        (goto-char (point-min))
+        (while (and (< (length results) max-results)
+                    (re-search-forward "^\\(.*\\):\\([0-9]+\\):\\([0-9]+\\):\\(.*\\)$" nil t))
+          (push (ai/agent--object
+                 "path" (ai/agent--relative-path (match-string 1))
+                 "line" (string-to-number (match-string 2))
+                 "column" (string-to-number (match-string 3))
+                 "text" (match-string 4))
+                results))))
+    (nreverse results)))
+
+(defun ai/agent--grep-fallback (pattern directory glob case-sensitive max-results)
+  "Search text files with Emacs when ripgrep is unavailable."
+  (let ((case-fold-search (not case-sensitive))
+        (file-regexp (and glob (wildcard-to-regexp glob)))
+        results)
+    (catch 'done
+      (dolist (file (directory-files-recursively directory "."))
+        (when (and (file-regular-p file)
+                   (or (null file-regexp)
+                       (string-match-p file-regexp (file-relative-name file directory))))
+          (condition-case nil
+              (with-temp-buffer
+                (insert-file-contents file nil 0 ai/agent-max-read-bytes)
+                (goto-char (point-min))
+                (while (and (< (length results) max-results)
+                            (re-search-forward pattern nil t))
+                  (push (ai/agent--object
+                         "path" (ai/agent--relative-path file)
+                         "line" (line-number-at-pos (match-beginning 0))
+                         "column" (1+ (- (match-beginning 0)
+                                         (line-beginning-position)))
+                         "text" (buffer-substring-no-properties
+                                 (line-beginning-position) (line-end-position)))
+                        results)))
+            (error nil)))
+        (when (>= (length results) max-results)
+          (throw 'done nil))))
+    (nreverse results)))
+
+(defun ai/agent-grep (pattern &optional path glob case-sensitive max-results)
+  "Search PATTERN recursively below PATH, optionally restricted by GLOB."
+  (let* ((directory (ai/agent--resolve-path (or path ".")))
+         (max-results (or max-results ai/agent-max-search-results))
+         (matches (if (executable-find "rg")
+                      (ai/agent--grep-with-rg pattern directory glob case-sensitive max-results)
+                    (ai/agent--grep-fallback pattern directory glob case-sensitive max-results))))
+    (ai/agent--json "ok" t "pattern" pattern
+                    "matches" (vconcat matches)
+                    "limited" (if (>= (length matches) max-results) t :json-false))))
+
+(defun ai/agent-write-file (path content &optional overwrite)
+  "Write CONTENT to PATH atomically.
+Refuse to replace an existing file unless OVERWRITE is non-nil."
+  (let ((file (ai/agent--resolve-path path)))
+    (when (and (file-exists-p file) (not overwrite))
+      (error "File exists; set overwrite=true or use Edit: %s" path))
+    (ai/agent--atomic-write file content)
+    (ai/agent--json "ok" t "path" (ai/agent--relative-path file)
+                    "bytes" (string-bytes content)
+                    "operation" (if overwrite "overwritten" "created"))))
+
+(defun ai/agent-edit-file (path old-text new-text &optional replace-all preview)
+  "Replace exact OLD-TEXT with NEW-TEXT in PATH.
+When PREVIEW is non-nil, return the diff without writing."
+  (let* ((file (ai/agent--resolve-path path))
+         (old-content (ai/agent--read-string file))
+         (replacement (ai/agent--replace-exact old-content old-text new-text replace-all))
+         (new-content (car replacement))
+         (count (cdr replacement))
+         (diff (ai/agent--diff-strings file old-content new-content))
+         (truncated (ai/agent--truncate diff)))
+    (unless preview (ai/agent--atomic-write file new-content))
+    (ai/agent--json "ok" t "path" (ai/agent--relative-path file)
+                    "replacements" count
+                    "preview" (if preview t :json-false)
+                    "diff_truncated" (if (cdr truncated) t :json-false)
+                    "diff" (car truncated))))
+
+(defun ai/agent-multi-edit (path edits &optional preview)
+  "Apply sequential exact-match EDITS to PATH in one atomic transaction."
+  (let* ((file (ai/agent--resolve-path path))
+         (original (ai/agent--read-string file))
+         (content original)
+         (applied 0))
+    (dolist (edit edits)
+      (let* ((old-text (ai/agent--arg edit :old_text))
+             (new-text (ai/agent--arg edit :new_text ""))
+             (replace-all (ai/agent--arg edit :replace_all nil))
+             (replacement (ai/agent--replace-exact content old-text new-text replace-all)))
+        (setq content (car replacement)
+              applied (+ applied (cdr replacement)))))
+    (let* ((diff (ai/agent--diff-strings file original content))
+           (truncated (ai/agent--truncate diff)))
+      (unless preview (ai/agent--atomic-write file content))
+      (ai/agent--json "ok" t "path" (ai/agent--relative-path file)
+                      "edits" (length edits)
+                      "replacements" applied
+                      "preview" (if preview t :json-false)
+                      "diff_truncated" (if (cdr truncated) t :json-false)
+                      "diff" (car truncated)))))
+
+(defun ai/agent--patch-paths (patch)
+  "Return target paths referenced by unified PATCH."
+  (with-temp-buffer
+    (insert patch)
+    (goto-char (point-min))
+    (let (paths)
+      (while (re-search-forward "^+++ \\(?:b/\\)?\\([^\t\n]+\\)" nil t)
+        (let ((path (match-string 1)))
+          (unless (string= path "/dev/null")
+            (push path paths))))
+      (delete-dups (nreverse paths)))))
+
+(defun ai/agent--validate-patch (patch)
+  "Validate that PATCH only targets project-relative paths."
+  (let ((paths (ai/agent--patch-paths patch)))
+    (unless paths (error "Patch contains no target paths"))
+    (dolist (path paths)
+      (when (or (file-name-absolute-p path)
+                (member ".." (split-string path "/" t)))
+        (error "Unsafe patch path: %s" path))
+      (ai/agent--resolve-path path))
+    paths))
+
+(defun ai/agent-apply-patch (patch &optional check reverse)
+  "Apply unified PATCH with `git apply'.
+CHECK performs validation only.  REVERSE applies the patch in reverse."
+  (let* ((root (ai/agent--project-root))
+         (paths (ai/agent--validate-patch patch))
+         (patch-file (make-temp-file "ai-agent-patch-"))
+         (arguments (append '("apply" "--whitespace=nowarn")
+                            (when check '("--check"))
+                            (when reverse '("--reverse"))
+                            (list patch-file))))
+    (unwind-protect
+        (progn
+          (with-temp-file patch-file (insert patch))
+          (with-temp-buffer
+            (let ((default-directory root)
+                  (status (apply #'process-file "git" nil t nil arguments)))
+              (if (zerop status)
+                  (ai/agent--json "ok" t
+                                  "operation" (if check "checked" "applied")
+                                  "paths" (vconcat paths))
+                (ai/agent--json-error "Patch failed" (string-trim (buffer-string)))))))
+      (delete-file patch-file))))
+
+(defun ai/agent-make-directory (path)
+  "Create PATH and missing parents."
+  (let ((directory (ai/agent--resolve-path path)))
+    (make-directory directory t)
+    (ai/agent--json "ok" t "path" (ai/agent--relative-path directory))))
+
+(defun ai/agent-move-path (source destination &optional overwrite)
+  "Move SOURCE to DESTINATION."
+  (let ((source-path (ai/agent--resolve-path source))
+        (destination-path (ai/agent--resolve-path destination)))
+    (unless (file-exists-p source-path)
+      (error "Source does not exist: %s" source))
+    (when (and (file-exists-p destination-path) (not overwrite))
+      (error "Destination exists: %s" destination))
+    (ai/agent--ensure-parent destination-path)
+    (rename-file source-path destination-path overwrite)
+    (ai/agent--json "ok" t
+                    "source" (ai/agent--relative-path source-path)
+                    "destination" (ai/agent--relative-path destination-path))))
+
+(defun ai/agent-delete-path (path &optional recursive)
+  "Delete PATH.  Directories require RECURSIVE."
+  (let ((target (ai/agent--resolve-path path)))
+    (cond
+     ((file-directory-p target)
+      (unless recursive (error "Directory deletion requires recursive=true"))
+      (delete-directory target t))
+     ((file-exists-p target) (delete-file target))
+     (t (error "Path does not exist: %s" path)))
+    (ai/agent--json "ok" t "deleted" (ai/agent--relative-path target))))
+
+(defun ai/agent--run-process (program arguments &optional directory timeout)
+  "Run PROGRAM with ARGUMENTS in DIRECTORY with TIMEOUT seconds."
+  (let* ((buffer (generate-new-buffer " *ai-agent-process*"))
+         (default-directory (or directory default-directory))
+         (deadline (+ (float-time) (or timeout ai/agent-command-timeout)))
+         (process (make-process :name "ai-agent-process"
+                                :buffer buffer
+                                :stderr buffer
+                                :command (cons program arguments)
+                                :connection-type 'pipe
+                                :noquery t))
+         timed-out)
+    (unwind-protect
+        (progn
+          (while (and (process-live-p process) (< (float-time) deadline))
+            (accept-process-output process 0.1))
+          (when (process-live-p process)
+            (setq timed-out t)
+            (delete-process process))
+          (with-current-buffer buffer
+            (list :exit-code (unless timed-out (process-exit-status process))
+                  :timed-out timed-out
+                  :output (buffer-substring-no-properties (point-min) (point-max)))))
+      (kill-buffer buffer))))
+
+(defun ai/agent-bash (command &optional timeout working-directory)
+  "Run shell COMMAND inside the project and return structured output."
+  (let* ((directory (ai/agent--resolve-path (or working-directory ".")))
+         (result (ai/agent--run-process shell-file-name
+                                       (list shell-command-switch command)
+                                       directory timeout))
+         (truncated (ai/agent--truncate (plist-get result :output))))
+    (ai/agent--json
+     "ok" (if (and (not (plist-get result :timed-out))
+                    (zerop (or (plist-get result :exit-code) 1)))
+               t :json-false)
+     "exit_code" (plist-get result :exit-code)
+     "timed_out" (if (plist-get result :timed-out) t :json-false)
+     "working_directory" (ai/agent--relative-path directory)
+     "output_truncated" (if (cdr truncated) t :json-false)
+     "output" (car truncated))))
+
+(defun ai/agent-git-status ()
+  "Return porcelain-v2 Git status for the current project."
+  (let* ((root (ai/agent--project-root))
+         (result (ai/agent--run-process "git" '("status" "--porcelain=v2" "--branch") root 30))
+         (truncated (ai/agent--truncate (plist-get result :output))))
+    (ai/agent--json "ok" (if (zerop (or (plist-get result :exit-code) 1)) t :json-false)
+                    "root" root "output" (car truncated))))
+
+(defun ai/agent-git-diff (&optional cached ref path)
+  "Return Git diff, optionally CACHED, against REF, or restricted to PATH."
+  (let* ((root (ai/agent--project-root))
+         (arguments '("diff" "--no-ext-diff")))
+    (when cached (setq arguments (append arguments '("--cached"))))
+    (when (and ref (not (string-empty-p ref)))
+      (setq arguments (append arguments (list ref))))
+    (when path
+      (let ((file (ai/agent--resolve-path path)))
+        (setq arguments (append arguments (list "--" (file-relative-name file root))))))
+    (let* ((result (ai/agent--run-process "git" arguments root 60))
+           (truncated (ai/agent--truncate (plist-get result :output))))
+      (ai/agent--json "ok" (if (zerop (or (plist-get result :exit-code) 1)) t :json-false)
+                      "truncated" (if (cdr truncated) t :json-false)
+                      "diff" (car truncated)))))
+
+(defun ai/agent-diff-files (path-a path-b)
+  "Return a unified diff between PATH-A and PATH-B."
+  (let* ((a (ai/agent--resolve-path path-a))
+         (b (ai/agent--resolve-path path-b))
+         (result (ai/agent--run-process "diff" (list "-u" a b) (ai/agent--project-root) 30))
+         (status (plist-get result :exit-code))
+         (truncated (ai/agent--truncate (plist-get result :output))))
+    (unless (memq status '(0 1))
+      (error "diff failed: %s" (plist-get result :output)))
+    (ai/agent--json "ok" t "different" (if (= status 1) t :json-false)
+                    "truncated" (if (cdr truncated) t :json-false)
+                    "diff" (car truncated))))
+
+(defun ai/agent-read-buffer (buffer &optional start end)
+  "Read BUFFER between START and END positions."
+  (unless-let ((target (get-buffer buffer)))
+    (error "Buffer is not live: %s" buffer))
+  (with-current-buffer target
+    (let* ((start (max (point-min) (or start (point-min))))
+           (end (min (point-max) (or end (point-max))))
+           (truncated (ai/agent--truncate
+                       (buffer-substring-no-properties start end)
+                       ai/agent-max-read-bytes)))
+      (ai/agent--json "ok" t "buffer" buffer "start" start "end" end
+                      "truncated" (if (cdr truncated) t :json-false)
+                      "content" (car truncated)))))
+
+(defun ai/agent-edit-buffer (buffer old-text new-text &optional replace-all preview)
+  "Apply an exact-match edit to BUFFER."
+  (unless-let ((target (get-buffer buffer)))
+    (error "Buffer is not live: %s" buffer))
+  (with-current-buffer target
+    (let* ((original (buffer-substring-no-properties (point-min) (point-max)))
+           (replacement (ai/agent--replace-exact original old-text new-text replace-all))
+           (new-content (car replacement)))
+      (unless preview
+        (atomic-change-group
+          (erase-buffer)
+          (insert new-content)))
+      (ai/agent--json "ok" t "buffer" buffer
+                      "replacements" (cdr replacement)
+                      "preview" (if preview t :json-false)))))
+
+(defun ai/agent-list-buffers ()
+  "Return useful metadata for live buffers."
+  (let (results)
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+        (unless (string-prefix-p " " (buffer-name))
+          (push (ai/agent--object
+                 "name" (buffer-name)
+                 "file" (or buffer-file-name nil)
+                 "mode" (symbol-name major-mode)
+                 "modified" (if (buffer-modified-p) t :json-false))
+                results))))
+    (ai/agent--json "ok" t "buffers" (vconcat (nreverse results)))))
+
+(defun ai/agent-symbol-info (name)
+  "Return documentation and source location for Emacs symbol NAME."
+  (let ((symbol (intern-soft name)))
+    (unless symbol (error "Unknown symbol: %s" name))
+    (let* ((function-p (fboundp symbol))
+           (variable-p (boundp symbol))
+           (documentation
+            (cond (function-p (ignore-errors (documentation symbol t)))
+                  (variable-p (ignore-errors (documentation-property symbol 'variable-documentation t)))))
+           (source (or (symbol-file symbol 'defun) (symbol-file symbol 'defvar))))
+      (ai/agent--json "ok" t "symbol" name
+                      "function" (if function-p t :json-false)
+                      "variable" (if variable-p t :json-false)
+                      "source" source
+                      "documentation" documentation))))
+
+(defun ai/agent-eval-elisp (expression)
+  "Evaluate Elisp EXPRESSION and return the printed value."
+  (let ((value (eval (read expression) lexical-binding)))
+    (ai/agent--json "ok" t "value" (prin1-to-string value))))
+
+(defun ai/agent-web-fetch (url &optional method headers body)
+  "Fetch URL with METHOD, HEADERS, and BODY using Emacs URL."
+  (unless (string-match-p "\\`https?://" url)
+    (error "Only HTTP and HTTPS URLs are allowed"))
+  (let* ((url-request-method (upcase (or method "GET")))
+         (url-request-extra-headers
+          (mapcar (lambda (header)
+                    (cons (or (ai/agent--arg header :name)
+                              (ai/agent--arg header :key))
+                          (ai/agent--arg header :value)))
+                  headers))
+         (url-request-data body)
+         (buffer (url-retrieve-synchronously url t t 30)))
+    (unless buffer (error "Request failed: %s" url))
+    (unwind-protect
+        (with-current-buffer buffer
+          (goto-char (point-min))
+          (let ((status (or (bound-and-true-p url-http-response-status) 0)))
+            (re-search-forward "\r?\n\r?\n" nil 'move)
+            (let ((truncated (ai/agent--truncate
+                              (buffer-substring-no-properties (point) (point-max)))))
+              (ai/agent--json "ok" (if (and (>= status 200) (< status 400)) t :json-false)
+                              "status" status
+                              "url" url
+                              "truncated" (if (cdr truncated) t :json-false)
+                              "body" (car truncated)))))
+      (kill-buffer buffer))))
+
+(defun ai/agent--context-root ()
+  "Return the project .context directory."
+  (expand-file-name ".context" (ai/agent--project-root)))
+
+(defun ai/agent-list-context ()
+  "List readable project context files."
+  (let ((root (ai/agent--context-root)))
+    (if (file-directory-p root)
+        (ai/agent--json "ok" t "files"
+                        (vconcat (mapcar (lambda (file) (file-relative-name file root))
+                                        (directory-files-recursively root "."))))
+      (ai/agent--json "ok" t "files" []))))
+
+(defun ai/agent-read-context (path)
+  "Read PATH below the project .context directory."
+  (let* ((root (ai/agent--context-root))
+         (file (expand-file-name path root)))
+    (unless (ai/agent--inside-p file root)
+      (error "Context path escapes .context: %s" path))
+    (ai/agent-read-file (file-relative-name file (ai/agent--project-root)))))
+
+(defun ai/agent-write-context (path content &optional overwrite)
+  "Write CONTENT to PATH below the project .context directory."
+  (let* ((root (ai/agent--context-root))
+         (file (expand-file-name path root)))
+    (unless (ai/agent--inside-p file root)
+      (error "Context path escapes .context: %s" path))
+    (ai/agent-write-file (file-relative-name file (ai/agent--project-root)) content overwrite)))
+
+(provide 'ai-agent-core)
+;;; agent-core.el ends here

--- a/lisp/llm/agent.el
+++ b/lisp/llm/agent.el
@@ -1,1379 +1,251 @@
-;;; agent.el --- agent tool system -*- lexical-binding: t; -*-
-
-;; Author: nsaspy 
-;; Version: 0.2
-;; Package-Requires: ((emacs "29.1") (gptel "0.9") (plz "0.9"))
-
-;;; Commentary:
-;; A Set of tools for LLM workflows.
-
-;;; Code:
-
-(require 'gptel)
-(require 'cl-lib)
-(require 'plz)
-
-
-(defvar ai/agent-context-files '("AGENTS.md")
-  "List of files to include ")
-
-
-(let ((ai-lib (expand-file-name "ai.el"
-                                (file-name-directory (or load-file-name buffer-file-name)))))
-  (when (file-exists-p ai-lib)
-    (load ai-lib nil t)))
-
-
-(defun ai/--expand-file (filename)
-  "Expand FILENAME, handling TRAMP paths correctly."
-  (if (file-remote-p filename)
-      filename
-    (expand-file-name filename)))
-
-(defun ai/--file-exists (filename)
-  "Check if FILENAME exists."
-  (file-exists-p (ai/--expand-file filename)))
-
-(defun ai/--read-file (filename)
-  "Read contents of FILENAME."
-  (let ((file (ai/--expand-file filename)))
-    (if (file-exists-p file)
-        (with-temp-buffer
-          (insert-file-contents file)
-          (buffer-string))
-      (error "File not found: %s" filename))))
-
-(defun ai/--write-file (filename content)
-  "Write CONTENT to FILENAME atomically."
-  (let ((file (ai/--expand-file filename)))
-    (with-temp-file file
-      (insert content))
-    "File written successfully"))
-
-(defun ai/--file-backup (filename)
-  "Create .bak backup of FILENAME."
-  (let ((file (ai/--expand-file filename)))
-    (when (file-exists-p file)
-      (let ((backup (concat file ".bak")))
-        (copy-file file backup t)
-        backup))))
-
-(defun ai/--list-files (&optional path)
-  "List files in PATH (defaults to current directory)."
-  (let ((dir (if (or (null path) (string= path ""))
-                 default-directory
-               (if (file-remote-p path)
-                   path
-                 (expand-file-name path)))))
-    (if (file-directory-p dir)
-        (directory-files dir nil "^[^.].*")
-      (error "Not a directory: %s" dir))))
-
-(defun ai/--read-file-numbered (filename)
-  "Read FILENAME with line numbers."
-  (let* ((content (ai/--read-file filename))
-         (lines (split-string content "\n"))
-         (i 0))
-    (mapconcat (lambda (line)
-                 (setq i (1+ i))
-                 (format "%4d| %s" i line))
-               lines "\n")))
-
-(defun ai/--get-file-lines (filename start end)
-  "Get lines from START to END in FILENAME."
-  (let* ((content (ai/--read-file filename))
-         (lines (split-string content "\n"))
-         (num-lines (length lines))
-         ;; Ensure start/end are within bounds
-         (start-line (max 1 (min start num-lines)))
-         (end-line (max start-line (min end num-lines)))
-         ;; Extract subset (nth is 0-indexed, lines are 1-indexed)
-         (subset (seq-subseq lines (1- start-line) end-line))
-         (i (1- start-line)))
-    (mapconcat (lambda (line)
-                 (setq i (1+ i))
-                 (format "%4d| %s" i line))
-               subset "\n")))
-
-(defun ai/--search-replace (filename search replace &optional replace-all)
-  "Search and replace in FILENAME."
-  (let ((file (ai/--expand-file filename)))
-    (if (file-exists-p file)
-        (let ((count 0))
-          (with-temp-file file
-            (insert-file-contents (ai/--expand-file filename))
-            (goto-char (point-min))
-            (while (search-forward search nil t)
-              (replace-match replace)
-              (setq count (1+ count))
-              (unless replace-all (goto-char (point-max)))))
-          (format "Replaced %d occurrences" count))
-      (error "File not found: %s" filename))))
-
-(defun ai/--apply-line-changes (filename changes)
-  "Apply CHANGES to FILENAME. CHANGES is a list of plists with :line and :content."
-  (let ((file (ai/--expand-file filename)))
-    (if (file-exists-p file)
-        (let ((lines (with-temp-buffer
-                       (insert-file-contents file)
-                       (split-string (buffer-string) "\n")))
-              (updates (make-hash-table :test 'eql))
-              (count 0))
-          ;; Index updates
-          (dolist (change changes)
-            (puthash (plist-get change :line) (plist-get change :content) updates))
-          ;; Write back
-          (with-temp-file file
-            (let ((i 0))
-              (dolist (line lines)
-                (setq i (1+ i))
-                (if-let ((new-content (gethash i updates)))
-                    (progn
-                      (insert new-content "\n")
-                      (setq count (1+ count)))
-                  (insert line "\n")))))
-          (format "Applied %d line changes to %s" count filename))
-      (error "File not found: %s" filename))))
-
-(defun ai/--preview-changes (filename changes)
-  "Preview CHANGES to FILENAME without applying."
-  (let ((file (ai/--expand-file filename)))
-    (if (file-exists-p file)
-        (let ((lines (with-temp-buffer
-                       (insert-file-contents file)
-                       (split-string (buffer-string) "\n")))
-              (output ""))
-          (dolist (change changes)
-            (let* ((line-num (plist-get change :line))
-                   (new-content (plist-get change :content))
-                   (old-content (if (<= line-num (length lines))
-                                    (nth (1- line-num) lines)
-                                  "[EOF]")))
-              (setq output (concat output
-                                   (format "Line %d:\n- %s\n+ %s\n\n"
-                                           line-num (or old-content "") new-content)))))
-          (if (string-empty-p output) "No changes to preview" output))
-      (error "File not found: %s" filename))))
-
-;;; Helper Functions - Diff/Patch
-
-(defun ai/--diff-files (file1 file2)
-  "Generate unified diff between FILE1 and FILE2."
-  (let ((f1 (ai/--expand-file file1))
-        (f2 (ai/--expand-file file2)))
-    (if (and (file-exists-p f1) (file-exists-p f2))
-        (with-temp-buffer
-          (call-process "diff" nil t nil "-u" f1 f2)
-          (buffer-string))
-      (error "One or both files not found: %s, %s" file1 file2))))
-
-(defun ai/--git-diff (mode &optional target)
-  "Run git diff in MODE (staged, unstaged, ref) for TARGET."
-  (let ((args (list "diff"))
-        (default-directory (ai/--project-root)))
-    (cond
-     ((string= mode "staged") (push "--cached" args))
-     ((string= mode "unstaged") nil) ;; default
-     ((string= mode "ref") (when target (push target args)))) ;; ref is target
-
-    ;; Append target file path if specific file requested (and not handled by ref)
-    (when (and target (not (string= mode "ref")))
-      (push "--" args)
-      (push target args))
-
-    (with-temp-buffer
-      (apply #'call-process "git" nil t nil (nreverse args))
-      (buffer-string))))
-
-(defun ai/--diff-changes (filename)
-  "Diff current FILENAME content against HEAD."
-  (ai/--git-diff "unstaged" filename))
-
-(defun ai/--count-patch-target-files (patch)
-  "Return number of target files referenced by unified PATCH text."
-  (with-temp-buffer
-    (insert patch)
-    (goto-char (point-min))
-    (let ((count 0))
-      (while (re-search-forward "^diff --git " nil t)
-        (setq count (1+ count)))
-      (when (zerop count)
-        (goto-char (point-min))
-        (while (re-search-forward "^\\+\\+\\+ [ab]/" nil t)
-          (setq count (1+ count))))
-      count)))
-
-(defun ai/--apply-patch (patch &optional dry-run)
-  "Apply PATCH (string) to files. Enforces single-file apply unless specified."
-  (let ((patch-file (make-temp-file "ai-patch")))
-    (unwind-protect
-        (progn
-          (with-temp-file patch-file
-            (insert patch))
-
-          (when (> (ai/--count-patch-target-files patch) 1)
-            (error "Multi-file patches are not allowed by default. Apply one file at a time."))
-
-          (let ((args (append
-                       '("apply" "--ignore-space-change" "--ignore-whitespace")
-                       (when dry-run '("--check"))
-                       (list patch-file)))
-                (default-directory (ai/--project-root)))
-            (with-temp-buffer
-              (let ((exit-code (apply #'call-process "git" nil t nil args)))
-                (if (zerop exit-code)
-                    (if dry-run
-                        "Patch applies cleanly (dry-run)"
-                      "Patch applied successfully")
-                  (format "Patch failed:\n%s" (buffer-string)))))))
-      (when (file-exists-p patch-file)
-        (delete-file patch-file)))))
-
-(defun ai/--apply-diff-patch (patch &optional dry-run)
-  "Alias for `ai/--apply-patch'."
-  (ai/--apply-patch patch dry-run))
-
-;;; Helper Functions - Emacs Introspection
-
-(defun ai/--eval-elisp (expression)
-  "Evaluate elisp EXPRESSION and return formatted result."
-  (format "%S" (eval (read expression))))
-
-(defun ai/--symbol-exists (name)
-  "Check if symbol NAME exists in obarray."
-  (intern-soft name))
-
-(defun ai/--function-source (symbol)
-  "Get source code for SYMBOL function."
-  (when-let ((sym (intern-soft symbol)))
-    (ai/--introspect-source sym nil)))
-
-(defun ai/--variable-source (symbol)
-  "Get source code for SYMBOL variable."
-  (when-let ((sym (intern-soft symbol)))
-    (ai/--introspect-source sym 'defvar)))
-
-(defun ai/--introspect-source (symbol &optional type)
-  "Get source code for SYMBOL of TYPE."
-  (when-let* ((save-silently t)
-              (vc-follow-symlinks t)
-              (buffer-point (find-definition-noselect symbol type)))
-    (with-current-buffer (car buffer-point)
-      (goto-char (cdr buffer-point))
-      (buffer-substring-no-properties
-       (point)
-       (progn
-         (if (null type)
-             (end-of-defun)
-           (cond ((derived-mode-p 'c-mode)
-                  (forward-sexp 2)
-                  (forward-char))
-                 ((derived-mode-p 'emacs-lisp-mode)
-                  (forward-sexp))
-                 (t (error "Unexpected file mode"))))
-         (point))))))
-
-(defun ai/--function-documentation (symbol)
-  "Get documentation for SYMBOL function."
-  (when-let ((sym (intern-soft symbol)))
-    (documentation sym)))
-
-(defun ai/--variable-documentation (symbol)
-  "Get documentation for SYMBOL variable."
-  (when-let ((sym (intern-soft symbol)))
-    (custom-variable-documentation sym)))
-
-(defun ai/--variable-value (symbol)
-  "Get global value of SYMBOL variable."
-  (when-let ((sym (intern-soft symbol)))
-    (default-value sym)))
-
-(defun ai/--function-completions (prefix)
-  "Find functions matching PREFIX."
-  (require 'orderless)
-  (string-join (orderless-filter prefix obarray #'functionp) "\n"))
-
-(defun ai/--variable-completions (prefix)
-  "Find variables matching PREFIX."
-  (require 'orderless)
-  (string-join (orderless-filter prefix obarray #'boundp) "\n"))
-
-(defun ai/--command-completions (prefix)
-  "Find commands matching PREFIX."
-  (require 'orderless)
-  (string-join (orderless-filter prefix obarray #'commandp) "\n"))
-
-(defun ai/--features ()
-  "Return loaded features."
-  (mapconcat #'symbol-name features "\n"))
-
-(defun ai/--load-paths ()
-  "Return load-path directories."
-  (string-join load-path "\n"))
-
-(defun ai/--library-source (library-name)
-  "Get source code for LIBRARY-NAME."
-  (if-let ((library (find-library-name library-name)))
-      (with-temp-buffer
-        (insert-file-contents library)
-        (buffer-string))
-    (error "Library not found: %s" library-name)))
-
-(defun ai/--feature-available (feature)
-  "Check if FEATURE is loaded or available."
-  (if-let ((sym (intern-soft feature)))
-      (when (featurep sym) feature)
-    (find-library-name feature)))
-
-;;; Helper Functions - Manual/Documentation
-
-(defun ai/--manual-names ()
-  "Get list of available Info manuals."
-  (json-serialize (vconcat (info--filter-manual-names
-                            (info--manual-names nil)))))
-
-(defun ai/--manual-nodes (name)
-  "Get list of nodes in manual NAME."
-  (json-serialize
-   (vconcat
-    (mapcar #'car (Info-build-node-completions name)))))
-
-(defun ai/--manual-node-contents (manual node)
-  "Get contents of NODE in MANUAL."
-  (condition-case err
-      (save-window-excursion
-        (Info-goto-node (format "(%s)%s" manual node))
-        (buffer-substring-no-properties (point-min) (point-max)))
-    (user-error
-     (error (error-message-string err)))))
-
-(defun ai/--symbol-in-manual (symbol)
-  "Get manual contents for SYMBOL."
-  (require 'helpful)
-  (when-let* ((sym (intern-soft symbol))
-              (_in-manual (helpful--in-manual-p sym)))
-    (save-window-excursion
-      (info-lookup 'symbol sym #'emacs-lisp-mode)
-      (buffer-substring-no-properties (point-min) (point-max)))))
-
-;;; Helper Functions - Buffer Operations
-
-(defun ai/--read-buffer (buffer)
-  "Read complete contents of BUFFER."
-  (unless (buffer-live-p (get-buffer buffer))
-    (error "Buffer '%s' does not exist or is not live" buffer))
-  (with-current-buffer (get-buffer buffer)
-    (buffer-substring-no-properties (point-min) (point-max))))
-
-(defun ai/--append-to-buffer (buffer text)
-  "Append TEXT to BUFFER."
-  (with-current-buffer (get-buffer-create buffer)
-    (save-excursion
-      (goto-char (point-max))
-      (insert text)))
-  (format "Appended text to buffer %s" buffer))
-
-(defun ai/--create-org-buffer (buffer-name content)
-  "Create org-mode BUFFER-NAME with CONTENT."
-  (let ((buffer (get-buffer-create buffer-name)))
-    (with-current-buffer buffer
-      (erase-buffer)
-      (insert content)
-      (goto-char (point-min))
-      (org-mode))
-    (display-buffer buffer '((display-buffer-reuse-window
-                              display-buffer-pop-up-window)
-                             (reusable-frames . visible)))
-    buffer))
-
-;;; Helper Functions - Context System
-
-(defvar ai/context-root nil
-  "Root directory for context files. Cached after first lookup.")
-
-(defun ai/--context-dir ()
-  "Find nearest .context directory, with caching."
-  (or ai/context-root
-      (setq ai/context-root
-            (locate-dominating-file default-directory ".context"))))
-
-(defun ai/--context-allowed ()
-  "Check if context system is enabled."
-  (not (file-exists-p ".no-context")))
-
-(defun ai/--list-context ()
-  "List all context files."
-  (when-let ((ctx-dir (ai/--context-dir)))
-    (directory-files-recursively
-     (expand-file-name ".context" ctx-dir)
-     "" nil
-     (lambda (file)
-       (and (file-regular-p file)
-            (file-readable-p file))))))
-
-(defun ai/--read-context (filename)
-  "Read FILENAME from context directory."
-  (when-let ((ctx-dir (ai/--context-dir)))
-    (let ((file (expand-file-name filename
-                                  (expand-file-name ".context" ctx-dir))))
-      (when (file-exists-p file)
-        (with-temp-buffer
-          (insert-file-contents file)
-          (buffer-string))))))
-
-(defun ai/--init-context (&optional path)
-  "Initialize context directory at PATH."
-  (let* ((target (or path default-directory))
-         (ctx-dir (expand-file-name ".context" target))
-         (index (expand-file-name "00_index.org" ctx-dir)))
-    (unless (file-exists-p ctx-dir)
-      (make-directory ctx-dir t)
-      (let ((default-directory ctx-dir))
-        (shell-command-to-string "git init")
-        (with-temp-file index
-          (insert "#+TITLE: Project Context Index\n")
-          (insert "#+DATE: " (format-time-string "%Y-%m-%d") "\n\n")
-          (insert "* Project Context Files\n")
-          (insert "This directory contains project context for AI assistance.\n"))
-        (shell-command-to-string "git add .")
-        (shell-command-to-string "git commit -m 'Initialize context'")))
-    "Context initialized"))
-
-(defun ai/--write-context (filename content)
-  "Write CONTENT to context FILENAME."
-  (when-let ((ctx-dir (ai/--context-dir)))
-    (let* ((ctx-path (expand-file-name ".context" ctx-dir))
-           (file (expand-file-name filename ctx-path)))
-      (with-temp-file file
-        (insert content))
-      (let ((default-directory ctx-path))
-        (shell-command-to-string (format "git add %s" (shell-quote-argument filename)))
-        (shell-command-to-string
-         (format "git commit -m 'Update: %s'" (shell-quote-argument filename))))
-      t)))
-
-(defun ai/--create-context (slug content priority)
-  "Create context file with SLUG, CONTENT, and PRIORITY."
-  (let ((filename (format "%02d_%s.org" priority slug)))
-    (ai/--write-context filename content)))
-
-;;; Helper Functions - Web Operations
-
-(defun ai/--brave-search (query &optional country search-lang count offset)
-  "Search using Brave API with QUERY and optional parameters."
-  (let* ((api-key (or  (getenv "BRAVE_API_KEY")
-                       (nsa/auth-source-get :host "api.brave.com")))
-         (country (or country "US"))
-         (search-lang (or search-lang "en"))
-         (count (or count 5))
-         (offset (or offset 0))
-         (url (format "https://api.search.brave.com/res/v1/web/search?q=%s&country=%s&search_lang=%s&count=%d&offset=%d"
-                      (url-encode-url query)
-                      country search-lang count offset)))
-    (plz 'get url
-      :headers `(("Accept" . "application/json")
-                 ("Accept-Encoding" . "gzip")
-                 ("X-Subscription-Token" . ,api-key))
-      :as #'json-read)))
-
-(defun ai/--http-request (url &optional method headers data)
-  "Make HTTP request to URL with METHOD, HEADERS, and DATA."
-  (let* ((method (or method "GET"))
-         (method-upper (upcase method))
-         (cmd (list "curl" "-s" "-L" "--max-time" "30")))
-
-    (unless (string-match-p "^https?://" url)
-      (error "Invalid URL: must start with http:// or https://"))
-
-    (push "-X" cmd)
-    (push method-upper cmd)
-
-    (dolist (header headers)
-      (push "-H" cmd)
-      (push (format "%s: %s" (car header) (cdr header)) cmd))
-
-    (when (and data (member method-upper '("POST" "PUT")))
-      (push "-d" cmd)
-      (push data cmd))
-
-    (push url cmd)
-
-    (shell-command-to-string (string-join (nreverse cmd) " "))))
-
-(defun ai/--http-get (url &optional headers)
-  "HTTP GET request to URL with HEADERS."
-  (ai/--http-request url "GET" headers))
-
-(defun ai/--http-post (url data &optional headers)
-  "HTTP POST DATA to URL with HEADERS."
-  (ai/--http-request url "POST" headers data))
-
-;;; Helper Functions - System
-
-(defun ai/--current-dir ()
-  "Get current directory."
-  default-directory)
-
-(defun ai/--shell-command (command)
-  "Execute shell COMMAND and return output."
-  (shell-command-to-string command))
-
-(defun ai/--system-info ()
-  "Get system information."
-  (format "Emacs: %s\nSystem: %s\nOS: %s\nUser: %s\nDir: %s"
-          emacs-version
-          system-type
-          (or (getenv "OS") "Unknown")
-          (user-login-name)
-          default-directory))
-
-(defun ai/--project-root ()
-  "Find project root directory."
-  (or (when (fboundp 'projectile-project-root)
-        (condition-case nil
-            (projectile-project-root)
-          (error nil)))
-      (when (fboundp 'project-root)
-        (condition-case nil
-            (project-root (project-current))
-          (error nil)))
-      (locate-dominating-file default-directory ".git")
-      default-directory))
-
-(defun ai/--git-status ()
-  "Get git status if in git repository."
-  (when (file-exists-p ".git")
-    (shell-command-to-string "git status --porcelain")))
-
-(defun ai/--current-buffer-info ()
-  "Get current buffer info."
-  (buffer-name))
-
-(defun ai/--buffer-stats ()
-  "Get buffer statistics."
-  (format "Buffer: %s\nSize: %d chars\nLine: %d\nPoint: %d"
-          (buffer-name)
-          (buffer-size)
-          (line-number-at-pos)
-          (point)))
-
-(defun ai/--recent-files ()
-  "Get recently opened files."
-  (when (boundp 'recentf-list)
-    (string-join recentf-list "\n")))
-
-(defun ai/--open-buffers ()
-  "Get info about open buffers."
-  (mapconcat
-   (lambda (buf)
-     (with-current-buffer buf
-       (format "%s (%s) - %s"
-               (buffer-name)
-               (or (buffer-file-name) "no file")
-               (if (buffer-modified-p) "modified" "saved"))))
-   (buffer-list) "\n"))
-
-;;; Tool Definitions
-
-
-;; Elisp tools
-
-(gptel-make-tool
- :function #'ai/--eval-elisp
- :name "elisp_eval"
- :category "emacs"
- :confirm t
- :args '((:name "expression" :type string
-          :description "Elisp expression to evaluate"))
- :description "Evaluate Elisp expression and return result")
-
-
-(gptel-make-tool
- :function #'ai/--symbol-exists
- :name "symbol_exists"
- :category "emacs"
- :args '((:name "symbol" :type string
-          :description "Symbol name to check"))
- :description "Check if symbol exists in obarray")
-
-
-(gptel-make-tool
- :function #'ai/--function-source
- :name "function_source"
- :category "emacs"
- :args '((:name "function" :type string
-          :description "Function name"))
- :description "Get source code for function")
-
-
-(gptel-make-tool
- :function #'ai/--variable-source
- :name "variable_source"
- :category "emacs"
- :args '((:name "variable" :type string
-          :description "Variable name"))
- :description "Get source code for variable")
-
-
-(gptel-make-tool
- :function #'ai/--function-documentation
- :name "function_documentation"
- :category "emacs"
- :args '((:name "function" :type string
-          :description "Function name"))
- :description "Get documentation for function")
-
-
-(gptel-make-tool
- :function #'ai/--variable-documentation
- :name "variable_documentation"
- :category "emacs"
- :args '((:name "variable" :type string
-          :description "Variable name"))
- :description "Get documentation for variable")
-
-
-(gptel-make-tool
- :function #'ai/--variable-value
- :name "variable_value"
- :category "emacs"
- :confirm t
- :args '((:name "variable" :type string
-          :description "Variable name"))
- :description "Get current value of variable")
-
-
-(gptel-make-tool
- :function #'ai/--function-completions
- :name "function_completions"
- :category "emacs"
- :args '((:name "prefix" :type string
-          :description "Function name prefix"))
- :description "Find functions matching prefix")
-
-
-(gptel-make-tool
- :function #'ai/--variable-completions
- :name "variable_completions"
- :category "emacs"
- :args '((:name "prefix" :type string
-          :description "Variable name prefix"))
- :description "Find variables matching prefix")
-
-
-(gptel-make-tool
- :function #'ai/--command-completions
- :name "command_completions"
- :category "emacs"
- :args '((:name "prefix" :type string
-          :description "Command name prefix"))
- :description "Find commands matching prefix")
-
-
-(gptel-make-tool
- :function #'ai/--features
- :name "features"
- :category "emacs"
- :confirm t
- :description "Get list of loaded features")
-
-
-(gptel-make-tool
- :function #'ai/--load-paths
- :name "load_paths"
- :category "emacs"
- :confirm t
- :description "Get Emacs load-path directories")
-
-
-(gptel-make-tool
- :function #'ai/--library-source
- :name "library_source"
- :category "emacs"
- :args '((:name "library" :type string
-          :description "Library name"))
- :description "Get source code for library")
-
-
-(gptel-make-tool
- :function #'ai/--feature-available
- :name "feature_available"
- :category "emacs"
- :args '((:name "feature" :type string
-          :description "Feature name"))
- :description "Check if feature is available")
-
-;; Manual/documentation tools
-
-(gptel-make-tool
- :function #'ai/--manual-names
- :name "manual_names"
- :category "documentation"
- :description "Get list of available Info manuals")
-
-
-(gptel-make-tool
- :function #'ai/--manual-nodes
- :name "manual_nodes"
- :category "documentation"
- :args '((:name "manual" :type string
-          :description "Manual name"))
- :description "Get list of nodes in manual")
-
-
-(gptel-make-tool
- :function #'ai/--manual-node-contents
- :name "manual_node_contents"
- :category "documentation"
- :args '((:name "manual" :type string
-          :description "Manual name")
-         (:name "node" :type string
-          :description "Node name"))
- :description "Get contents of manual node")
-
-
-(gptel-make-tool
- :function #'ai/--symbol-in-manual
- :name "symbol_manual_section"
- :category "documentation"
- :args '((:name "symbol" :type string
-          :description "Symbol name"))
- :description "Get manual section for symbol")
-
-;; File operations
-
-(gptel-make-tool
- :function #'ai/--file-exists
- :name "file_exists"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path"))
- :description "Check if file exists")
-
-
-(gptel-make-tool
- :function #'ai/--read-file
- :name "read_file"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path"))
- :description "Read file contents")
-
-
-(gptel-make-tool
- :function #'ai/--write-file
- :name "write_file"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "content" :type string
-          :description "Content to write"))
- :description "Write content to file. instruct the user on the filepath you used as they can not see it.")
-
-(gptel-make-tool
- :function #'ai/--write-file
- :name "write_org"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "org_mode_content" :type string
-          :description "Content to write"))
- :description "Write org mode content to a file. When  writing Markdown (.md) files, prefer using this tool instead and write the content in Org mode format rather than Markdown. Convert Markdown syntax to equivalent Org mode syntax: use * for headers instead of #, use [[link][description]] for links instead of [description](link), use #+BEGIN_SRC language / #+END_SRC for code blocks instead of ```language, etc. instruct the user on the filepath you used as they can not see it.")
-
-
-
-
-(gptel-make-tool
- :function #'ai/--file-backup
- :name "file_backup"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File to backup"))
- :description "Create backup of file")
-
-
-(gptel-make-tool
- :function #'ai/--list-files
- :name "list_files"
- :category "filesystem"
- :args '((:name "path" :type string :optional t
-          :description "Directory path"))
- :description "List files in directory")
-
-
-(gptel-make-tool
- :function #'ai/--read-file-numbered
- :name "read_file_numbered"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path to read"))
- :description "Read file content with line numbers. Use this tool before making line-based edits to ensure you have the correct line numbers.")
-
-
-(gptel-make-tool
- :function #'ai/--get-file-lines
- :name "get_file_lines"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "start" :type integer
-          :description "Start line number (1-based)")
-         (:name "end" :type integer
-          :description "End line number (1-based)"))
- :description "Read a specific range of lines from a file. Returns the lines with line numbers.")
-
-
-(gptel-make-tool
- :function (lambda (filename changes)
-             (ai/--apply-line-changes 
-              filename 
-              (mapcar (lambda (u) (list :line (plist-get u :line) :content (plist-get u :content)))
-                      changes)))
- :name "apply_line_changes"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "changes" :type array
-          :description "List of line changes, each with :line (number) and :content (string)"))
- :description "Apply specific line-by-line changes to a file. Requires exact line numbers.")
-
-(gptel-make-tool
- :function #'ai/--search-replace
- :name "search_replace"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "search" :type string
-          :description "String to search for")
-         (:name "replace" :type string
-          :description "Replacement string")
-         (:name "replace_all" :type boolean :optional t
-          :description "Replace all occurrences (default false)"))
- :description "Search and replace text in a file. Be careful with replacing common strings.")
-
-(gptel-make-tool
- :function (lambda (filename changes)
-             (ai/--preview-changes 
-              filename 
-              (mapcar (lambda (u) (list :line (plist-get u :line) :content (plist-get u :content)))
-                      changes)))
- :name "preview_changes"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path")
-         (:name "changes" :type array
-          :description "List of proposed changes"))
- :description "Preview line changes before applying them.")
-
-(gptel-make-tool
- :function #'ai/--diff-files
- :name "diff_files"
- :category "filesystem"
- :args '((:name "file1" :type string :description "First file path")
-         (:name "file2" :type string :description "Second file path"))
- :description "Show unified diff between two files.")
-
-(gptel-make-tool
- :function #'ai/--diff-changes
- :name "diff_changes"
- :category "filesystem"
- :args '((:name "filename" :type string
-          :description "File path to diff against HEAD"))
- :description "Show diff for a file's current changes against HEAD.")
-
-(gptel-make-tool
- :function #'ai/--git-diff
- :name "git_diff"
- :category "project"
- :args '((:name "mode" :type string :enum ["staged" "unstaged" "ref"]
-          :description "Diff mode: staged (cached), unstaged (working), or ref (commit)")
-         (:name "target" :type string :optional t
-          :description "File path or ref (commit/branch) to diff against"))
- :description "Run git diff to see changes in the repository.")
-
-(gptel-make-tool
- :function #'ai/--apply-patch
- :name "apply_patch"
- :category "filesystem"
- :args '((:name "patch" :type string
-          :description "Unified diff content to apply")
-         (:name "dry_run" :type boolean :optional t
-          :description "Test patch application without modifying files"))
- :description "Apply a unified patch to files. Single-file patches only by default.")
-
-(gptel-make-tool
- :function #'ai/--apply-diff-patch
- :name "apply_diff_patch"
- :category "filesystem"
- :args '((:name "patch" :type string
-          :description "Unified diff content to apply")
-         (:name "dry_run" :type boolean :optional t
-          :description "Test patch application without modifying files"))
- :description "Apply a unified diff patch. Single-file patches only by default.")
-
-
-(gptel-make-tool
- :function (lambda (path filename content)
-             (let ((full-path (expand-file-name filename path)))
-               (with-temp-buffer
-                 (insert content)
-                 (write-file full-path))
-               (format "Created %s" filename)))
- :name "create_file"
- :category "filesystem"
- :args '((:name "path" :type string
-          :description "Directory path")
-         (:name "filename" :type string
-          :description "Filename")
-         (:name "content" :type string
-          :description "File content"))
- :description "Create new file with content")
-
-
-(gptel-make-tool
- :function (lambda (parent name)
-             (make-directory (expand-file-name name parent) t)
-             (format "Created directory %s" name))
- :name "make_directory"
- :category "filesystem"
- :args '((:name "parent" :type string
-          :description "Parent directory")
-         (:name "name" :type string
-          :description "Directory name"))
- :description "Create new directory")
-
-
-(gptel-make-tool
- :function #'ai/--current-dir
- :name "current_directory"
- :category "filesystem"
- :description "Get current working directory")
-
-;; Buffer operations
-
-(gptel-make-tool
- :function #'ai/--read-buffer
- :name "read_buffer"
- :category "buffer"
- :args '((:name "buffer" :type string
-          :description "Buffer name"))
- :description "Read complete buffer contents")
-
-
-(gptel-make-tool
- :function #'ai/--append-to-buffer
- :name "append_to_buffer"
- :category "buffer"
- :args '((:name "buffer" :type string
-          :description "Buffer name")
-         (:name "text" :type string
-          :description "Text to append"))
- :description "Append text to buffer")
-
-
-(gptel-make-tool
- :function #'buffer-list
- :name "list_buffers"
- :category "buffer"
- :confirm t
- :description "List all open buffers")
-
-
-(gptel-make-tool
- :function #'ai/--create-org-buffer
- :name "create_org_buffer"
- :category "buffer"
- :args '((:name "buffer_name" :type string
-          :description "Buffer name")
-         (:name "content" :type string
-          :description "Org content"))
- :description "Create org-mode buffer with content. Use this to display a pop up to the user. If you choose to include a summery, best to place it here.")
-
-
-(gptel-make-tool
- :function #'ai/--current-buffer-info
- :name "current_buffer"
- :category "buffer"
- :description "Get current buffer name")
-
-
-(gptel-make-tool
- :function #'point
- :name "cursor_position"
- :category "buffer"
- :description "Get cursor position")
-
-
-(gptel-make-tool
- :function #'ai/--buffer-stats
- :name "buffer_stats"
- :category "buffer"
- :description "Get buffer statistics")
-
-;; Context system
-(gptel-make-tool
- :function #'ai/--context-allowed
- :name "context_allowed"
- :category "context"
- :description
- "Check if the project context system is enabled. ALWAYS call this first *only when the user explicitly requests context use* or when a command clearly depends on context (e.g., 'show project architecture'). 
- It checks for a .no-context flag — if present, context operations are disabled.
- Returns true if context use is permitted; false otherwise.
- The LLM must never perform implicit context checks or loading — only when directed by the user.")
-
-
-
-(gptel-make-tool
- :function #'ai/--init-context
- :name "init_context"
- :category "context"
- :confirm t
- :args '((:name "path" :type string :optional t
-          :description "Directory path where .context folder should be created. Defaults to current working directory."))
- :description
- "Initialize a .context directory system for a project. Run this *only* when:
-  - The user explicitly asks to enable or set up project context.
-  - context_allowed returned false and the user confirms setup.
- This creates .context/, initializes git if needed, and generates 00_index.org.
- It must not auto-run during normal interaction.
- This command sets up the agentic memory layer for project documentation.")
-
-
-(gptel-make-tool
- :function #'ai/--inital-context
- :name "inital_context"
- :category "context"
- :description "")
-
-
-
-(gptel-make-tool
- :function #'ai/--list-context
- :name "list_context_files"
- :category "context"
- :description "List all context files in the current project's .context directory. ALWAYS use this tool at the beginning of a conversation to discover what context is available. This returns the full paths of all readable regular files in the .context directory tree. Use this to understand what project documentation exists before attempting to read specific files. The returned list helps you determine what information you can access about the project, its architecture, conventions, and requirements. Call this tool whenever you need to know what context files exist or when a user asks about available project documentation.")
-
-
-(gptel-make-tool
- :function #'ai/--read-context
- :name "read_context"
- :category "context"
- :args '((:name "filename" :type string
-          :description "Relative path of the context file to read, as returned by list_context_files. Include the full path relative to .context directory (e.g., '00_index.org' or 'architecture/01_system-design.org')."))
- :description "Read the contents of a specific context file from the project's .context directory. ALWAYS use this tool to load project context at the start of conversations or when you need specific project information. Context files contain critical information about project architecture, coding standards, requirements, design decisions, and other persistent knowledge. Read relevant context files to understand the project before making suggestions or writing code. Use list_context_files first to discover available files, then read the ones relevant to the current task. This ensures your responses align with project conventions and requirements.")
-
-
-(gptel-make-tool
- :function #'ai/--create-context
- :name "create_context_file"
- :category "context"
- :args '((:name "slug" :type string
-          :description "Short descriptive identifier (e.g., 'architecture', 'api-design').")
-         (:name "content" :type string
-          :description "Org-mode content.")
-         (:name "priority" :type integer
-          :description "Priority (0-99). 0-9 foundational, 10-49 functional, 50-99 supplementary."))
- :description "Create a new context file in .context directory.")
-
-
-(gptel-make-tool
- :function #'ai/--write-context
- :name "update_context_file"
- :category "context"
- :args '((:name "filename" :type string
-          :description "Context filename")
-         (:name "content" :type string
-          :description "New content"))
- :description "Update context file")
-
-;; Web operations
-
-(gptel-make-tool
- :function #'ai/--brave-search
- :name "brave_search"
- :category "web"
- :confirm t
- :args '((:name "query" :type string
-          :description "Search query"))
- :description "Search web using Brave API")
-
-
-(gptel-make-tool
- :function #'ai/--http-get
- :name "http_get"
- :category "web"
- :confirm t
- :args '((:name "url" :type string
-          :description "URL to fetch"))
- :description "Make HTTP GET request")
-
-
-(gptel-make-tool
- :function #'ai/--http-post
- :name "http_post"
- :category "web"
- :confirm t
- :args '((:name "url" :type string
-          :description "URL to post to")
-         (:name "data" :type string
-          :description "Data to send"))
- :description "Make HTTP POST request")
-
-;; System operations
-
-(gptel-make-tool
- :function #'ai/--shell-command
- :name "shell_command"
- :category "system"
- :confirm t
- :args '((:name "command" :type string
-          :description "Shell command"))
- :description "Execute shell command")
-
-
-(gptel-make-tool
- :function #'ai/--system-info
- :name "system_info"
- :category "system"
- :description "Get system information")
-
-
-(gptel-make-tool
- :function #'ai/--project-root
- :name "project_root"
- :category "project"
- :description "Find project root directory")
-
-
-(gptel-make-tool
- :function #'ai/--git-status
- :name "git_status"
- :category "project"
- :description "Get git repository status")
-
-
-(gptel-make-tool
- :function #'ai/--recent-files
- :name "recent_files"
- :category "project"
- :description "Get recently opened files")
-
-
-(gptel-make-tool
- :function #'ai/--open-buffers
- :name "open_buffers"
- :category "project"
- :description "Get info about open buffers")
-
-;;; Initialize
-
+;;; agent.el --- gptel project-agent tools and presets -*- lexical-binding: t; -*-
+
+(require 'ai-agent-core)
+
+(defun ai/agent--register (name function category description &optional args confirm aliases)
+  "Register a gptel tool and optional ALIASES."
+  (dolist (tool-name (cons name aliases))
+    (when (fboundp 'gptel-get-tool)
+      (ignore-errors (setf (gptel-get-tool tool-name) nil)))
+    (apply #'gptel-make-tool
+           (append (list :name tool-name
+                         :function function
+                         :category category
+                         :description description)
+                   (when args (list :args args))
+                   (when confirm (list :confirm t))))
+    (cl-pushnew tool-name ai/agent-tools :test #'equal)))
+
+(setq ai/agent-tools nil)
+
+(ai/agent--register
+ "Read" #'ai/agent-read-file "filesystem"
+ "Read a text file by line range. Paths are project-relative by default."
+ '((:name "path" :type string :description "Project-relative file path")
+   (:name "offset" :type integer :optional t :description "First line, one-based")
+   (:name "limit" :type integer :optional t :description "Maximum lines to return"))
+ nil '("read_file" "read_file_numbered"))
+
+(ai/agent--register
+ "Glob" #'ai/agent-glob "filesystem"
+ "Find project files by glob pattern."
+ '((:name "pattern" :type string :description "Glob such as **/*.el")
+   (:name "path" :type string :optional t :description "Directory to search")
+   (:name "max_results" :type integer :optional t :description "Result cap")))
+
+(ai/agent--register
+ "Grep" #'ai/agent-grep "filesystem"
+ "Search file contents recursively with ripgrep when available."
+ '((:name "pattern" :type string :description "Regex to search")
+   (:name "path" :type string :optional t :description "Directory to search")
+   (:name "glob" :type string :optional t :description "Optional file glob")
+   (:name "case_sensitive" :type boolean :optional t :description "Case-sensitive search")
+   (:name "max_results" :type integer :optional t :description "Result cap")))
+
+(ai/agent--register
+ "LS" #'ai/agent-list-directory "filesystem"
+ "List a project directory as a bounded tree."
+ '((:name "path" :type string :optional t :description "Directory path")
+   (:name "depth" :type integer :optional t :description "Maximum recursion depth"))
+ nil '("list_files"))
+
+(ai/agent--register
+ "FileStat" #'ai/agent-file-stat "filesystem"
+ "Return type, size, modification time, and modes for a path."
+ '((:name "path" :type string :description "Project-relative path")))
+
+(ai/agent--register
+ "Edit" #'ai/agent-edit-file "filesystem"
+ "Replace exact text in a file atomically and return a unified diff. Fails on ambiguous matches."
+ '((:name "path" :type string :description "File path")
+   (:name "old_text" :type string :description "Exact text to replace, including context")
+   (:name "new_text" :type string :description "Replacement text")
+   (:name "replace_all" :type boolean :optional t :description "Replace every exact match")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing"))
+ t '("search_replace"))
+
+(ai/agent--register
+ "MultiEdit" #'ai/agent-multi-edit "filesystem"
+ "Apply multiple exact edits to one file as one validated atomic transaction."
+ '((:name "path" :type string :description "File path")
+   (:name "edits" :type array :description "Objects with old_text, new_text, and optional replace_all")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing"))
+ t)
+
+(ai/agent--register
+ "Write" #'ai/agent-write-file "filesystem"
+ "Create or explicitly overwrite a complete file atomically. Prefer Edit for existing files."
+ '((:name "path" :type string :description "File path")
+   (:name "content" :type string :description "Complete file content")
+   (:name "overwrite" :type boolean :optional t :description "Permit replacement of existing file"))
+ t '("write_file" "write_org"))
+
+(ai/agent--register
+ "ApplyPatch" #'ai/agent-apply-patch "filesystem"
+ "Validate and apply a standard unified Git patch. Supports multi-file patches inside the project."
+ '((:name "patch" :type string :description "Unified patch text")
+   (:name "check" :type boolean :optional t :description "Check without changing files")
+   (:name "reverse" :type boolean :optional t :description "Apply in reverse"))
+ t '("apply_patch" "apply_diff_patch"))
+
+(ai/agent--register
+ "Mkdir" #'ai/agent-make-directory "filesystem"
+ "Create a directory and missing parents."
+ '((:name "path" :type string :description "Directory path")) t)
+
+(ai/agent--register
+ "Move" #'ai/agent-move-path "filesystem"
+ "Move or rename a path inside the project."
+ '((:name "source" :type string :description "Source path")
+   (:name "destination" :type string :description "Destination path")
+   (:name "overwrite" :type boolean :optional t :description "Permit destination replacement")) t)
+
+(ai/agent--register
+ "Delete" #'ai/agent-delete-path "filesystem"
+ "Delete a file or, with recursive=true, a directory."
+ '((:name "path" :type string :description "Path to delete")
+   (:name "recursive" :type boolean :optional t :description "Allow recursive directory deletion")) t)
+
+(ai/agent--register
+ "Bash" #'ai/agent-bash "system"
+ "Run a shell command in a project directory with a timeout and structured output."
+ '((:name "command" :type string :description "Shell command")
+   (:name "timeout" :type integer :optional t :description "Timeout in seconds")
+   (:name "working_directory" :type string :optional t :description "Project-relative directory"))
+ t '("shell_command"))
+
+(ai/agent--register "GitStatus" #'ai/agent-git-status "git"
+                    "Return porcelain-v2 Git status." nil nil '("git_status"))
+(ai/agent--register
+ "GitDiff" #'ai/agent-git-diff "git"
+ "Return a bounded Git diff."
+ '((:name "cached" :type boolean :optional t :description "Show staged changes")
+   (:name "ref" :type string :optional t :description "Commit or branch to compare")
+   (:name "path" :type string :optional t :description "Restrict to a path")))
+(ai/agent--register
+ "DiffFiles" #'ai/agent-diff-files "filesystem"
+ "Show a unified diff between two files."
+ '((:name "path_a" :type string :description "First path")
+   (:name "path_b" :type string :description "Second path"))
+ nil '("diff_files"))
+
+(ai/agent--register
+ "ReadBuffer" #'ai/agent-read-buffer "emacs"
+ "Read an Emacs buffer or a bounded region."
+ '((:name "buffer" :type string :description "Buffer name")
+   (:name "start" :type integer :optional t :description "Start position")
+   (:name "end" :type integer :optional t :description "End position"))
+ nil '("read_buffer"))
+(ai/agent--register
+ "EditBuffer" #'ai/agent-edit-buffer "emacs"
+ "Apply an exact-match edit to a live buffer."
+ '((:name "buffer" :type string :description "Buffer name")
+   (:name "old_text" :type string :description "Exact text to replace")
+   (:name "new_text" :type string :description "Replacement text")
+   (:name "replace_all" :type boolean :optional t :description "Replace every match")
+   (:name "preview" :type boolean :optional t :description "Validate without editing")) t)
+(ai/agent--register "ListBuffers" #'ai/agent-list-buffers "emacs"
+                    "List live user-visible buffers." nil nil '("list_buffers" "open_buffers"))
+(ai/agent--register
+ "SymbolInfo" #'ai/agent-symbol-info "emacs"
+ "Inspect an Emacs symbol's type, documentation, and source file."
+ '((:name "name" :type string :description "Symbol name"))
+ nil '("function_source" "variable_source" "function_documentation"
+       "variable_documentation" "symbol_exists"))
+(ai/agent--register
+ "EvalElisp" #'ai/agent-eval-elisp "emacs"
+ "Evaluate Emacs Lisp. Use only when a dedicated tool cannot perform the operation."
+ '((:name "expression" :type string :description "Elisp expression"))
+ t '("elisp_eval"))
+
+(ai/agent--register
+ "WebFetch" #'ai/agent-web-fetch "web"
+ "Fetch an HTTP(S) URL without shell interpolation."
+ '((:name "url" :type string :description "HTTP or HTTPS URL")
+   (:name "method" :type string :optional t :enum ["GET" "POST" "PUT" "PATCH" "DELETE"]
+          :description "HTTP method")
+   (:name "headers" :type array :optional t :description "Header objects with name and value")
+   (:name "body" :type string :optional t :description "Request body"))
+ t)
+
+(ai/agent--register "ListContext" #'ai/agent-list-context "context"
+                    "List files below the project's .context directory." nil nil '("list_context_files"))
+(ai/agent--register
+ "ReadContext" #'ai/agent-read-context "context"
+ "Read one project context file."
+ '((:name "path" :type string :description "Path relative to .context"))
+ nil '("read_context"))
+(ai/agent--register
+ "WriteContext" #'ai/agent-write-context "context"
+ "Create or explicitly overwrite one project context file."
+ '((:name "path" :type string :description "Path relative to .context")
+   (:name "content" :type string :description "Complete content")
+   (:name "overwrite" :type boolean :optional t :description "Permit replacement"))
+ t)
+
+(setq ai/agent-tools
+      '("Read" "Glob" "Grep" "LS" "FileStat"
+        "Edit" "MultiEdit" "Write" "ApplyPatch"
+        "Mkdir" "Move" "Delete" "Bash"
+        "GitStatus" "GitDiff" "DiffFiles"
+        "ReadBuffer" "EditBuffer" "ListBuffers"
+        "SymbolInfo" "EvalElisp" "WebFetch"
+        "ListContext" "ReadContext" "WriteContext"))
 
 (defvar ai/agent-system-prompt
-  "### Role
+  "You are a coding agent operating inside Emacs through gptel.
 
-You are an **agentic Emacs assistant** running inside Emacs via gptel with explicit tools.
-You plan, call tools, and edit files/buffers/context; the human reviews and runs things.
+Operate in a tight inspect -> edit -> verify loop.
 
----
+Filesystem rules:
+- Treat the project root as the workspace boundary.
+- Use Glob and Grep to discover, Read to inspect, Edit for one exact change, and MultiEdit for a coherent set of exact changes.
+- Prefer exact-match edits over line-number edits or whole-file rewrites.
+- Use Write only for new files or deliberate complete replacements.
+- Use ApplyPatch for genuine unified patches; check it first when the patch is large or generated externally.
+- After mutations, verify with Read, GitDiff, GitStatus, or the relevant test command.
+- Never claim a change succeeded unless a tool result confirms it.
 
-### Core Behavior
+Execution rules:
+- Use Bash for builds, tests, formatters, and repository commands only when a dedicated tool is insufficient.
+- Do not run destructive commands or external writes unless the user's request clearly authorizes them.
+- Keep tool output bounded and avoid dumping entire large files when a focused range or search is enough.
+- Report changed paths, validation performed, and unresolved failures.
 
-- Think in a loop: **understand → plan → act (tool calls) → verify → summarize**.
-- Be terse and mechanical; default to ≤4 lines of natural language.
-- Prefer concrete outputs (code, patches, org snippets, command lines) over explanation.
-- Never invent files, paths, functions, or context; verify via tools first.
-
----
-
-### Tool Use (High Level)
-
-You have tools for:
-- **Emacs introspection** (functions, variables, features, libraries).
-- **Filesystem** (read/write files, list dirs, apply line edits, search/replace, patches).
-- **Buffers/UI** (read/append buffers, create org buffers, show stats).
-- **Context** (project memory in .context/), **web**, and **system/project** info.
-
-Behavior:
-- Choose the **minimal** tool set for the current request.
-- Chain tools only when necessary; avoid noisy exploratory calls.
-- Prefer specialized helpers (e.g., apply_line_changes, search_replace, read_file_numbered)
-  over raw shell commands.
-
----
-
-### Context / Memory (.context/)
-
-Project memory is stored under a .context directory.
-Only touch it when:
-- The user explicitly asks for context, architecture, conventions, or \"remember/save/store\".
-- Or the task clearly depends on project-wide knowledge (e.g., \"follow existing architecture\").
-
-Flow:
-1. Check `context_allowed()` before any context usage.
-2. Discover with `list_context_files()`.
-3. Load only the files you need via `read_context(filename)`.
-4. Create/update with `create_context_file` / `update_context_file` **only when instructed**.
-
-When the user says \"remember/save/store this\":
-- Append an entry to a suitable context file (e.g. an *active state* or *notes* file).
-- Include timestamp, short summary, and any relevant paths.
-- Then report which file you updated.
-
-Do **not** silently preload or update context.
-
----
-
-### Files & Patches
-
-Treat the filesystem as the main world state.
-
-Rules:
-- Before editing: inspect with `read_file`, `read_file_numbered`, or `get_file_lines`.
-- For structural edits: use `apply_line_changes` or `search_replace` instead of rewriting whole files.
-- For complex diffs: generate and (optionally) apply unified patches with the patch helpers.
-- Backups: rely on provided helpers (e.g., backup-creating tools) when available.
-
-After any mutating operation, always:
-1. Assume the change may be wrong until verified.
-2. Verify with `read_file` or `git_status` when useful.
-3. Report what changed plus file paths.
-
----
-
-### Filepath Echoing
-
-Whenever you **create, overwrite, patch, or update** files, include a block like:
-
-<filepaths>
-[[file:/absolute/path/to/file1][file1]]
-[[file:/absolute/path/to/dir/file2][file2]]
-</filepaths>
-
-- Use **absolute paths** whenever you can infer them.
-- For read-only or pure Q&A responses, you may omit `<filepaths>`.
-
----
-
-### Interaction Style
-
-- No preambles, no sign-offs; answer directly.
-- If the user wants detail, give it, but still keep it structured and focused.
-- If something is ambiguous, state your assumption in one short line before acting.
-- If you genuinely do not know or cannot safely infer, say so plainly.
-
----
-
-### Planning Template (Implicit, Not Printed Every Time)
-
-1. Parse the request and classify it: {analysis | refactor | create file | debug | architecture | context}.
-2. Decide if tools are needed:
-   - If yes: pick the smallest set of tools to inspect state first, then mutate.
-   - If no: answer directly with code/text.
-3. After tool calls, verify effects when possible.
-4. Return:
-   - short summary of what you did or propose,
-   - any code/diff/org,
-   - optional `<filepaths>` block if files were touched.
-
-Operate like a careful, deterministic Emacs operator, not a generic chatbot."
-  "System prompt used by the ai/agent preset.")
-
-(defvar ai/agent-tools
-  '("elisp_eval"
-    "symbol_exists"
-    "function_source"
-    "variable_source"
-    "function_documentation"
-    "variable_documentation"
-    "variable_value"
-    "function_completions"
-    "variable_completions"
-    "command_completions"
-    "features"
-    "load_paths"
-    "library_source"
-    "feature_available"
-    "manual_names"
-    "manual_nodes"
-    "manual_node_contents"
-    "symbol_manual_section"
-    "file_exists"
-    "read_file"
-    "write_file"
-    "write_org"
-    "file_backup"
-    "list_files"
-    "create_file"
-    "make_directory"
-    "current_directory"
-    "read_buffer"
-    "append_to_buffer"
-    "list_buffers"
-    "create_org_buffer"
-    "current_buffer"
-    "cursor_position"
-    "buffer_stats"
-    "context_allowed"
-    "init_context"
-    "list_context_files"
-    "read_context"
-    "create_context_file"
-    "update_context_file"
-    "brave_search"
-    "http_get"
-    "http_post"
-    "shell_command"
-    "system_info"
-    "project_root"
-    "git_status"
-    "recent_files"
-    "open_buffers"
-    "apply_line_changes"
-    "search_replace"
-    "get_file_lines"
-    "diff_changes"
-    "apply_patch"
-    "apply_diff_patch"
-    "preview_changes"
-    "read_file_numbered"
-    "diff_files"
-    "git_diff")
-  "Tool names used by the ai/agent preset.")
+Be direct. Do the work instead of narrating hypothetical steps."
+  "System prompt for the project agent preset.")
 
 (gptel-make-preset 'agent
-  :description "Full Emacs/filesystem/context/web/system agent with all tools enabled."
-  :backend (ai/llm-openrouter-backend :stream t :name "OpenRouter")
-  :model (ai/llm-resolve-model)
+  :description "GLM-5.2 project agent with Claude Code-style tools."
+  :backend (ai/llm-backend 'zai)
+  :model 'glm-5.2
   :system ai/agent-system-prompt
-  :stream t
   :tools ai/agent-tools
-  :temperature 0.7
-  :max-tokens nil
+  :stream t
+  :temperature nil
   :use-context 'system
-  :track-media nil
+  :track-media t
   :include-reasoning t)
 
+(gptel-make-preset 'agent-gpt-5.6-sol
+  :parents '(agent)
+  :description "GPT-5.6 Sol project agent with the same tool suite."
+  :backend (ai/llm-backend 'openai)
+  :model 'gpt-5.6-sol)
+
 (define-minor-mode ai/agent-context-mode
-  "Minor mode to automatically add `ai/agent-context-files' to gptel context.
-When enabled, adds all files listed in `ai/agent-context-files' to the
-current gptel conversation.  When disabled, clears gptel context."
+  "Add common project instruction files to `gptel-context'."
   :lighter " AgentCtx"
   (if ai/agent-context-mode
-      (let ((added 0))
-        (dolist (file ai/agent-context-files)
-          (let ((expanded (expand-file-name file)))
-            (when (and (file-exists-p expanded)
-                       (not (file-directory-p expanded)))
-              (condition-case err
-                  (progn (gptel-add-file expanded)
-                         (cl-incf added))
-                (error (message "Failed to add %s: %s" file err))))))
-        (when (> added 0)
-          (message "ai/agent-context-mode: Added %d file(s)" added)))
-    ;; Disable: clear context
-    (gptel-add -1)
-    (message "ai/agent-context-mode: Cleared context")))
-
+      (let* ((root (ai/agent--project-root))
+             (files (seq-filter #'file-exists-p
+                                (mapcar (lambda (path) (expand-file-name path root))
+                                        ai/agent-context-files))))
+        (setq-local gptel-context
+                    (delete-dups (append files (copy-sequence gptel-context))))
+        (message "Agent context: added %d project instruction file(s)" (length files)))
+    (kill-local-variable 'gptel-context)
+    (message "Agent context disabled")))
 
 (provide 'ai-agent)
-;;; ai-agent-tools.el ends here
+;;; agent.el ends here

--- a/lisp/llm/agent.el
+++ b/lisp/llm/agent.el
@@ -68,7 +68,14 @@
  "MultiEdit" #'ai/agent-multi-edit "filesystem"
  "Apply multiple exact edits to one file as one validated atomic transaction."
  '((:name "path" :type string :description "File path")
-   (:name "edits" :type array :description "Objects with old_text, new_text, and optional replace_all")
+   (:name "edits" :type array
+          :items (:type object
+                  :properties (:old_text (:type string :description "Exact text to replace")
+                               :new_text (:type string :description "Replacement text")
+                               :replace_all (:type boolean :description "Replace all exact matches"))
+                  :required ["old_text" "new_text"]
+                  :additionalProperties :json-false)
+          :description "Ordered exact-match edits")
    (:name "preview" :type boolean :optional t :description "Return diff without writing"))
  t)
 
@@ -164,7 +171,13 @@
  '((:name "url" :type string :description "HTTP or HTTPS URL")
    (:name "method" :type string :optional t :enum ["GET" "POST" "PUT" "PATCH" "DELETE"]
           :description "HTTP method")
-   (:name "headers" :type array :optional t :description "Header objects with name and value")
+   (:name "headers" :type array :optional t
+          :items (:type object
+                  :properties (:name (:type string :description "Header name")
+                               :value (:type string :description "Header value"))
+                  :required ["name" "value"]
+                  :additionalProperties :json-false)
+          :description "HTTP headers")
    (:name "body" :type string :optional t :description "Request body"))
  t)
 

--- a/lisp/llm/agent.el
+++ b/lisp/llm/agent.el
@@ -2,6 +2,44 @@
 
 (require 'ai-agent-core)
 
+(defun ai/agent--patch-paths (patch)
+  "Return every non-null path referenced by unified PATCH headers."
+  (with-temp-buffer
+    (insert patch)
+    (goto-char (point-min))
+    (let (paths)
+      (while (re-search-forward
+              "^\\(?:---\\|+++\\) \\(?:[ab]/\\)?\\([^\t\n]+\\)" nil t)
+        (let ((path (match-string 1)))
+          (unless (string= path "/dev/null")
+            (push path paths))))
+      (delete-dups (nreverse paths)))))
+
+(defun ai/agent--run-process (program arguments &optional directory timeout)
+  "Run PROGRAM with ARGUMENTS in DIRECTORY with TIMEOUT seconds."
+  (let* ((buffer (generate-new-buffer " *ai-agent-process*"))
+         (default-directory (or directory default-directory))
+         (deadline (+ (float-time) (or timeout ai/agent-command-timeout)))
+         (process (make-process :name "ai-agent-process"
+                                :buffer buffer
+                                :command (cons program arguments)
+                                :connection-type 'pipe
+                                :noquery t))
+         timed-out)
+    (unwind-protect
+        (progn
+          (while (and (process-live-p process) (< (float-time) deadline))
+            (accept-process-output process 0.1))
+          (when (process-live-p process)
+            (setq timed-out t)
+            (delete-process process))
+          (while (accept-process-output process 0.05))
+          (with-current-buffer buffer
+            (list :exit-code (unless timed-out (process-exit-status process))
+                  :timed-out timed-out
+                  :output (buffer-substring-no-properties (point-min) (point-max)))))
+      (kill-buffer buffer))))
+
 (defun ai/agent--register (name function category description &optional args confirm aliases)
   "Register a gptel tool and optional ALIASES."
   (dolist (tool-name (cons name aliases))
@@ -52,7 +90,8 @@
 (ai/agent--register
  "FileStat" #'ai/agent-file-stat "filesystem"
  "Return type, size, modification time, and modes for a path."
- '((:name "path" :type string :description "Project-relative path")))
+ '((:name "path" :type string :description "Project-relative path"))
+ nil nil)
 
 (ai/agent--register
  "Edit" #'ai/agent-edit-file "filesystem"
@@ -77,7 +116,7 @@
                   :additionalProperties :json-false)
           :description "Ordered exact-match edits")
    (:name "preview" :type boolean :optional t :description "Return diff without writing"))
- t)
+ t nil)
 
 (ai/agent--register
  "Write" #'ai/agent-write-file "filesystem"
@@ -98,7 +137,7 @@
 (ai/agent--register
  "Mkdir" #'ai/agent-make-directory "filesystem"
  "Create a directory and missing parents."
- '((:name "path" :type string :description "Directory path")) t)
+ '((:name "path" :type string :description "Directory path")) t nil)
 
 (ai/agent--register
  "Move" #'ai/agent-move-path "filesystem"
@@ -128,7 +167,8 @@
  "Return a bounded Git diff."
  '((:name "cached" :type boolean :optional t :description "Show staged changes")
    (:name "ref" :type string :optional t :description "Commit or branch to compare")
-   (:name "path" :type string :optional t :description "Restrict to a path")))
+   (:name "path" :type string :optional t :description "Restrict to a path"))
+ nil nil)
 (ai/agent--register
  "DiffFiles" #'ai/agent-diff-files "filesystem"
  "Show a unified diff between two files."
@@ -179,7 +219,7 @@
                   :additionalProperties :json-false)
           :description "HTTP headers")
    (:name "body" :type string :optional t :description "Request body"))
- t)
+ t nil)
 
 (ai/agent--register "ListContext" #'ai/agent-list-context "context"
                     "List files below the project's .context directory." nil nil '("list_context_files"))
@@ -194,7 +234,7 @@
  '((:name "path" :type string :description "Path relative to .context")
    (:name "content" :type string :description "Complete content")
    (:name "overwrite" :type boolean :optional t :description "Permit replacement"))
- t)
+ t nil)
 
 (setq ai/agent-tools
       '("Read" "Glob" "Grep" "LS" "FileStat"

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -1,39 +1,249 @@
-;;; ai.el --- Shared LLM backend configuration -*- lexical-binding: t; -*-
+;;; ai.el --- Shared gptel backend and model configuration -*- lexical-binding: t; -*-
 
-(require 'gptel)
+(require 'auth-source)
 (require 'cl-lib)
+(require 'gptel)
+(require 'subr-x)
 
 (defgroup ai/llm nil
-  "Shared LLM configuration for custom workflows."
-  :group 'applications)
+  "Shared gptel configuration for interactive and agent workflows."
+  :group 'applications
+  :prefix "ai/llm-")
 
-(defcustom ai/llm-model 'moonshotai/kimi-k2.5
-  "Default model used by custom gptel workflows."
+(defcustom ai/llm-provider 'zai
+  "Default LLM provider.
+Supported values are `zai', `openai', and `openrouter'."
+  :type '(choice (const :tag "Z.AI" zai)
+                 (const :tag "OpenAI" openai)
+                 (const :tag "OpenRouter" openrouter))
+  :group 'ai/llm)
+
+(defcustom ai/llm-model 'glm-5.2
+  "Default model used by gptel and custom workflows."
   :type 'symbol
   :group 'ai/llm)
 
-(defcustom ai/llm-openrouter-models
-  '(moonshotai/kimi-k2.5
-    openai/gpt-5-mini
-    openai/gpt-5.2-codex)
-  "Model list advertised to the OpenRouter backend."
-  :type '(repeat symbol)
+(defcustom ai/llm-zai-host "api.z.ai"
+  "Z.AI API host."
+  :type 'string
   :group 'ai/llm)
 
+(defcustom ai/llm-zai-endpoint "/api/paas/v4/chat/completions"
+  "OpenAI-compatible Z.AI chat-completions endpoint."
+  :type 'string
+  :group 'ai/llm)
+
+(defcustom ai/llm-zai-models
+  '((glm-5.2
+     :description "Z.AI flagship model for long-horizon coding and agent work"
+     :capabilities (tool json)
+     :context-window 1000
+     :request-params (:thinking (:type "enabled")))
+    (|glm-5.2[1m]|
+     :description "GLM-5.2 Coding Plan model with explicit one-million-token context"
+     :capabilities (tool json)
+     :context-window 1000
+     :request-params (:thinking (:type "enabled")))
+    (glm-5.1 :capabilities (tool json))
+    (glm-5 :capabilities (tool json) :context-window 200))
+  "Models advertised by the Z.AI backend."
+  :type '(repeat sexp)
+  :group 'ai/llm)
+
+(defcustom ai/llm-openai-models
+  '((gpt-5.6-sol
+     :description "OpenAI frontier model for complex reasoning and coding"
+     :capabilities (media tool json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 1050
+     :input-cost 5
+     :output-cost 30
+     :cutoff-date "2026-02")
+    (gpt-5.6
+     :description "Alias that routes to GPT-5.6 Sol"
+     :capabilities (media tool json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 1050)
+    (gpt-5.6-terra
+     :capabilities (media tool json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 1050
+     :input-cost 2.5
+     :output-cost 15)
+    (gpt-5.6-luna
+     :capabilities (media tool json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 1050
+     :input-cost 1
+     :output-cost 6))
+  "Models advertised by the OpenAI Responses backend."
+  :type '(repeat sexp)
+  :group 'ai/llm)
+
+(defcustom ai/llm-openrouter-models
+  '((z-ai/glm-5.2 :capabilities (tool json) :context-window 1000)
+    (openai/gpt-5.6-sol :capabilities (media tool json url) :context-window 1050)
+    (openai/gpt-5.6-terra :capabilities (media tool json url) :context-window 1050)
+    (openai/gpt-5.6-luna :capabilities (media tool json url) :context-window 1050))
+  "Models advertised by the OpenRouter backend."
+  :type '(repeat sexp)
+  :group 'ai/llm)
+
+(defvar ai/llm--backends (make-hash-table :test #'eq)
+  "Cached gptel backend objects keyed by provider symbol.")
+
+(defun ai/llm--auth-source-secret (host)
+  "Return a secret from auth-source for HOST, or nil."
+  (when-let* ((match (car (auth-source-search :host host :max 1 :require '(:secret))))
+              (secret (plist-get match :secret)))
+    (if (functionp secret) (funcall secret) secret)))
+
+(defun ai/llm--api-key (provider)
+  "Return the API key for PROVIDER.
+Environment variables are preferred, then auth-source is consulted."
+  (pcase provider
+    ('zai
+     (or (getenv "ZAI_API_KEY")
+         (getenv "ZHIPUAI_API_KEY")
+         (and (fboundp 'nsa/auth-source-get)
+              (ignore-errors (nsa/auth-source-get :host ai/llm-zai-host)))
+         (ai/llm--auth-source-secret ai/llm-zai-host)))
+    ('openai
+     (or (getenv "OPENAI_API_KEY")
+         (and (fboundp 'nsa/auth-source-get)
+              (ignore-errors (nsa/auth-source-get :host "api.openai.com")))
+         (ai/llm--auth-source-secret "api.openai.com")))
+    ('openrouter
+     (or (getenv "OPENROUTER_API_KEY")
+         (and (fboundp 'nsa/auth-source-get)
+              (ignore-errors (nsa/auth-source-get :host "openrouter.ai")))
+         (ai/llm--auth-source-secret "openrouter.ai")))
+    (_ (error "Unsupported LLM provider: %S" provider))))
+
+(defun ai/llm--require-api-key (provider)
+  "Return PROVIDER's API key or signal a useful error."
+  (or (ai/llm--api-key provider)
+      (user-error "No API key for %s; configure auth-source or the provider environment variable"
+                  provider)))
+
+(cl-defun ai/llm-zai-backend (&key (stream t) (name "Z.AI"))
+  "Return a Z.AI OpenAI-compatible backend.
+STREAM controls response streaming and NAME is the backend display name."
+  (gptel-make-openai name
+    :host ai/llm-zai-host
+    :endpoint (or (getenv "ZAI_API_ENDPOINT") ai/llm-zai-endpoint)
+    :stream stream
+    :key (lambda () (ai/llm--require-api-key 'zai))
+    :models ai/llm-zai-models))
+
+(cl-defun ai/llm-openai-backend (&key (stream t) (name "OpenAI"))
+  "Return an OpenAI backend with GPT-5.6 family support."
+  (gptel-make-openai name
+    :host "api.openai.com"
+    :stream stream
+    :key (lambda () (ai/llm--require-api-key 'openai))
+    :models ai/llm-openai-models))
+
 (cl-defun ai/llm-openrouter-backend (&key (stream t) (name "OpenRouter"))
-  "Return an OpenRouter backend.
-STREAM controls response streaming. NAME sets backend display name."
+  "Return an OpenRouter backend."
   (gptel-make-openai name
     :host "openrouter.ai"
     :endpoint "/api/v1/chat/completions"
     :stream stream
-    :key #'(lambda () (nsa/auth-source-get :host "openrouter.ai"))
+    :key (lambda () (ai/llm--require-api-key 'openrouter))
     :models ai/llm-openrouter-models))
+
+(defun ai/llm-backend (&optional provider refresh)
+  "Return the backend for PROVIDER.
+PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
+  (let ((provider (or provider ai/llm-provider)))
+    (when refresh (remhash provider ai/llm--backends))
+    (or (gethash provider ai/llm--backends)
+        (puthash provider
+                 (pcase provider
+                   ('zai (ai/llm-zai-backend))
+                   ('openai (ai/llm-openai-backend))
+                   ('openrouter (ai/llm-openrouter-backend))
+                   (_ (error "Unsupported LLM provider: %S" provider)))
+                 ai/llm--backends))))
 
 (defun ai/llm-resolve-model (&optional model)
   "Return MODEL when provided, otherwise `ai/llm-model'."
   (or model ai/llm-model))
 
-(provide 'ai)
+(defun ai/llm-models-for-provider (&optional provider)
+  "Return configured models for PROVIDER."
+  (pcase (or provider ai/llm-provider)
+    ('zai (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-zai-models))
+    ('openai (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-openai-models))
+    ('openrouter (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-openrouter-models))
+    (_ nil)))
 
+(defun ai/llm-use (provider model &optional local)
+  "Switch gptel to PROVIDER and MODEL.
+With LOCAL non-nil, only change the current buffer."
+  (interactive
+   (let* ((provider (intern
+                     (completing-read "Provider: " '("zai" "openai" "openrouter")
+                                      nil t nil nil (symbol-name ai/llm-provider))))
+          (models (mapcar #'symbol-name (ai/llm-models-for-provider provider)))
+          (model (intern (completing-read "Model: " models nil t nil nil
+                                          (symbol-name
+                                           (if (memq ai/llm-model
+                                                     (ai/llm-models-for-provider provider))
+                                               ai/llm-model
+                                             (car (ai/llm-models-for-provider provider))))))))
+     (list provider model current-prefix-arg)))
+  (if local
+      (progn
+        (setq-local gptel-backend (ai/llm-backend provider))
+        (setq-local gptel-model model))
+    (setq ai/llm-provider provider
+          ai/llm-model model
+          gptel-backend (ai/llm-backend provider)
+          gptel-model model))
+  (message "gptel: %s / %s%s" provider model (if local " (buffer-local)" "")))
+
+(defun ai/llm-use-glm-5.2 (&optional local)
+  "Use GLM-5.2 through Z.AI.
+With prefix argument LOCAL, apply only in the current buffer."
+  (interactive "P")
+  (ai/llm-use 'zai 'glm-5.2 local))
+
+(defun ai/llm-use-gpt-5.6-sol (&optional local)
+  "Use GPT-5.6 Sol through OpenAI.
+With prefix argument LOCAL, apply only in the current buffer."
+  (interactive "P")
+  (ai/llm-use 'openai 'gpt-5.6-sol local))
+
+(defun ai/llm-apply-defaults ()
+  "Apply shared modern gptel defaults."
+  (setq gptel-backend (ai/llm-backend ai/llm-provider)
+        gptel-model ai/llm-model
+        gptel-default-mode 'org-mode
+        gptel-use-tools t
+        gptel-confirm-tool-calls t
+        gptel-include-reasoning t
+        gptel-org-branching-context t
+        gptel-track-response t
+        gptel-use-header-line t
+        gptel-context-restrict-to-project-files t))
+
+(ai/llm-apply-defaults)
+
+(gptel-make-preset 'glm-5.2
+  :description "GLM-5.2 with Z.AI, one-million-token model option available."
+  :backend (ai/llm-backend 'zai)
+  :model 'glm-5.2
+  :stream t
+  :include-reasoning t)
+
+(gptel-make-preset 'gpt-5.6-sol
+  :description "OpenAI GPT-5.6 Sol for complex reasoning and coding."
+  :backend (ai/llm-backend 'openai)
+  :model 'gpt-5.6-sol
+  :stream t
+  :include-reasoning t)
+
+(provide 'ai)
 ;;; ai.el ends here

--- a/lisp/llm/chat.el
+++ b/lisp/llm/chat.el
@@ -1,306 +1,200 @@
-;;; chat.el --- Enhanced AI/Chat interface with automatic summarization -*- lexical-binding: t -*-
+;;; chat.el --- Org-native gptel agent chat -*- lexical-binding: t; -*-
 
-;; Author: Your Name
-;; Version: 2.0
-;; Package-Requires: ((emacs "27.1") (gptel "0.1"))
-;; Keywords: ai, chat, llm
-
-;;; Commentary:
-
-;; Enhanced AI/Chat interface using gptel with org-mode.
-;; Features:
-;; - Auto-summarization using Claude Haiku after first exchange
-;; - Automatic buffer title updates
-;; - Clean token usage (removes wasteful insertions)
-;; - Auto-save as .org.llm files
-;; - Base tools integration
-;; - Auto-insert USER prompt after AI responses
-
-;;; Code:
-
+(require 'cl-lib)
 (require 'gptel)
 (require 'org)
+(require 'subr-x)
+(require 'ai)
+(require 'ai-agent)
 
-(let ((ai-lib (expand-file-name "ai.el"
-                                (file-name-directory (or load-file-name buffer-file-name)))))
-  (when (file-exists-p ai-lib)
-    (load ai-lib nil t)))
+(defgroup ai/chat nil
+  "Org-native gptel chat sessions."
+  :group 'ai/llm
+  :prefix "ai/chat-")
 
-;;; ============================================================================
-;;; Configuration Variables
-;;; ============================================================================
-
-(defcustom ai/chat-summary-backend nil
-  "Backend to use for summarization. If nil, creates Claude Haiku backend."
-  :type 'symbol
-  :group 'ai-chat)
-
-(defcustom ai/chat-save-directory (expand-file-name "~/Document/Notes/org/roam/llm/")
-  "Directory to save chat files."
+(defcustom ai/chat-save-directory
+  (expand-file-name "~/Documents/Notes/org/roam/llm/")
+  "Directory used for persistent Org chat files."
   :type 'directory
-  :group 'ai-chat)
+  :group 'ai/chat)
 
 (defcustom ai/chat-auto-save t
-  "Whether to auto-save chats after summarization."
+  "When non-nil, save chat buffers after each successful response."
   :type 'boolean
-  :group 'ai-chat)
+  :group 'ai/chat)
 
-;;; ============================================================================
-;;; Backend Setup
-;;; ============================================================================
+(defcustom ai/chat-auto-title t
+  "When non-nil, generate a title after the first response."
+  :type 'boolean
+  :group 'ai/chat)
 
-(defun ai/chat--get-summary-backend ()
-  "Get or create the OpenRouter backend for summarization."
-  (or ai/chat-summary-backend
-      (setq ai/chat-summary-backend
-            (ai/llm-openrouter-backend :stream nil :name "OpenRouterReWrite"))))
+(defcustom ai/chat-system-prompt ai/agent-system-prompt
+  "System message used for new agent chat buffers."
+  :type 'string
+  :group 'ai/chat)
 
-(defun ai/chat--get-main-backend ()
-  "Get the main chat backend."
-  (ai/llm-openrouter-backend :stream t :name "OpenRouter"))
+(defvar-local ai/chat--titled nil
+  "Non-nil after the current chat has received an automatic title.")
 
-;;; ============================================================================
-;;; Summarization Logic
-;;; ============================================================================
+(defvar-local ai/chat--session-id nil
+  "Stable identifier used for the current chat file.")
 
-(defvar ai/chat--first-exchange-done nil
-  "Buffer-local variable tracking if first exchange is complete.")
-(make-variable-buffer-local 'ai/chat--first-exchange-done)
+(defun ai/chat--slug (text)
+  "Return a filesystem-safe slug for TEXT."
+  (let* ((downcase (downcase (string-trim text)))
+         (clean (replace-regexp-in-string "[^[:alnum:]]+" "-" downcase)))
+    (string-trim clean "-+" "-+")))
 
-(defvar ai/chat--original-content nil
-  "Buffer-local variable storing original content before summarization.")
-(make-variable-buffer-local 'ai/chat--original-content)
+(defun ai/chat--session-id ()
+  "Return or create the current chat session identifier."
+  (or ai/chat--session-id
+      (setq ai/chat--session-id (format-time-string "%Y%m%dT%H%M%S"))))
 
-(defun ai/chat--extract-conversation ()
-  "Extract the conversation content from current buffer."
+(defun ai/chat--file (&optional title)
+  "Return the chat file path, optionally incorporating TITLE."
+  (let* ((slug (and title (ai/chat--slug title)))
+         (basename (if (and slug (not (string-empty-p slug)))
+                       (format "%s-%s.org" (ai/chat--session-id) slug)
+                     (format "%s-chat.org" (ai/chat--session-id)))))
+    (expand-file-name basename ai/chat-save-directory)))
+
+(defun ai/chat--ensure-header ()
+  "Ensure the current Org chat has persistent gptel metadata headers."
   (save-excursion
     (goto-char (point-min))
-    ;; Find first USER message
-    (when (re-search-forward "^\\*+ USER:" nil t)
-      (let ((start (match-beginning 0)))
-        (buffer-substring-no-properties start (point-max))))))
+    (unless (looking-at-p "#\\+title:")
+      (insert "#+title: LLM Chat\n"
+              "#+category: llm\n"
+              "#+filetags: :llm:gptel:\n\n"))))
 
-(defun ai/chat--summarize-async (conversation buffer-name callback)
-  "Summarize CONVERSATION using Claude Haiku.
-BUFFER-NAME is the chat buffer name for context.
-CALLBACK is called with (title summary) on success."
-  (let ((backend (ai/chat--get-summary-backend))
-        (prompt (format "Please analyze this conversation and provide:
-
-1. A concise title (max 60 chars) that captures the main topic/request
-2. A brief summary (2-3 sentences) of what was discussed and accomplished
-
-Format your response as:
-TITLE: [your title here]
-SUMMARY: [your summary here]
-
-Conversation:
-%s" conversation)))
-    
-    (gptel-request prompt
-      :backend backend
-      :model (ai/llm-resolve-model)
-      :callback
-      (lambda (response info)
-        (if response
-            (let ((title (ai/chat--extract-title response))
-                  (summary (ai/chat--extract-summary response)))
-              (funcall callback title summary))
-          (message "Failed to summarize: %s" (plist-get info :status)))))))
-
-(defun ai/chat--extract-title (response)
-  "Extract title from summarization RESPONSE."
-  (when (string-match "TITLE: *\\(.+\\)" response)
-    (string-trim (match-string 1 response))))
-
-(defun ai/chat--extract-summary (response)
-  "Extract summary from summarization RESPONSE."
-  (when (string-match "SUMMARY: *\\(.+\\)" response)
-    (string-trim (match-string 1 response))))
-
-;;; ============================================================================
-;;; Buffer Management
-;;; ============================================================================
-
-(defun ai/chat--update-buffer-header (title summary)
-  "Update buffer header with TITLE and SUMMARY."
+(defun ai/chat--conversation-text ()
+  "Return the current conversation without Org file metadata."
   (save-excursion
     (goto-char (point-min))
-    ;; Replace or add the header
-    (if (looking-at "^#\\+TITLE:")
-        ;; Replace existing header
-        (progn
-          (kill-line)
-          (kill-line) ; Remove description line if exists
-          (when (looking-at "^#\\+DESCRIPTION:")
-            (kill-line))
-          (when (looking-at "^$")
-            (kill-line))) ; Remove blank line
-      ;; Insert new header
-      (insert "\n")
-      (goto-char (point-min)))
-    
-    ;; Insert new header
-    (insert (format "#+TITLE: %s\n" title))
-    (insert (format "#+DESCRIPTION: %s\n\n" summary))))
+    (while (looking-at-p "#\\+") (forward-line 1))
+    (string-trim (buffer-substring-no-properties (point) (point-max)))))
 
-(defun ai/chat--save-buffer (buffer-name title)
-  "Save buffer to file with proper name based on TITLE."
+(defun ai/chat--summary-backend ()
+  "Return a non-streaming backend matching `ai/llm-provider'."
+  (pcase ai/llm-provider
+    ('zai (ai/llm-zai-backend :stream nil :name "Z.AI Summary"))
+    ('openai (ai/llm-openai-backend :stream nil :name "OpenAI Summary"))
+    ('openrouter (ai/llm-openrouter-backend :stream nil :name "OpenRouter Summary"))))
+
+(defun ai/chat--extract-field (field response)
+  "Extract FIELD from RESPONSE formatted as FIELD: value."
+  (when (string-match (format "^%s:[[:space:]]*\\(.+\\)$" (regexp-quote field))
+                      response)
+    (string-trim (match-string 1 response))))
+
+(defun ai/chat--set-title (title summary)
+  "Set Org TITLE and SUMMARY metadata and rename the buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (if (re-search-forward "^#\\+title:.*$" nil t)
+        (replace-match (format "#+title: %s" title) t t)
+      (insert (format "#+title: %s\n" title)))
+    (goto-char (point-min))
+    (if (re-search-forward "^#\\+description:.*$" nil t)
+        (replace-match (format "#+description: %s" summary) t t)
+      (forward-line 1)
+      (insert (format "#+description: %s\n" summary))))
+  (rename-buffer (format "*LLM: %s*" title) t)
   (when ai/chat-auto-save
-    (let* ((safe-title (replace-regexp-in-string "[^a-zA-Z0-9-_ ]" "" title))
-           (filename (format "%s.org.llm" safe-title))
-           (filepath (expand-file-name filename ai/chat-save-directory)))
-      
-      ;; Ensure directory exists
-      (unless (file-exists-p ai/chat-save-directory)
-        (make-directory ai/chat-save-directory t))
-      
-      ;; Save buffer
-      (write-file filepath)
-      (message "Saved chat: %s" filepath))))
+    (let ((old-file buffer-file-name)
+          (new-file (ai/chat--file title)))
+      (make-directory ai/chat-save-directory t)
+      (set-visited-file-name new-file t)
+      (save-buffer)
+      (when (and old-file (not (equal old-file new-file)) (file-exists-p old-file))
+        (ignore-errors (delete-file old-file))))))
 
-;;; ============================================================================
-;;; Hook Functions
-;;; ============================================================================
+(defun ai/chat--title-async ()
+  "Generate and apply a title and summary for the current chat."
+  (let ((source-buffer (current-buffer))
+        (conversation (ai/chat--conversation-text)))
+    (unless (string-empty-p conversation)
+      (gptel-request
+       (format "Return exactly two single-line fields for this conversation:\nTITLE: a concrete title under 60 characters\nSUMMARY: one sentence describing the work\n\n%s"
+               conversation)
+       :backend (ai/chat--summary-backend)
+       :model (ai/llm-resolve-model)
+       :stream nil
+       :callback
+       (lambda (response info)
+         (when (and response (buffer-live-p source-buffer))
+           (let ((title (ai/chat--extract-field "TITLE" response))
+                 (summary (ai/chat--extract-field "SUMMARY" response)))
+             (when (and title summary)
+               (with-current-buffer source-buffer
+                 (setq ai/chat--titled t)
+                 (ai/chat--set-title title summary)))))
+         (unless response
+           (message "Chat title generation failed: %s" (plist-get info :status))))))))
 
-(defun ai/chat--auto-insert-user-prompt (start end)
-  "Auto-insert USER prompt after AI response.
-Called as a hook function with START and END positions of the AI response."
-  ;; Only run in LLM Chat buffers
-  (when (string-match-p "\\*LLM Chat\\*" (buffer-name))
-    (save-excursion
-      (goto-char end)
-      ;; Move past any trailing whitespace
-      (skip-chars-forward " \t\n")
-      ;; Check if we're not already at a USER prompt
-      (unless (looking-at "\\*+ USER:")
-        ;; Insert newline if not at beginning of line
-        (unless (bolp)
-          (insert "\n"))
-        ;; Insert the USER prompt with consistent level
-        (insert "\n*** USER: ")))))
+(defun ai/chat--save ()
+  "Persist the current chat buffer."
+  (when ai/chat-auto-save
+    (make-directory ai/chat-save-directory t)
+    (unless buffer-file-name
+      (set-visited-file-name (ai/chat--file) t))
+    (save-buffer)))
 
-(defun ai/chat--post-response-handler (start end)
-  "Handle post-response tasks including summarization.
-Called with START and END positions of the AI response."
-  (when (string-match-p "\\*LLM Chat\\*" (buffer-name))
-    ;; Insert user prompt first
-    (ai/chat--auto-insert-user-prompt start end)
-    
-    ;; Check if this is the first exchange completion
-    (unless ai/chat--first-exchange-done
-      (setq ai/chat--first-exchange-done t)
-      (setq ai/chat--original-content (buffer-string))
-      
-      ;; Start summarization process
-      (let ((conversation (ai/chat--extract-conversation))
-            (current-buffer (current-buffer))
-            (buffer-name (buffer-name)))
-        (when conversation
-          (ai/chat--summarize-async
-           conversation
-           buffer-name
-           (lambda (title summary)
-             (when (buffer-live-p current-buffer)
-               (with-current-buffer current-buffer
-                 (ai/chat--update-buffer-header title summary)
-                 (rename-buffer (format "*%s*" title))
-                 (ai/chat--save-buffer buffer-name title)
-                 (message "Chat summarized: %s" title))))))))))
-
-;;; ============================================================================
-;;; Main Interface
-;;; ============================================================================
+(defun ai/chat--after-response (_start _end)
+  "Post-response hook for persistence and one-time automatic titling."
+  (when (derived-mode-p 'org-mode)
+    (ai/chat--save)
+    (when (and ai/chat-auto-title (not ai/chat--titled))
+      (ai/chat--title-async))))
 
 ;;;###autoload
-(defun ai/chat ()
-  "Start an enhanced AI chat session with auto-summarization."
+(defun ai/chat (&optional name)
+  "Open a persistent Org agent chat named NAME.
+The default model is GLM-5.2; use gptel presets to switch per request."
   (interactive)
-  (let* ((buffer-name (read-string "Chat name: " "*LLM Chat*"))
-         (buffer (get-buffer-create buffer-name))
-         (backend (ai/chat--get-main-backend)))
-    
+  (let* ((name (or name (read-string "Chat name: " "LLM Chat")))
+         (buffer (generate-new-buffer (format "*%s*" name))))
     (with-current-buffer buffer
-      ;; Initialize org-mode and buffer state
-      (unless (eq major-mode 'org-mode)
-        (org-mode))
-      
-      ;; Clear buffer and start fresh
-      (erase-buffer)
-      
-      ;; Set up minimal initial content (no wasteful descriptions)
-      (insert "*** USER: ")
-      
-       ;; Configure gptel
-       (setq-local gptel-backend backend)
-       (setq-local gptel-model (ai/llm-resolve-model))
-       (setq-local gptel--system-message ai/todo-system-prompt)
-      
-      ;; Initialize buffer-local variables
-      (setq-local ai/chat--first-exchange-done nil)
-      (setq-local ai/chat--original-content nil)
-      
-      ;; Set up hooks
-      (add-hook 'gptel-post-response-functions #'ai/chat--post-response-handler nil t)
-      
-      ;; Activate gptel-mode
-      (gptel-mode 1))
-    
-    ;; Switch to buffer and position cursor
+      (org-mode)
+      (setq-local ai/chat--session-id (format-time-string "%Y%m%dT%H%M%S"))
+      (setq-local gptel-backend (ai/llm-backend))
+      (setq-local gptel-model (ai/llm-resolve-model))
+      (setq-local gptel-system-message ai/chat-system-prompt)
+      (setq-local gptel-tools ai/agent-tools)
+      (setq-local gptel-use-context 'system)
+      (setq-local gptel-track-media t)
+      (setq-local gptel-include-reasoning t)
+      (ai/chat--ensure-header)
+      (goto-char (point-max))
+      (insert "* User\n")
+      (add-hook 'gptel-post-response-functions #'ai/chat--after-response nil t)
+      (gptel-mode 1)
+      (ai/chat--save))
     (switch-to-buffer buffer)
-    (goto-char (point-max))
-    (message "Enhanced AI Chat started. First exchange will be auto-summarized.")))
-
-;;; ============================================================================
-;;; Utility Functions
-;;; ============================================================================
+    (goto-char (point-max))))
 
 ;;;###autoload
 (defun ai/chat-list-saved ()
-  "List all saved chat files."
+  "Open a Dired buffer containing saved LLM chats."
   (interactive)
-  (if (file-exists-p ai/chat-save-directory)
-      (let ((files (directory-files ai/chat-save-directory nil "\\.org\\.llm$")))
-        (if files
-            (progn
-              (with-current-buffer (get-buffer-create "*Saved Chats*")
-                (erase-buffer)
-                (insert "# Saved AI Chats\n\n")
-                (dolist (file files)
-                  (insert (format "- [[file:%s][%s]]\n" 
-                                  (expand-file-name file ai/chat-save-directory)
-                                  (file-name-sans-extension file))))
-                (org-mode)
-                (goto-char (point-min)))
-              (switch-to-buffer "*Saved Chats*"))
-          (message "No saved chats found")))
-    (message "Chat directory doesn't exist: %s" ai/chat-save-directory)))
+  (make-directory ai/chat-save-directory t)
+  (dired ai/chat-save-directory))
 
 ;;;###autoload
-(defun ai/chat-open-saved (filename)
-  "Open a saved chat file."
+(defun ai/chat-resume (file)
+  "Resume saved gptel chat FILE."
   (interactive
-   (list (completing-read "Open chat: "
-                          (when (file-exists-p ai/chat-save-directory)
-                            (directory-files ai/chat-save-directory nil "\\.org\\.llm$")))))
-  (let ((filepath (expand-file-name filename ai/chat-save-directory)))
-    (if (file-exists-p filepath)
-        (find-file filepath)
-      (error "Chat file not found: %s" filepath))))
-
-;;;###autoload
-(defun ai/chat-clean-directory ()
-  "Clean up old chat files (interactive selection)."
-  (interactive)
-  (when (file-exists-p ai/chat-save-directory)
-    (let ((files (directory-files ai/chat-save-directory nil "\\.org\\.llm$")))
-      (when files
-        (let ((to-delete (completing-read-multiple "Delete chats: " files)))
-          (dolist (file to-delete)
-            (when (y-or-n-p (format "Really delete %s? " file))
-              (delete-file (expand-file-name file ai/chat-save-directory))
-              (message "Deleted: %s" file))))))))
+   (list (read-file-name "Chat file: " ai/chat-save-directory nil t nil
+                         (lambda (path)
+                           (or (file-directory-p path)
+                               (string-match-p "\\.org\\'" path))))))
+  (find-file file)
+  (org-mode)
+  (setq-local gptel-backend (ai/llm-backend))
+  (setq-local gptel-model (ai/llm-resolve-model))
+  (setq-local gptel-tools ai/agent-tools)
+  (add-hook 'gptel-post-response-functions #'ai/chat--after-response nil t)
+  (gptel-mode 1))
 
 (provide 'chat)
-
 ;;; chat.el ends here

--- a/lisp/llm/init.el
+++ b/lisp/llm/init.el
@@ -1,0 +1,11 @@
+;;; init.el --- Load the Emacs LLM stack -*- lexical-binding: t; -*-
+
+(require 'ai)
+(require 'ai-agent)
+(require 'chat)
+
+(with-eval-after-load 'org-ql
+  (require 'todo nil t))
+
+(provide 'ai-init)
+;;; init.el ends here

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -1,0 +1,94 @@
+#+title: Emacs LLM and gptel configuration
+#+author: nsaspy
+#+startup: overview
+#+property: header-args:emacs-lisp :results none :lexical yes
+
+* Defaults
+
+The local gptel stack defaults to Z.AI =glm-5.2=.  OpenAI
+=gpt-5.6-sol= is available as a first-class Responses API backend.
+
+API keys are resolved from environment variables first and then
+=auth-source=:
+
+- =ZAI_API_KEY= or host =api.z.ai=
+- =OPENAI_API_KEY= or host =api.openai.com=
+- =OPENROUTER_API_KEY= or host =openrouter.ai=
+
+A Coding Plan endpoint can be selected without changing Lisp:
+
+#+begin_src shell
+export ZAI_API_ENDPOINT=/api/coding/paas/v4/chat/completions
+#+end_src
+
+* Loading
+
+Doom autoloads the stack after gptel is loaded.  It can also be loaded
+explicitly:
+
+#+begin_src emacs-lisp
+(require 'ai-init)
+(ai/llm-apply-defaults)
+#+end_src
+
+* Model switching
+
+#+begin_src emacs-lisp
+(ai/llm-use-glm-5.2)
+(ai/llm-use-gpt-5.6-sol)
+#+end_src
+
+The same switches are exposed as =M-x +llm/use-glm-5.2= and
+=M-x +llm/use-gpt-5.6-sol=.  A prefix argument makes the selection
+buffer-local.
+
+Available presets:
+
+- =@glm-5.2=
+- =@gpt-5.6-sol=
+- =@agent= — GLM-5.2 with the project agent tools
+- =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tools
+
+* Agent file tools
+
+The enabled agent surface is intentionally small and Claude Code-like:
+
+- =Read=, =Glob=, =Grep=, =LS=, =FileStat=
+- =Edit=, =MultiEdit=, =Write=, =ApplyPatch=
+- =Mkdir=, =Move=, =Delete=
+- =Bash=, =GitStatus=, =GitDiff=, =DiffFiles=
+- buffer, Emacs introspection, web fetch, and project-context tools
+
+Mutations are project-confined by default, writes are atomic, exact edits
+fail on ambiguous matches, command output is bounded, and unified patches
+are validated before =git apply=.  Historical tool names remain registered
+for old prompts but are not enabled in the default agent preset.
+
+* Org todo editing
+
+The old subtree patch path has been replaced by transactional tools:
+
+- =todo_read=
+- =todo_edit=
+- =todo_multi_edit=
+- =todo_replace_subtree=
+- =apply_todo_patch=
+
+Raw patches are applied only to an isolated temporary subtree copy.  The
+actual Org buffer is changed only after the patch succeeds.
+
+* Persistent chat
+
+=M-x +llm/chat= opens an Org-native gptel chat using the active backend,
+agent tool set, response autosave, and one-time automatic title generation.
+Chats are stored below =~/Documents/Notes/org/roam/llm/=.
+
+* Source files
+
+#+INCLUDE: "ai.el" src emacs-lisp
+#+INCLUDE: "agent-core.el" src emacs-lisp
+#+INCLUDE: "agent.el" src emacs-lisp
+#+INCLUDE: "../../.doom.d/autoload/llm.el" src emacs-lisp
+#+INCLUDE: "chat.el" src emacs-lisp
+#+INCLUDE: "todo-diff.el" src emacs-lisp
+#+INCLUDE: "init.el" src emacs-lisp

--- a/lisp/llm/todo-diff.el
+++ b/lisp/llm/todo-diff.el
@@ -325,7 +325,14 @@ The patch is never run against the actual Org file."
  "todo_multi_edit" #'ai/todo-multi-edit
  "Apply multiple exact edits to one todo subtree as one transaction."
  '((:name "title" :type string :description "Exact heading title")
-   (:name "edits" :type array :description "Objects with old_text, new_text, optional replace_all")
+   (:name "edits" :type array
+          :items (:type object
+                  :properties (:old_text (:type string :description "Exact text to replace")
+                               :new_text (:type string :description "Replacement text")
+                               :replace_all (:type boolean :description "Replace all exact matches"))
+                  :required ["old_text" "new_text"]
+                  :additionalProperties :json-false)
+          :description "Ordered exact-match edits")
    (:name "file" :type string :optional t :description "Todo Org file")
    (:name "preview" :type boolean :optional t :description "Return diff without writing")) t)
 
@@ -341,14 +348,26 @@ The patch is never run against the actual Org file."
  "apply_todo_line_changes" #'ai/todo-apply-line-changes
  "Compatibility line-number editor. Prefer todo_multi_edit."
  '((:name "title" :type string :description "Exact heading title")
-   (:name "updates" :type array :description "Objects with absolute line and content")
+   (:name "updates" :type array
+          :items (:type object
+                  :properties (:line (:type integer :description "Absolute line number")
+                               :content (:type string :description "Complete replacement line"))
+                  :required ["line" "content"]
+                  :additionalProperties :json-false)
+          :description "Absolute line replacements")
    (:name "file" :type string :optional t :description "Todo Org file")) t)
 
 (ai/todo-edit--register
  "preview_todo_changes" #'ai/todo-preview-line-changes
  "Preview compatibility line-number changes."
  '((:name "title" :type string :description "Exact heading title")
-   (:name "updates" :type array :description "Objects with absolute line and content")
+   (:name "updates" :type array
+          :items (:type object
+                  :properties (:line (:type integer :description "Absolute line number")
+                               :content (:type string :description "Complete replacement line"))
+                  :required ["line" "content"]
+                  :additionalProperties :json-false)
+          :description "Absolute line replacements")
    (:name "file" :type string :optional t :description "Todo Org file")))
 
 (ai/todo-edit--register

--- a/lisp/llm/todo-diff.el
+++ b/lisp/llm/todo-diff.el
@@ -1,312 +1,399 @@
-;;; todo-diff.el --- Todo update tools mirroring diff operations -*- lexical-binding: t; -*-
+;;; todo-diff.el --- Transactional Org subtree editing tools -*- lexical-binding: t; -*-
 
-;; Author: nsaspy
-;; Version: 0.1
-;; Package-Requires: ((emacs "29.1") (gptel "0.9") (org "9.0"))
-
-;;; Commentary:
-;; Todo update tools that mirror the diff/patch operations from agent.el
-;; These tools allow precise updates to todo items similar to how diffs update files.
-
-;;; Code:
-
+(require 'cl-lib)
+(require 'gptel)
+(require 'json)
 (require 'org)
 (require 'org-element)
-(require 'gptel)
+(require 'seq)
+(require 'subr-x)
 
-;;; Helper Functions
+(defgroup ai/todo-edit nil
+  "Safe exact-match and diff-based editing for Org todo subtrees."
+  :group 'ai/todo
+  :prefix "ai/todo-edit-")
 
-(defun ai/todo--find-heading-by-title (title &optional file)
-  "Find heading with TITLE in FILE (defaults to `ai/todo-file').
-Returns marker to the heading or nil if not found."
-  (let ((file (or file ai/todo-file)))
-    (when (file-exists-p file)
-      (with-current-buffer (find-file-noselect file)
-        (save-excursion
-          (goto-char (point-min))
-          (when (re-search-forward
-                 (format "^\\*+ .*%s" (regexp-quote title)) nil t)
-            (copy-marker (line-beginning-position))))))))
+(defun ai/todo-edit--object (&rest pairs)
+  "Return an alist from alternating string keys and values in PAIRS."
+  (let (result)
+    (while pairs
+      (push (cons (pop pairs) (pop pairs)) result))
+    (nreverse result)))
 
-(defun ai/todo--get-heading-lines (title &optional file show-numbers)
-  "Get lines of heading with TITLE from FILE.
-If SHOW-NUMBERS is non-nil, prepend line numbers.
-Returns cons cell (start-line . lines-string)."
-  (let* ((file (or file ai/todo-file))
-         (marker (ai/todo--find-heading-by-title title file)))
-    (when marker
-      (with-current-buffer (marker-buffer marker)
-        (save-excursion
-          (goto-char marker)
-          (let* ((start-pos (point))
-                 (start-line (line-number-at-pos))
-                 (end-pos (save-excursion
-                            (org-end-of-subtree t t)
-                            (point)))
-                 (content (buffer-substring-no-properties start-pos end-pos))
-                 (lines (split-string content "\n" nil)))
-            (cons start-line
-                  (if show-numbers
-                      (mapconcat
-                       (lambda (line)
-                         (prog1
-                             (format "%d: %s" start-line line)
-                           (setq start-line (1+ start-line))))
-                       lines "\n")
-                    content))))))))
+(defun ai/todo-edit--json (&rest pairs)
+  "Serialize alternating string keys and values in PAIRS as JSON."
+  (json-serialize (apply #'ai/todo-edit--object pairs)
+                  :null-object nil :false-object :json-false))
 
-(defun ai/todo--apply-line-updates (title updates &optional file)
-  "Apply line UPDATES to heading with TITLE in FILE.
-UPDATES is a list of (line-number . new-content) pairs."
-  (let* ((file (or file ai/todo-file))
-         (marker (ai/todo--find-heading-by-title title file)))
-    (unless marker
-      (error "Todo heading not found: %s" title))
+(defun ai/todo-edit--arg (object key &optional default)
+  "Read KEY from plist or alist OBJECT."
+  (let* ((name (substring (symbol-name key) 1))
+         (symbol (intern name)))
+    (cond
+     ((and (listp object) (keywordp (car object)))
+      (if (plist-member object key) (plist-get object key) default))
+     ((listp object)
+      (let ((cell (or (assoc key object) (assoc symbol object) (assoc name object))))
+        (if cell (cdr cell) default)))
+     (t default))))
+
+(defun ai/todo-edit--resolve-file (&optional file)
+  "Resolve FILE or `ai/todo-file' to an absolute path."
+  (let ((candidate (or file (and (boundp 'ai/todo-file) ai/todo-file))))
+    (unless candidate (error "No todo file configured"))
+    (expand-file-name candidate)))
+
+(defun ai/todo-edit--heading-markers (title file)
+  "Return markers for exact heading TITLE in FILE."
+  (with-current-buffer (find-file-noselect file)
+    (unless (derived-mode-p 'org-mode) (org-mode))
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (let (markers)
+       (org-map-entries
+        (lambda ()
+          (when (string= title (org-get-heading t t t t))
+            (push (copy-marker (line-beginning-position)) markers)))
+        nil 'file)
+       (nreverse markers)))))
+
+(defun ai/todo-edit--heading-marker (title &optional file)
+  "Return the unique marker for exact heading TITLE in FILE."
+  (let* ((file (ai/todo-edit--resolve-file file))
+         (markers (ai/todo-edit--heading-markers title file)))
+    (pcase (length markers)
+      (0 (error "Todo heading not found: %s" title))
+      (1 (car markers))
+      (_ (error "Todo heading is ambiguous (%d exact matches): %s"
+                (length markers) title)))))
+
+(defun ai/todo-edit--bounds (marker)
+  "Return subtree bounds for MARKER as a cons cell."
+  (with-current-buffer (marker-buffer marker)
+    (org-with-wide-buffer
+     (goto-char marker)
+     (cons (line-beginning-position)
+           (save-excursion
+             (org-end-of-subtree t t)
+             (point))))))
+
+(defun ai/todo-edit--subtree (marker)
+  "Return MARKER's complete subtree text."
+  (with-current-buffer (marker-buffer marker)
+    (pcase-let ((`(,start . ,end) (ai/todo-edit--bounds marker)))
+      (buffer-substring-no-properties start end))))
+
+(defun ai/todo-edit--count (needle haystack)
+  "Count non-overlapping exact NEEDLE occurrences in HAYSTACK."
+  (when (string-empty-p needle) (error "old_text must not be empty"))
+  (let ((start 0) (count 0))
+    (while (string-match (regexp-quote needle) haystack start)
+      (setq count (1+ count) start (match-end 0)))
+    count))
+
+(defun ai/todo-edit--replace (content old-text new-text replace-all)
+  "Replace exact OLD-TEXT with NEW-TEXT in CONTENT."
+  (let ((count (ai/todo-edit--count old-text content)))
+    (cond
+     ((zerop count) (error "old_text was not found in the todo subtree"))
+     ((and (> count 1) (not replace-all))
+      (error "old_text matched %d times; include more context or set replace_all" count))
+     (replace-all
+      (cons (replace-regexp-in-string (regexp-quote old-text) new-text content t t)
+            count))
+     (t
+      (let ((position (string-match (regexp-quote old-text) content)))
+        (cons (concat (substring content 0 position)
+                      new-text
+                      (substring content (+ position (length old-text))))
+              1))))))
+
+(defun ai/todo-edit--diff (title old-content new-content)
+  "Return unified diff between OLD-CONTENT and NEW-CONTENT for TITLE."
+  (let ((old-file (make-temp-file "todo-old-"))
+        (new-file (make-temp-file "todo-new-")))
+    (unwind-protect
+        (progn
+          (with-temp-file old-file (insert old-content))
+          (with-temp-file new-file (insert new-content))
+          (with-temp-buffer
+            (let ((status (call-process "diff" nil t nil "-u"
+                                        "--label" (format "a/todo:%s" title)
+                                        "--label" (format "b/todo:%s" title)
+                                        old-file new-file)))
+              (unless (memq status '(0 1))
+                (error "diff failed: %s" (string-trim (buffer-string))))
+              (buffer-string))))
+      (delete-file old-file)
+      (delete-file new-file))))
+
+(defun ai/todo-edit--replace-subtree (marker content)
+  "Replace MARKER's subtree with CONTENT as one undoable operation."
+  (with-current-buffer (marker-buffer marker)
+    (pcase-let ((`(,start . ,end) (ai/todo-edit--bounds marker)))
+      (atomic-change-group
+        (goto-char start)
+        (delete-region start end)
+        (insert content))
+      (save-buffer))))
+
+(defun ai/todo-read-heading (title &optional file numbered)
+  "Read exact todo heading TITLE from FILE.
+When NUMBERED is non-nil, return absolute line numbers."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (content (ai/todo-edit--subtree marker)))
+    (if numbered
+        (with-current-buffer (marker-buffer marker)
+          (let* ((start-line (line-number-at-pos marker))
+                 (lines (split-string content "\n" nil))
+                 (line start-line))
+            (ai/todo-edit--json
+             "ok" t "title" title "start_line" start-line
+             "content"
+             (mapconcat (lambda (text)
+                          (prog1 (format "%6d\t%s" line text)
+                            (setq line (1+ line))))
+                        lines "\n"))))
+      (ai/todo-edit--json "ok" t "title" title "content" content))))
+
+(defun ai/todo-edit-exact (title old-text new-text &optional file replace-all preview)
+  "Replace exact OLD-TEXT with NEW-TEXT inside todo TITLE."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (original (ai/todo-edit--subtree marker))
+         (replacement (ai/todo-edit--replace original old-text new-text replace-all))
+         (updated (car replacement))
+         (diff (ai/todo-edit--diff title original updated)))
+    (unless preview (ai/todo-edit--replace-subtree marker updated))
+    (ai/todo-edit--json "ok" t "title" title
+                        "replacements" (cdr replacement)
+                        "preview" (if preview t :json-false)
+                        "diff" diff)))
+
+(defun ai/todo-multi-edit (title edits &optional file preview)
+  "Apply sequential exact-match EDITS to todo TITLE transactionally."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (original (ai/todo-edit--subtree marker))
+         (updated original)
+         (replacements 0))
+    (dolist (edit edits)
+      (let* ((old-text (ai/todo-edit--arg edit :old_text))
+             (new-text (ai/todo-edit--arg edit :new_text ""))
+             (replace-all (ai/todo-edit--arg edit :replace_all nil))
+             (result (ai/todo-edit--replace updated old-text new-text replace-all)))
+        (setq updated (car result)
+              replacements (+ replacements (cdr result)))))
+    (let ((diff (ai/todo-edit--diff title original updated)))
+      (unless preview (ai/todo-edit--replace-subtree marker updated))
+      (ai/todo-edit--json "ok" t "title" title
+                          "edits" (length edits)
+                          "replacements" replacements
+                          "preview" (if preview t :json-false)
+                          "diff" diff))))
+
+(defun ai/todo-replace-subtree (title content &optional file preview)
+  "Replace todo TITLE's complete subtree with CONTENT."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (original (ai/todo-edit--subtree marker))
+         (diff (ai/todo-edit--diff title original content)))
+    (unless preview (ai/todo-edit--replace-subtree marker content))
+    (ai/todo-edit--json "ok" t "title" title
+                        "preview" (if preview t :json-false)
+                        "diff" diff)))
+
+(defun ai/todo-edit--line-updates (title updates &optional file preview)
+  "Compatibility line editor for todo TITLE using absolute line UPDATES."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (original (ai/todo-edit--subtree marker))
+         (start-line (with-current-buffer (marker-buffer marker)
+                       (line-number-at-pos marker)))
+         (trailing-newline (string-suffix-p "\n" original))
+         (lines (vconcat (split-string original "\n" nil)))
+         (count (length lines)))
+    (when (and trailing-newline (> count 0) (string-empty-p (aref lines (1- count))))
+      (setq lines (seq-subseq lines 0 (1- count))
+            count (1- count)))
+    (dolist (update updates)
+      (let* ((absolute-line (ai/todo-edit--arg update :line))
+             (content (ai/todo-edit--arg update :content))
+             (index (- absolute-line start-line)))
+        (unless (and (integerp absolute-line) (<= 0 index) (< index count))
+          (error "Line %S is outside todo subtree lines %d..%d"
+                 absolute-line start-line (+ start-line count -1)))
+        (aset lines index content)))
+    (let ((updated (concat (string-join (append lines nil) "\n")
+                           (if trailing-newline "\n" ""))))
+      (if preview
+          (ai/todo-edit--json "ok" t "title" title "preview" t
+                              "diff" (ai/todo-edit--diff title original updated))
+        (ai/todo-edit--replace-subtree marker updated)
+        (ai/todo-edit--json "ok" t "title" title
+                            "changes" (length updates)
+                            "diff" (ai/todo-edit--diff title original updated))))))
+
+(defun ai/todo-apply-line-changes (title updates &optional file)
+  "Compatibility wrapper for absolute line updates. Prefer `todo_multi_edit'."
+  (ai/todo-edit--line-updates title updates file nil))
+
+(defun ai/todo-preview-line-changes (title updates &optional file)
+  "Preview compatibility absolute line updates."
+  (ai/todo-edit--line-updates title updates file t))
+
+(defun ai/todo-search-replace (title search replace &optional file)
+  "Replace every exact SEARCH occurrence with REPLACE in todo TITLE."
+  (ai/todo-edit-exact title search replace file t nil))
+
+(defun ai/todo-get-lines (title start-line end-line &optional file)
+  "Return absolute START-LINE through END-LINE from todo TITLE."
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (bounds (ai/todo-edit--bounds marker)))
     (with-current-buffer (marker-buffer marker)
       (save-excursion
-        (goto-char marker)
-        (let* ((start-line (line-number-at-pos))
-               (end-pos (save-excursion
-                          (org-end-of-subtree t t)
-                          (point)))
-               (changes-made 0))
-          (dolist (update updates)
-            (let* ((target-line (car update))
-                   (new-content (cdr update))
-                   (relative-line (- target-line start-line)))
-              (when (>= relative-line 0)
-                (goto-char marker)
-                (forward-line relative-line)
-                (when (< (point) end-pos)
-                  (delete-region (line-beginning-position) (line-end-position))
-                  (insert new-content)
-                  (setq changes-made (1+ changes-made))))))
-          (save-buffer)
-          (format "Updated %d line(s) in todo '%s'" changes-made title))))))
+        (goto-char (car bounds))
+        (let ((heading-start (line-number-at-pos)))
+          (unless (and (<= heading-start start-line end-line)
+                       (<= end-line (line-number-at-pos (cdr bounds))))
+            (error "Requested lines are outside the todo subtree"))
+          (forward-line (- start-line heading-start))
+          (let ((start (line-beginning-position)))
+            (forward-line (1+ (- end-line start-line)))
+            (ai/todo-edit--json
+             "ok" t "title" title "start_line" start-line "end_line" end-line
+             "content" (buffer-substring-no-properties start (min (point) (cdr bounds))))))))))
 
-(defun ai/todo--search-replace-in-heading (title search replace &optional file)
-  "Search for SEARCH and replace with REPLACE in heading TITLE in FILE."
-  (let* ((file (or file ai/todo-file))
-         (marker (ai/todo--find-heading-by-title title file)))
-    (unless marker
-      (error "Todo heading not found: %s" title))
-    (with-current-buffer (marker-buffer marker)
-      (save-excursion
-        (goto-char marker)
-        (let* ((start-pos (point))
-               (end-pos (save-excursion
-                          (org-end-of-subtree t t)
-                          (point)))
-               (count 0))
-          (while (search-forward search end-pos t)
-            (replace-match replace nil t)
-            (setq count (1+ count)))
-          (when (> count 0)
-            (save-buffer))
-          (format "Replaced %d occurrence(s) of '%s' with '%s' in todo '%s'"
-                  count search replace title))))))
+(defun ai/todo-apply-patch (title patch &optional file preview)
+  "Apply unified PATCH to todo TITLE using isolated temporary files.
+The patch is never run against the actual Org file."
+  (unless (executable-find "patch")
+    (error "The patch executable is required"))
+  (let* ((marker (ai/todo-edit--heading-marker title file))
+         (original (ai/todo-edit--subtree marker))
+         (input (make-temp-file "todo-patch-input-"))
+         (patch-file (make-temp-file "todo-patch-"))
+         (output (make-temp-file "todo-patch-output-"))
+         (log (generate-new-buffer " *todo-patch-log*")))
+    (unwind-protect
+        (progn
+          (delete-file output)
+          (with-temp-file input (insert original))
+          (with-temp-file patch-file (insert patch))
+          (let ((status (process-file "patch" nil log nil
+                                      "--batch" "--forward" "--silent"
+                                      "-o" output input patch-file)))
+            (unless (zerop status)
+              (error "Patch failed: %s"
+                     (with-current-buffer log (string-trim (buffer-string)))))
+            (let* ((updated (with-temp-buffer
+                              (insert-file-contents output)
+                              (buffer-string)))
+                   (diff (ai/todo-edit--diff title original updated)))
+              (unless preview (ai/todo-edit--replace-subtree marker updated))
+              (ai/todo-edit--json "ok" t "title" title
+                                  "preview" (if preview t :json-false)
+                                  "diff" diff))))
+      (dolist (temporary (list input patch-file output))
+        (when (file-exists-p temporary) (delete-file temporary)))
+      (kill-buffer log))))
 
-(defun ai/todo--preview-line-changes (title updates &optional file)
-  "Preview line UPDATES to heading with TITLE without applying.
-Returns a diff-style preview string."
-  (let* ((file (or file ai/todo-file))
-         (heading-data (ai/todo--get-heading-lines title file t)))
-    (unless heading-data
-      (error "Todo heading not found: %s" title))
-    (let* ((start-line (car heading-data))
-           (current-content (cdr heading-data))
-           (lines (split-string current-content "\n" t))
-           (preview-parts '()))
-      (push (format "Preview changes to: %s" title) preview-parts)
-      (push "" preview-parts)
-      (dolist (update updates)
-        (let* ((line-num (car update))
-               (new-content (cdr update))
-               (relative-line (- line-num start-line)))
-          (when (and (>= relative-line 0) (< relative-line (length lines)))
-            (let ((old-content (nth relative-line lines)))
-              (push (format "Line %d:" line-num) preview-parts)
-              (push (format "- %s" (string-trim old-content)) preview-parts)
-              (push (format "+ %s" new-content) preview-parts)
-              (push "" preview-parts)))))
-      (string-join (nreverse preview-parts) "\n"))))
+(defun ai/todo-edit--register (name function description args &optional confirm)
+  "Register todo tool NAME using FUNCTION, DESCRIPTION, and ARGS."
+  (when (fboundp 'gptel-get-tool)
+    (ignore-errors (setf (gptel-get-tool name) nil)))
+  (apply #'gptel-make-tool
+         (append (list :name name :function function
+                       :category "todo_editing" :description description
+                       :args args)
+                 (when confirm (list :confirm t)))))
 
-(defun ai/todo--get-lines-range (title start-line end-line &optional file)
-  "Get lines START-LINE through END-LINE from heading TITLE in FILE."
-  (let* ((file (or file ai/todo-file))
-         (heading-data (ai/todo--get-heading-lines title file nil))
-         (marker (ai/todo--find-heading-by-title title file)))
-    (unless marker
-      (error "Todo heading not found: %s" title))
-    (with-current-buffer (marker-buffer marker)
-      (save-excursion
-        (goto-char marker)
-        (let* ((heading-start-line (line-number-at-pos))
-               (relative-start (- start-line heading-start-line))
-               (relative-end (- end-line heading-start-line)))
-          (forward-line relative-start)
-          (let ((start-pos (line-beginning-position)))
-            (forward-line (- relative-end relative-start))
-            (buffer-substring-no-properties start-pos (line-end-position))))))))
+(ai/todo-edit--register
+ "todo_read" #'ai/todo-read-heading
+ "Read one exact todo heading and its subtree."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "file" :type string :optional t :description "Todo Org file")
+   (:name "numbered" :type boolean :optional t :description "Include absolute line numbers")))
 
-(defun ai/todo--apply-structured-patch (title patch &optional file)
-  "Apply structured PATCH to heading TITLE in FILE.
-PATCH is a string in unified diff format or structured update format."
-  (let* ((file (or file ai/todo-file))
-         (marker (ai/todo--find-heading-by-title title file)))
-    (unless marker
-      (error "Todo heading not found: %s" title))
-    (with-temp-file (concat file ".patch")
-      (insert patch))
-    (with-current-buffer (marker-buffer marker)
-      (let* ((start-pos (marker-position marker))
-             (end-pos (save-excursion
-                        (goto-char marker)
-                        (org-end-of-subtree t t)
-                        (point)))
-             (result (shell-command-on-region
-                      start-pos end-pos
-                      (format "patch -p0 - < %s.patch" file)
-                      t t)))
-        (save-buffer)
-        (delete-file (concat file ".patch"))
-        (if (zerop result)
-            (format "Successfully applied patch to todo '%s'" title)
-          (format "Patch application had issues: %s" result))))))
+(ai/todo-edit--register
+ "todo_edit" #'ai/todo-edit-exact
+ "Replace exact text inside one todo subtree and return a unified diff."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "old_text" :type string :description "Exact text with enough context to be unique")
+   (:name "new_text" :type string :description "Replacement text")
+   (:name "file" :type string :optional t :description "Todo Org file")
+   (:name "replace_all" :type boolean :optional t :description "Replace every exact match")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing")) t)
 
-(defun ai/todo--read-heading-numbered (title &optional file)
-  "Read heading TITLE from FILE with line numbers prepended."
-  (let ((heading-data (ai/todo--get-heading-lines title file t)))
-    (if heading-data
-        (cdr heading-data)
-      (error "Todo heading not found: %s" title))))
+(ai/todo-edit--register
+ "todo_multi_edit" #'ai/todo-multi-edit
+ "Apply multiple exact edits to one todo subtree as one transaction."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "edits" :type array :description "Objects with old_text, new_text, optional replace_all")
+   (:name "file" :type string :optional t :description "Todo Org file")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing")) t)
 
-;;; Tool Definitions
+(ai/todo-edit--register
+ "todo_replace_subtree" #'ai/todo-replace-subtree
+ "Replace a complete todo subtree and return a unified diff."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "content" :type string :description "Complete replacement subtree")
+   (:name "file" :type string :optional t :description "Todo Org file")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing")) t)
 
-(gptel-make-tool
- :function (lambda (title updates &optional file)
-             (ai/todo--apply-line-updates 
-              title
-              (mapcar (lambda (u) (cons (plist-get u :line) (plist-get u :content)))
-                      updates)
-              file))
- :name "apply_todo_line_changes"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading to update")
-         (:name "updates" :type array
-          :description "Array of updates, each with :line (number) and :content (string)")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Apply line-by-line changes to a specific todo heading.
-Similar to apply_line_changes but operates on todo headings instead of files.
-Updates are applied by line number within the heading's subtree.")
+(ai/todo-edit--register
+ "apply_todo_line_changes" #'ai/todo-apply-line-changes
+ "Compatibility line-number editor. Prefer todo_multi_edit."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "updates" :type array :description "Objects with absolute line and content")
+   (:name "file" :type string :optional t :description "Todo Org file")) t)
 
-(gptel-make-tool
- :function #'ai/todo--search-replace-in-heading
- :name "todo_search_replace"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading")
-         (:name "search" :type string
-          :description "Text to search for")
-         (:name "replace" :type string
-          :description "Replacement text")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Search and replace text within a specific todo heading.
-Similar to search_replace but operates on todo headings.
-Replaces all occurrences of search string with replacement within the heading's subtree.")
+(ai/todo-edit--register
+ "preview_todo_changes" #'ai/todo-preview-line-changes
+ "Preview compatibility line-number changes."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "updates" :type array :description "Objects with absolute line and content")
+   (:name "file" :type string :optional t :description "Todo Org file")))
 
-(gptel-make-tool
- :function (lambda (title updates &optional file)
-             (ai/todo--preview-line-changes
-              title
-              (mapcar (lambda (u) (cons (plist-get u :line) (plist-get u :content)))
-                      updates)
-              file))
- :name "preview_todo_changes"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading")
-         (:name "updates" :type array
-          :description "Array of updates to preview, each with :line and :content")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Preview line changes to a todo heading without applying them.
-Shows before/after comparison of the changes that would be made.
-Use this before apply_todo_line_changes to verify correctness.")
+(ai/todo-edit--register
+ "todo_search_replace" #'ai/todo-search-replace
+ "Replace every exact string occurrence within one todo subtree."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "search" :type string :description "Exact text to replace")
+   (:name "replace" :type string :description "Replacement text")
+   (:name "file" :type string :optional t :description "Todo Org file")) t)
 
-(gptel-make-tool
- :function #'ai/todo--get-lines-range
- :name "get_todo_lines"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading")
-         (:name "start_line" :type integer
-          :description "Starting line number (absolute in file)")
-         (:name "end_line" :type integer
-          :description "Ending line number (absolute in file)")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Get a range of lines from a todo heading.
-Returns the text between start_line and end_line within the heading's subtree.
-Useful for inspecting specific sections before making changes.")
+(ai/todo-edit--register
+ "get_todo_lines" #'ai/todo-get-lines
+ "Read an inclusive absolute line range within one todo subtree."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "start_line" :type integer :description "First absolute line")
+   (:name "end_line" :type integer :description "Last absolute line")
+   (:name "file" :type string :optional t :description "Todo Org file")))
 
-(gptel-make-tool
- :function #'ai/todo--apply-structured-patch
- :name "apply_todo_patch"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading")
-         (:name "patch" :type string
-          :description "Unified diff format patch or structured update")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Apply a structured patch to a todo heading.
-Accepts unified diff format patches to make complex changes to todo entries.
-Use for multi-line edits that are easier to express as diffs.")
+(ai/todo-edit--register
+ "apply_todo_patch" #'ai/todo-apply-patch
+ "Apply a unified patch to an isolated copy of a todo subtree, then replace the subtree atomically."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "patch" :type string :description "Unified patch generated against the subtree")
+   (:name "file" :type string :optional t :description "Todo Org file")
+   (:name "preview" :type boolean :optional t :description "Return diff without writing")) t)
 
-(gptel-make-tool
- :function #'ai/todo--read-heading-numbered
- :name "read_todo_numbered"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading to read")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Read a todo heading with line numbers prepended to each line.
-Essential for making precise line-based edits - use this first to see line numbers,
-then use apply_todo_line_changes or other tools to make targeted updates.
-Line numbers are absolute file positions for accurate targeting.")
+(ai/todo-edit--register
+ "read_todo_numbered" (lambda (title &optional file)
+                         (ai/todo-read-heading title file t))
+ "Read one exact todo subtree with absolute line numbers."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "file" :type string :optional t :description "Todo Org file")))
 
-(gptel-make-tool
- :function (lambda (title &optional file)
-             (let ((heading-data (ai/todo--get-heading-lines title file nil)))
-               (if heading-data
-                   (cdr heading-data)
-                 (error "Todo heading not found: %s" title))))
- :name "read_todo_heading"
- :category "todo_editing"
- :args '((:name "title" :type string
-          :description "Title of the todo heading to read")
-         (:name "file" :type string :optional t
-          :description "Todo file path (defaults to ai/todo-file)"))
- :description "Read the complete content of a todo heading including its subtree.
-Returns all content under the heading without line numbers.
-Use read_todo_numbered if you need line numbers for editing.")
-
-;;; Extended Tool List
+(ai/todo-edit--register
+ "read_todo_heading" #'ai/todo-read-heading
+ "Read one exact todo subtree."
+ '((:name "title" :type string :description "Exact heading title")
+   (:name "file" :type string :optional t :description "Todo Org file")))
 
 (defvar ai/todo-edit-tools
-  (list 'apply_todo_line_changes
-        'todo_search_replace
-        'preview_todo_changes
-        'get_todo_lines
-        'apply_todo_patch
-        'read_todo_numbered
-        'read_todo_heading)
-  "List of todo editing tool names that mirror diff operations.")
+  '("todo_read" "todo_edit" "todo_multi_edit" "todo_replace_subtree"
+    "apply_todo_line_changes" "preview_todo_changes" "todo_search_replace"
+    "get_todo_lines" "apply_todo_patch" "read_todo_numbered"
+    "read_todo_heading")
+  "Tool names for safe Org todo editing.")
 
 (provide 'todo-diff)
 ;;; todo-diff.el ends here


### PR DESCRIPTION
## Summary

- default the Emacs LLM stack to Z.AI GLM-5.2
- add first-class OpenAI GPT-5.6 Sol support through gptel's Responses backend
- replace the sprawling agent surface with Claude Code-style project tools
- harden file access with project-root confinement, atomic writes, exact-match edits, transactional multi-edit, bounded output, timed commands, and validated multi-file patches
- replace the brittle Org todo diff editor with exact-heading transactional editing and isolated patch application
- modernize persistent Org chat, model switching, presets, context handling, and Doom autoloads
- add `lisp/llm/llm.org` as the maintained Org configuration/reference file

## Main tools

`Read`, `Glob`, `Grep`, `LS`, `FileStat`, `Edit`, `MultiEdit`, `Write`, `ApplyPatch`, `Mkdir`, `Move`, `Delete`, `Bash`, `GitStatus`, `GitDiff`, `DiffFiles`, buffer tools, Emacs introspection, HTTP fetch, and project-context tools.

Legacy tool names remain registered as compatibility aliases but are excluded from the default agent preset.

## Presets

- `@glm-5.2`
- `@gpt-5.6-sol`
- `@agent`
- `@agent-gpt-5.6-sol`

## Validation

- audited against the current upstream gptel backend, preset, context, and tool-schema APIs
- fixed required `:items` schemas for structured array arguments
- checked all changed Elisp files for balanced delimiters, strings, and comments
- inspected the final GitHub branch diff; only the intended eight files changed

An Emacs executable was not available in the execution environment, so byte-compilation and live gptel requests were not run here.

## After merge

Run `doom sync`, restart Emacs, and ensure `ZAI_API_KEY` or the matching `auth-source` entry is configured. `OPENAI_API_KEY` is needed for GPT-5.6 Sol.