### PR TITLE
proxmox-mcp: add ProxmoxMCP-Plus MCP server for emacs and opencode

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -925,13 +925,15 @@ strings."
  :commands (mcp-hub-start-all-server gptel-mcp-connect)
  :custom (mcp-hub-servers
           `(
-            
-            ("fetch" . (:command "npx" :args ("mcp-fetch-server")))
-            ("filesystem" . (:command "npx" :args ("-y" "@modelcontextprotocol/server-filesystem"
-                                                   ,(expand-file-name "~/Documents/Projects")
-                                                   ,(expand-file-name "~/common-lisp")
-                                                   ,(expand-file-name "~/.dotfiles"))))))
-            
+
+           ("proxmox" . (:command "sh"
+                                  :args ("-c" "exec proxmox-mcp-launcher")))
+           ("fetch" . (:command "npx" :args ("mcp-fetch-server")))
+           ("filesystem" . (:command "npx" :args ("-y" "@modelcontextprotocol/server-filesystem"
+                                                  ,(expand-file-name "~/Documents/Projects")
+                                                  ,(expand-file-name "~/common-lisp")
+                                                  ,(expand-file-name "~/.dotfiles"))))))
+
  :config
  (require 'gptel-integrations)
  (require 'mcp-hub)

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -1403,24 +1403,27 @@ Start a todo chat with tools needed
 #+end_src
 *** MCP Configuration
 
+Proxmox VE is exposed via the [[https://github.com/RekklesNA/ProxmoxMCP-Plus][ProxmoxMCP-Plus]] server. It is launched through the nixified =proxmox-mcp-launcher= wrapper (see =nix/home-manager/mods/proxmox-mcp.nix=) so credentials stay out of this public repo. The wrapper sources =~/.config/proxmox-mcp/proxmox-mcp.env= and then runs =uvx= against the local checkout at =~/git/ProxmoxMCP-Plus=. See [[ProxmoxMCP-Plus blockers][docs/proxmox-mcp.org]] for the manual setup steps.
 
 #+begin_src emacs-lisp
  (use-package! mcp
-  :after gptel
-  :commands (mcp-hub-start-all-server gptel-mcp-connect)
-  :custom (mcp-hub-servers
-           `(
+   :after gptel
+   :commands (mcp-hub-start-all-server gptel-mcp-connect)
+   :custom (mcp-hub-servers
+            `(
              
+             ("proxmox" . (:command "sh"
+                                    :args ("-c" "exec proxmox-mcp-launcher")))
              ("fetch" . (:command "npx" :args ("mcp-fetch-server")))
              ("filesystem" . (:command "npx" :args ("-y" "@modelcontextprotocol/server-filesystem"
                                                     ,(expand-file-name "~/Documents/Projects")
                                                     ,(expand-file-name "~/common-lisp")
                                                     ,(expand-file-name "~/.dotfiles"))))))
              
-  :config
-  (require 'gptel-integrations)
-  (require 'mcp-hub)
-  (gptel-mcp-connect))
+   :config
+   (require 'gptel-integrations)
+   (require 'mcp-hub)
+   (gptel-mcp-connect))
 #+end_src
 
 *** Keybinds

--- a/docs/proxmox-mcp.org
+++ b/docs/proxmox-mcp.org
@@ -1,0 +1,121 @@
+#+title: ProxmoxMCP-Plus Setup & Blockers
+#+property: header-args:shell :eval no
+
+This documents the ProxmoxMCP-Plus integration added to these dotfiles, and
+lists the manual steps the user must complete themselves (the agent cannot
+safely do them because they touch real Proxmox credentials / reboots).
+
+* What was configured
+
+- Repo cloned to =~/git/ProxmoxMCP-Plus= (kept as a local checkout; the
+  launcher runs it directly with =uvx --from <checkout>=).
+- New nix module =nix/home-manager/mods/proxmox-mcp.nix= providing a
+  =proxmox-mcp-launcher= wrapper. It sources
+  =~/.config/proxmox-mcp/proxmox-mcp.env= (kept *outside* git) and then runs
+  =uvx proxmox-mcp-plus= (preferring the local checkout).
+- Enabled in =nix/home-manager/systems/desktop/home.nix= via
+  =proxmox-mcp.enable = true;=.
+- Doom Emacs MCP server "proxmox" added in =.doom.d/config.org= (and the
+  tangled =.doom.d/config.el=) using =sh -c "exec proxmox-mcp-launcher"=.
+- OpenCode MCP server "proxmox-mcp-plus" added in
+  =~/.config/opencode/opencode.jsonc= using the same launcher.
+
+* Blockers you must do yourself
+
+These steps require secrets or environment changes the agent should not make
+automatically.
+
+** 1. Create a Proxmox API token
+
+In Proxmox VE, create an API token for the user you want the MCP server to act
+as, scoped to only the permissions your workflows need. See the upstream
+[[https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide][Security Guide]].
+
+You need:
+- =user= e.g. =root@pam= (or a dedicated =mcp@pve=)
+- =token_name= e.g. =mcp-token=
+- =token_value= (the secret shown once at creation time)
+
+** 2. Fill in the credential env file
+
+Edit =~/.config/proxmox-mcp/proxmox-mcp.env= (a placeholder copy already
+exists) and replace the placeholder values:
+
+#+begin_src shell
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=true
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO
+#+end_src
+
+For a self-signed lab certificate set *both*:
+#+begin_src shell
+export PROXMOX_VERIFY_SSL=false
+export PROXMOX_DEV_MODE=true
+#+end_src
+
+This file is intentionally outside any git repo — never commit it.
+
+** 3. Apply the home-manager generation
+
+The launcher is nix-managed, so apply the new generation once the PR is merged:
+
+#+begin_src shell
+home-manager switch --flake ~/.dotfiles#unseen@logos
+# or, from the dotfiles dir:
+nix run .#home-manager -- switch --flake .#unseen@logos
+#+end_src
+
+Then confirm the launcher is on PATH:
+
+#+begin_src shell
+command -v proxmox-mcp-launcher
+proxmox-mcp-launcher   # should print the credential-missing error until step 2 is done
+#+end_src
+
+** 4. Restart OpenCode
+
+OpenCode loads config once at startup. Quit and restart it so the new
+=proxmox-mcp-plus= MCP server is picked up. Verify read-only tools appear
+(=get_nodes=, =get_vms=, =get_containers=, =get_storage=).
+
+** 5. Reload Doom Emacs
+
+Run =doom sync= (or =M-x nsa/config-sync=) so the tangling + =mcp-hub=
+server list updates, then restart Emacs. Connect via gptel and confirm the
+=proxmox= server shows tools.
+
+** 6. (Optional) SSH for container command execution
+
+=execute_container_command= only appears if you add an =ssh= section to a
+ProxmoxMCP-Plus config file. The env-var path used here does not configure
+SSH. If you want it, create =~/git/ProxmoxMCP-Plus/proxmox-config/config.json=
+from =config.example.json=, fill the =ssh= block, and point the launcher at it
+by adding =PROXMOX_MCP_CONFIG=/home/unseen/git/ProxmoxMCP-Plus/proxmox-config/config.json=
+to =~/.config/proxmox-mcp/proxmox-mcp.env=.
+
+* Verification
+
+After steps 1–5:
+
+#+begin_src shell
+# launcher should now start the stdio server (it exits on stdin EOF)
+echo '{}' | proxmox-mcp-launcher | head
+#+end_src
+
+In OpenCode, ask the agent to list Proxmox nodes; in Emacs, use gptel with the
+=proxmox= MCP server connected.
+
+* Files changed
+
+- =nix/home-manager/mods/proxmox-mcp.nix= (new)
+- =nix/home-manager/mods/default.nix= (import)
+- =nix/home-manager/systems/desktop/home.nix= (enable)
+- =scripts/proxmox-mcp.env.example= (new)
+- =.doom.d/config.org= and =.doom.d/config.el= (proxmox MCP server)
+- =~/.config/opencode/opencode.jsonc= (outside this repo)
+- =~/.config/proxmox-mcp/proxmox-mcp.env= (outside this repo, untracked)

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -13,5 +13,6 @@
     ./media.nix
     ./pentesting.nix
     ./llm.nix
+    ./proxmox-mcp.nix
   ];
 }

--- a/nix/home-manager/mods/proxmox-mcp.nix
+++ b/nix/home-manager/mods/proxmox-mcp.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.proxmox-mcp;
+
+  proxmoxEnvFile = "${config.home.homeDirectory}/.config/proxmox-mcp/proxmox-mcp.env";
+  proxmoxRepo = "${config.home.homeDirectory}/git/ProxmoxMCP-Plus";
+
+  # A nixified launcher that sources the user's Proxmox credentials from an
+  # env file kept *outside* version control, then runs the MCP server.
+  #
+  # It prefers a local source checkout at ~/git/ProxmoxMCP-Plus so edits to
+  # the cloned repo are picked up immediately, and falls back to the PyPI
+  # package when the checkout is absent.
+  proxmox-mcp-launcher = pkgs.writeShellApplication {
+    name = "proxmox-mcp-launcher";
+    runtimeInputs = with pkgs; [
+      uv
+      coreutils
+    ];
+    text = ''
+      # Source user-provided credentials if present. The env file lives
+      # outside any git repo so real tokens never get committed.
+      if [ -f "${proxmoxEnvFile}" ]; then
+        # shellcheck disable=SC1090,SC1091
+        . "${proxmoxEnvFile}"
+      fi
+
+      # Fail fast if required Proxmox credentials are missing so MCP clients
+      # surface a readable error instead of a silent retry loop.
+      if [ -z "''${PROXMOX_HOST:-}" ] || [ -z "''${PROXMOX_TOKEN_VALUE:-}" ]; then
+        echo "proxmox-mcp-launcher: PROXMOX_HOST and PROXMOX_TOKEN_VALUE must be set." >&2
+        echo "Populate ${proxmoxEnvFile} (see ~/.dotfiles/docs/proxmox-mcp.org)." >&2
+        exit 1
+      fi
+
+      # Prefer the local source checkout when present, else fall back to PyPI.
+      if [ -d "${proxmoxRepo}/src/proxmox_mcp" ]; then
+        exec uvx --from "${proxmoxRepo}" proxmox-mcp-plus
+      else
+        exec uvx proxmox-mcp-plus
+      fi
+    '';
+  };
+in
+{
+  options = with lib; {
+    proxmox-mcp = {
+      enable = mkEnableOption "ProxmoxMCP-Plus MCP launcher and uv runtime";
+
+      package = mkOption {
+        type = types.package;
+        default = proxmox-mcp-launcher;
+        defaultText = literalExpression "proxmox-mcp-launcher";
+        description = "Launcher package that sources credentials and runs the MCP server.";
+      };
+    };
+  };
+
+  config = with lib; mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+      pkgs.uv
+    ];
+
+    # Drop the credential env file template into the user's config so they
+    # know the expected shape. Real values are filled in by the user.
+    home.file.".config/proxmox-mcp/proxmox-mcp.env.example".source =
+      ../../../scripts/proxmox-mcp.env.example;
+  };
+}

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -20,6 +20,10 @@
     enable = true;
   };
 
+  proxmox-mcp = {
+    enable = true;
+  };
+
   emacs = {
     enable = true;
     # I mostly use magit hence configured in the ./nixos/mods/emacs.nix module

--- a/scripts/proxmox-mcp.env.example
+++ b/scripts/proxmox-mcp.env.example
@@ -1,0 +1,19 @@
+# ProxmoxMCP-Plus environment variables.
+#
+# Copy this to ~/.config/proxmox-mcp/proxmox-mcp.env and fill in real values.
+# The real file is kept OUTSIDE version control on purpose — never commit it.
+#
+# Sourced by the `proxmox-mcp-launcher` nix package before `uvx` runs the
+# server. See ~/.dotfiles/docs/proxmox-mcp.org for the full setup + blockers.
+
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=true
+# For a self-signed lab cert, set BOTH of these:
+# export PROXMOX_VERIFY_SSL=false
+# export PROXMOX_DEV_MODE=true
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO


### PR DESCRIPTION
Adds ProxmoxMCP-Plus as an MCP server for both Doom Emacs (gptel/mcp-hub) and OpenCode, via a nixified launcher.

## What
- New nix module `nix/home-manager/mods/proxmox-mcp.nix` providing a `proxmox-mcp-launcher` wrapper (via `writeShellApplication`). It sources credentials from `~/.config/proxmox-mcp/proxmox-mcp.env` (kept **outside** git) and runs `uvx proxmox-mcp-plus`, preferring the local checkout at `~/git/ProxmoxMCP-Plus` and falling back to PyPI.
- Env template at `scripts/proxmox-mcp.env.example`, dropped into the user config as `~/.config/proxmox-mcp/proxmox-mcp.env.example`.
- Enabled in `nix/home-manager/systems/desktop/home.nix` (`proxmox-mcp.enable = true`).
- Doom: `proxmox` entry added to `mcp-hub-servers` in both `config.org` (literate source) and tangled `config.el`, using `sh -c "exec proxmox-mcp-launcher"`.
- OpenCode: `~/.config/opencode/opencode.jsonc` (outside this repo) registers `proxmox-mcp-plus` using the same launcher.
- `docs/proxmox-mcp.org` documents the manual blockers.

## Verification
- `nix build .#unseen-home` succeeds.
- Launcher fails cleanly with a readable error when credentials are missing.
- With a placeholder env, `uvx` builds the local checkout and the stdio MCP server starts (exits 0 on stdin EOF).

## Blockers the user must do themselves
1. Create a Proxmox API token (user/token_name/token_value).
2. Fill in `~/.config/proxmox-mcp/proxmox-mcp.env` (placeholder copy already created).
3. `home-manager switch --flake ~/.dotfiles#unseen@logos` so the launcher is on PATH.
4. Restart OpenCode (config is loaded once at startup).
5. `doom sync` + restart Emacs so the new `proxmox` MCP server loads.
6. (Optional) add an `ssh` section via a `config.json` if you want `execute_container_command`.

Full details in `docs/proxmox-mcp.org`. The repo itself is cloned to `~/git/ProxmoxMCP-Plus` (not part of this PR).