### PR TITLE
llm: restore opencode to home packages

### DIFF
--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -18,7 +18,8 @@
       inputs.org-vector.packages.${stdenv.hostPlatform.system}.org-vector
       nodejs_22
 
-      # LLM tooling
+      # LLM Editors
+      opencode
       claude-code
       playerctl
       pavucontrol


### PR DESCRIPTION
PR #21 removed opencode from llm.nix. Restore it — opencode and the emacs-native MCP integration are not mutually exclusive.