### PR TITLE
Fix Emacs ai-agent feature loading

### DIFF
--- a/lisp/llm/ai-agent-core.el
+++ b/lisp/llm/ai-agent-core.el
@@ -1,0 +1,11 @@
+;;; ai-agent-core.el --- Canonical loader for the project-agent core -*- lexical-binding: t; -*-
+
+(unless (featurep 'ai-agent-core)
+  (load (expand-file-name
+         "agent-core.el"
+         (file-name-directory (or load-file-name buffer-file-name)))
+        nil
+        'nomessage))
+
+(provide 'ai-agent-core)
+;;; ai-agent-core.el ends here

--- a/lisp/llm/ai-agent.el
+++ b/lisp/llm/ai-agent.el
@@ -1,0 +1,12 @@
+;;; ai-agent.el --- Canonical loader for the gptel project agent -*- lexical-binding: t; -*-
+
+(unless (featurep 'ai-agent)
+  (require 'ai-agent-core)
+  (load (expand-file-name
+         "agent.el"
+         (file-name-directory (or load-file-name buffer-file-name)))
+        nil
+        'nomessage))
+
+(provide 'ai-agent)
+;;; ai-agent.el ends here

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -31,6 +31,10 @@ explicitly:
 (ai/llm-apply-defaults)
 #+end_src
 
+The public =ai-agent= and =ai-agent-core= features use matching loader
+filenames.  Their implementations remain split into =agent.el= and
+=agent-core.el=.
+
 * Model switching
 
 #+begin_src emacs-lisp
@@ -104,7 +108,9 @@ Chats are stored below =~/Documents/Notes/org/roam/llm/=.
 * Source files
 
 #+INCLUDE: "ai.el" src emacs-lisp
+#+INCLUDE: "ai-agent-core.el" src emacs-lisp
 #+INCLUDE: "agent-core.el" src emacs-lisp
+#+INCLUDE: "ai-agent.el" src emacs-lisp
 #+INCLUDE: "agent.el" src emacs-lisp
 #+INCLUDE: "../../.doom.d/autoload/llm.el" src emacs-lisp
 #+INCLUDE: "chat.el" src emacs-lisp


### PR DESCRIPTION
## What changed

- add `lisp/llm/ai-agent.el` as the canonical loader for the `ai-agent` feature
- add `lisp/llm/ai-agent-core.el` as the canonical loader for the nested `ai-agent-core` feature
- keep the existing implementation split in `agent.el` and `agent-core.el`
- document the canonical loader filenames in `llm.org`

## Root cause

Emacs `require` resolves a missing feature by searching for a library with the same filename. The LLM overhaul required `ai-agent` and `ai-agent-core`, but the files were named `agent.el` and `agent-core.el`. Those implementation files provided the right features only after being loaded, so startup failed before Emacs could reach them.

## Impact

Loading gptel through Temple/Doom no longer aborts with:

```text
Cannot open load file: No such file or directory, ai-agent
```

## Validation

- confirmed the branch is based directly on current `master`
- confirmed `ai-agent.el` resolves `ai-agent-core` before loading `agent.el`
- confirmed both canonical libraries are now discoverable by their required feature names
- inspected the final diff: two loader files plus the Org source-reference update

Live Emacs execution was not available in the tool environment.