### PR TITLE
Modernize Emacs gptel configuration

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -16,6 +16,12 @@
         (cons '("proxmox" . (:command "proxmox-mcp-launcher"))
               (assoc-delete-all "proxmox" mcp-hub-servers))))
 
+(defun +llm/apply-final-defaults ()
+  "Make the shared gptel configuration authoritative after package setup."
+  (when (featurep 'gptel)
+    (require 'ai)
+    (ai/llm-apply-defaults)))
+
 ;;;###autoload
 (defun +llm/proxmox-connect ()
   "Register and connect the Proxmox MCP tools to gptel."
@@ -28,7 +34,9 @@
 ;;;###autoload
 (with-eval-after-load 'gptel
   (require 'ai)
-  (require 'ai-agent))
+  (require 'ai-agent)
+  ;; Run after every `eval-after-load' and `use-package!' callback for gptel.
+  (run-at-time 0 nil #'+llm/apply-final-defaults))
 
 ;;;###autoload
 (with-eval-after-load 'mcp-hub

--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -60,10 +60,24 @@
 
 ;;;###autoload
 (defun +llm/use-gpt-5.6-sol (&optional local)
-  "Switch to OpenAI GPT-5.6 Sol."
+  "Switch to OpenAI API GPT-5.6 Sol."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-gpt-5.6-sol local))
+
+;;;###autoload
+(defun +llm/use-openai-oauth (&optional local)
+  "Switch to GPT-5.6 Sol through OpenAI subscription OAuth."
+  (interactive "P")
+  (require 'ai)
+  (ai/llm-use-openai-oauth local))
+
+;;;###autoload
+(defun +llm/openai-login ()
+  "Authenticate the OpenAI subscription backend."
+  (interactive)
+  (require 'ai)
+  (ai/llm-openai-oauth-login))
 
 ;;;###autoload
 (defun +llm/agent-context ()

--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -46,7 +46,10 @@
 
 (package! org-drill)
 
-(package! gptel :recipe (:nonrecursive t))
+(unpin! gptel)
+(package! gptel
+  :recipe (:host github :repo "karthink/gptel"
+           :files ("*.el")))
 
 (package! mcp :recipe (:type git :host github :repo "lizqwerscott/mcp.el"))
 

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -225,7 +225,7 @@ A major mode for view pcap capture files
 (package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
 #+end_src
 ** exec-path-from-shell
-A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user’s shell.
+A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user's shell.
 #+begin_src emacs-lisp
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 #+end_src

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -129,7 +129,7 @@ GPTEL supports MCP.
 #+end_src
 * Development
 ** envrc
-A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in their files. This allows different versions of linters and other tools to be used in each project if desired.
+A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in those files. This allows different versions of linters and other tools to be used in each project if desired.
 
 #+begin_src emacs-lisp
 (package! envrc :recipe (:type git :host github :repo "purcell/envrc"))
@@ -208,7 +208,7 @@ paste your buffer to a pastebin like service.
 (package! webpaste :recipe (:type git :host github :repo "etu/webpaste.el"))
 #+end_src
 ** Burly
-This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows’ layout, and their buffers.
+This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows, the windows’ layout, and their buffers.
 
 #+begin_src emacs-lisp
 (package! burly :recipe (:type git :host github :repo "alphapapa/burly.el"))
@@ -225,7 +225,7 @@ A major mode for view pcap capture files
 (package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
 #+end_src
 ** exec-path-from-shell
-A GNU Emacs library to ensure environment variables inside Emacs look the same as the user's shell.
+A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user’s shell.
 #+begin_src emacs-lisp
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 #+end_src

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -113,10 +113,14 @@ Create Flashcards from
 
 * AI
 ** gptel
-Interact with LLM from orgmode
-GPTEL now supports agent like workflows via tools
+Interact with LLMs from Org mode and expose current tool, reasoning, Responses
+API, and OpenAI subscription OAuth support.  Track upstream gptel instead of
+Doom's older package pin.
 #+begin_src emacs-lisp
-(package! gptel :recipe (:nonrecursive t))
+(unpin! gptel)
+(package! gptel
+  :recipe (:host github :repo "karthink/gptel"
+           :files ("*.el")))
 #+end_src
 ** MCP Services
 GPTEL supports MCP.
@@ -125,7 +129,7 @@ GPTEL supports MCP.
 #+end_src
 * Development
 ** envrc
-A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in those files. This allows different versions of linters and other tools to be used in each project if desired.
+A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in their files. This allows different versions of linters and other tools to be used in each project if desired.
 
 #+begin_src emacs-lisp
 (package! envrc :recipe (:type git :host github :repo "purcell/envrc"))
@@ -204,7 +208,7 @@ paste your buffer to a pastebin like service.
 (package! webpaste :recipe (:type git :host github :repo "etu/webpaste.el"))
 #+end_src
 ** Burly
-This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows, the windows’ layout, and their buffers.
+This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows’ layout, and their buffers.
 
 #+begin_src emacs-lisp
 (package! burly :recipe (:type git :host github :repo "alphapapa/burly.el"))
@@ -221,7 +225,7 @@ A major mode for view pcap capture files
 (package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
 #+end_src
 ** exec-path-from-shell
-A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user's shell.
+A GNU Emacs library to ensure environment variables inside Emacs look the same as the user's shell.
 #+begin_src emacs-lisp
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 #+end_src

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -1,4 +1,4 @@
-;;; ai.el --- Shared gptel backend and model configuration -*- lexical-binding: t; -*-
+;;; ai.el --- Shared modern gptel backend configuration -*- lexical-binding: t; -*-
 
 (require 'auth-source)
 (require 'cl-lib)
@@ -12,9 +12,10 @@
 
 (defcustom ai/llm-provider 'zai
   "Default LLM provider.
-Supported values are `zai', `openai', and `openrouter'."
-  :type '(choice (const :tag "Z.AI" zai)
-                 (const :tag "OpenAI" openai)
+Supported values are `zai', `openai', `openai-oauth', and `openrouter'."
+  :type '(choice (const :tag "Z.AI API" zai)
+                 (const :tag "OpenAI API" openai)
+                 (const :tag "OpenAI subscription OAuth" openai-oauth)
                  (const :tag "OpenRouter" openrouter))
   :group 'ai/llm)
 
@@ -36,55 +37,46 @@ Supported values are `zai', `openai', and `openrouter'."
 (defcustom ai/llm-zai-models
   '((glm-5.2
      :description "Z.AI flagship model for long-horizon coding and agent work"
-     :capabilities (tool json)
+     :capabilities (reasoning tool-use json)
      :context-window 1000
      :request-params (:thinking (:type "enabled")))
     (|glm-5.2[1m]|
-     :description "GLM-5.2 Coding Plan model with explicit one-million-token context"
-     :capabilities (tool json)
+     :description "GLM-5.2 Coding Plan model with one-million-token context"
+     :capabilities (reasoning tool-use json)
      :context-window 1000
      :request-params (:thinking (:type "enabled")))
-    (glm-5.1 :capabilities (tool json))
-    (glm-5 :capabilities (tool json) :context-window 200))
+    (glm-5.1
+     :capabilities (reasoning tool-use json)
+     :context-window 200
+     :request-params (:thinking (:type "enabled")))
+    (glm-5
+     :capabilities (reasoning tool-use json)
+     :context-window 200
+     :request-params (:thinking (:type "enabled"))))
   "Models advertised by the Z.AI backend."
   :type '(repeat sexp)
   :group 'ai/llm)
 
 (defcustom ai/llm-openai-models
-  '((gpt-5.6-sol
-     :description "OpenAI frontier model for complex reasoning and coding"
-     :capabilities (media tool json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 1050
-     :input-cost 5
-     :output-cost 30
-     :cutoff-date "2026-02")
-    (gpt-5.6
-     :description "Alias that routes to GPT-5.6 Sol"
-     :capabilities (media tool json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 1050)
-    (gpt-5.6-terra
-     :capabilities (media tool json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 1050
-     :input-cost 2.5
-     :output-cost 15)
-    (gpt-5.6-luna
-     :capabilities (media tool json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 1050
-     :input-cost 1
-     :output-cost 6))
-  "Models advertised by the OpenAI Responses backend."
-  :type '(repeat sexp)
+  '(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna)
+  "OpenAI model IDs exposed by the local model switcher.
+Metadata is supplied by current gptel instead of being duplicated here."
+  :type '(repeat symbol)
   :group 'ai/llm)
 
 (defcustom ai/llm-openrouter-models
-  '((z-ai/glm-5.2 :capabilities (tool json) :context-window 1000)
-    (openai/gpt-5.6-sol :capabilities (media tool json url) :context-window 1050)
-    (openai/gpt-5.6-terra :capabilities (media tool json url) :context-window 1050)
-    (openai/gpt-5.6-luna :capabilities (media tool json url) :context-window 1050))
+  '((z-ai/glm-5.2
+     :capabilities (reasoning tool-use json)
+     :context-window 1000)
+    (openai/gpt-5.6-sol
+     :capabilities (reasoning media tool-use json url)
+     :context-window 1050)
+    (openai/gpt-5.6-terra
+     :capabilities (reasoning media tool-use json url)
+     :context-window 1050)
+    (openai/gpt-5.6-luna
+     :capabilities (reasoning media tool-use json url)
+     :context-window 1050))
   "Models advertised by the OpenRouter backend."
   :type '(repeat sexp)
   :group 'ai/llm)
@@ -94,7 +86,8 @@ Supported values are `zai', `openai', and `openrouter'."
 
 (defun ai/llm--auth-source-secret (host)
   "Return a secret from auth-source for HOST, or nil."
-  (when-let* ((match (car (auth-source-search :host host :max 1 :require '(:secret))))
+  (when-let* ((match (car (auth-source-search :host host :max 1
+                                               :require '(:secret))))
               (secret (plist-get match :secret)))
     (if (functionp secret) (funcall secret) secret)))
 
@@ -118,13 +111,14 @@ Environment variables are preferred, then auth-source is consulted."
          (and (fboundp 'nsa/auth-source-get)
               (ignore-errors (nsa/auth-source-get :host "openrouter.ai")))
          (ai/llm--auth-source-secret "openrouter.ai")))
-    (_ (error "Unsupported LLM provider: %S" provider))))
+    (_ (error "Unsupported API-key LLM provider: %S" provider))))
 
 (defun ai/llm--require-api-key (provider)
   "Return PROVIDER's API key or signal a useful error."
   (or (ai/llm--api-key provider)
-      (user-error "No API key for %s; configure auth-source or the provider environment variable"
-                  provider)))
+      (user-error
+       "No API key for %s; configure auth-source or its environment variable"
+       provider)))
 
 (cl-defun ai/llm-zai-backend (&key (stream t) (name "Z.AI"))
   "Return a Z.AI OpenAI-compatible backend.
@@ -137,15 +131,19 @@ STREAM controls response streaming and NAME is the backend display name."
     :models ai/llm-zai-models))
 
 (cl-defun ai/llm-openai-backend (&key (stream t) (name "OpenAI"))
-  "Return an OpenAI backend with GPT-5.6 family support."
+  "Return the current gptel OpenAI Responses API backend."
   (gptel-make-openai name
-    :host "api.openai.com"
     :stream stream
-    :key (lambda () (ai/llm--require-api-key 'openai))
-    :models ai/llm-openai-models))
+    :key (lambda () (ai/llm--require-api-key 'openai))))
+
+(cl-defun ai/llm-openai-oauth-backend
+    (&key (stream t) (name "OpenAI Subscription"))
+  "Return gptel's OpenAI subscription OAuth backend."
+  (require 'gptel-openai-oauth)
+  (gptel-make-openai-oauth name :stream stream))
 
 (cl-defun ai/llm-openrouter-backend (&key (stream t) (name "OpenRouter"))
-  "Return an OpenRouter backend."
+  "Return an OpenRouter chat-completions backend."
   (gptel-make-openai name
     :host "openrouter.ai"
     :endpoint "/api/v1/chat/completions"
@@ -157,12 +155,14 @@ STREAM controls response streaming and NAME is the backend display name."
   "Return the backend for PROVIDER.
 PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
   (let ((provider (or provider ai/llm-provider)))
-    (when refresh (remhash provider ai/llm--backends))
+    (when refresh
+      (remhash provider ai/llm--backends))
     (or (gethash provider ai/llm--backends)
         (puthash provider
                  (pcase provider
                    ('zai (ai/llm-zai-backend))
                    ('openai (ai/llm-openai-backend))
+                   ('openai-oauth (ai/llm-openai-oauth-backend))
                    ('openrouter (ai/llm-openrouter-backend))
                    (_ (error "Unsupported LLM provider: %S" provider)))
                  ai/llm--backends))))
@@ -171,38 +171,47 @@ PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
   "Return MODEL when provided, otherwise `ai/llm-model'."
   (or model ai/llm-model))
 
+(defun ai/llm--model-name (spec)
+  "Return the model symbol represented by SPEC."
+  (if (consp spec) (car spec) spec))
+
 (defun ai/llm-models-for-provider (&optional provider)
-  "Return configured models for PROVIDER."
+  "Return configured model symbols for PROVIDER."
   (pcase (or provider ai/llm-provider)
-    ('zai (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-zai-models))
-    ('openai (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-openai-models))
-    ('openrouter (mapcar (lambda (spec) (if (consp spec) (car spec) spec)) ai/llm-openrouter-models))
+    ('zai (mapcar #'ai/llm--model-name ai/llm-zai-models))
+    ((or 'openai 'openai-oauth) ai/llm-openai-models)
+    ('openrouter (mapcar #'ai/llm--model-name ai/llm-openrouter-models))
     (_ nil)))
 
 (defun ai/llm-use (provider model &optional local)
   "Switch gptel to PROVIDER and MODEL.
 With LOCAL non-nil, only change the current buffer."
   (interactive
-   (let* ((provider (intern
-                     (completing-read "Provider: " '("zai" "openai" "openrouter")
-                                      nil t nil nil (symbol-name ai/llm-provider))))
-          (models (mapcar #'symbol-name (ai/llm-models-for-provider provider)))
-          (model (intern (completing-read "Model: " models nil t nil nil
-                                          (symbol-name
-                                           (if (memq ai/llm-model
-                                                     (ai/llm-models-for-provider provider))
-                                               ai/llm-model
-                                             (car (ai/llm-models-for-provider provider))))))))
+   (let* ((provider
+           (intern
+            (completing-read
+             "Provider: " '("zai" "openai" "openai-oauth" "openrouter")
+             nil t nil nil (symbol-name ai/llm-provider))))
+          (available (ai/llm-models-for-provider provider))
+          (default (if (memq ai/llm-model available)
+                       ai/llm-model
+                     (car available)))
+          (model
+           (intern
+            (completing-read "Model: " (mapcar #'symbol-name available)
+                             nil t nil nil (symbol-name default)))))
      (list provider model current-prefix-arg)))
-  (if local
-      (progn
-        (setq-local gptel-backend (ai/llm-backend provider))
-        (setq-local gptel-model model))
-    (setq ai/llm-provider provider
-          ai/llm-model model
-          gptel-backend (ai/llm-backend provider)
-          gptel-model model))
-  (message "gptel: %s / %s%s" provider model (if local " (buffer-local)" "")))
+  (let ((backend (ai/llm-backend provider)))
+    (if local
+        (progn
+          (setq-local gptel-backend backend)
+          (setq-local gptel-model model))
+      (setq ai/llm-provider provider
+            ai/llm-model model
+            gptel-backend backend
+            gptel-model model)))
+  (message "gptel: %s / %s%s"
+           provider model (if local " (buffer-local)" "")))
 
 (defun ai/llm-use-glm-5.2 (&optional local)
   "Use GLM-5.2 through Z.AI.
@@ -211,39 +220,64 @@ With prefix argument LOCAL, apply only in the current buffer."
   (ai/llm-use 'zai 'glm-5.2 local))
 
 (defun ai/llm-use-gpt-5.6-sol (&optional local)
-  "Use GPT-5.6 Sol through OpenAI.
+  "Use GPT-5.6 Sol through the OpenAI API.
 With prefix argument LOCAL, apply only in the current buffer."
   (interactive "P")
   (ai/llm-use 'openai 'gpt-5.6-sol local))
 
+(defun ai/llm-use-openai-oauth (&optional local)
+  "Use GPT-5.6 Sol through an OpenAI subscription OAuth session.
+With prefix argument LOCAL, apply only in the current buffer."
+  (interactive "P")
+  (ai/llm-use 'openai-oauth 'gpt-5.6-sol local))
+
+(defun ai/llm-openai-oauth-login ()
+  "Authenticate gptel's OpenAI subscription backend."
+  (interactive)
+  (require 'gptel-openai-oauth)
+  (gptel-openai-oauth-login (ai/llm-backend 'openai-oauth)))
+
 (defun ai/llm-apply-defaults ()
-  "Apply shared modern gptel defaults."
+  "Apply shared defaults for current gptel."
   (setq gptel-backend (ai/llm-backend ai/llm-provider)
         gptel-model ai/llm-model
         gptel-default-mode 'org-mode
+        gptel-stream t
+        gptel-use-curl t
         gptel-use-tools t
-        gptel-confirm-tool-calls t
-        gptel-include-reasoning t
-        gptel-org-branching-context t
+        gptel-confirm-tool-calls 'auto
+        gptel-include-tool-results 'auto
+        gptel-use-context 'system
+        gptel-include-reasoning 'ignore
         gptel-track-response t
-        gptel-use-header-line t
-        gptel-context-restrict-to-project-files t))
+        gptel-org-convert-response t
+        gptel-org-branching-context t
+        gptel-use-header-line t))
 
 (ai/llm-apply-defaults)
 
 (gptel-make-preset 'glm-5.2
-  :description "GLM-5.2 with Z.AI, one-million-token model option available."
+  :description "GLM-5.2 through Z.AI with thinking and tool use."
   :backend (ai/llm-backend 'zai)
   :model 'glm-5.2
   :stream t
-  :include-reasoning t)
+  :include-reasoning 'ignore)
 
 (gptel-make-preset 'gpt-5.6-sol
-  :description "OpenAI GPT-5.6 Sol for complex reasoning and coding."
+  :description "GPT-5.6 Sol through the OpenAI Responses API."
   :backend (ai/llm-backend 'openai)
   :model 'gpt-5.6-sol
   :stream t
-  :include-reasoning t)
+  :request-params '(:reasoning (:effort "high" :summary "auto"))
+  :include-reasoning 'ignore)
+
+(gptel-make-preset 'gpt-5.6-sol-oauth
+  :description "GPT-5.6 Sol through OpenAI subscription OAuth."
+  :backend (ai/llm-backend 'openai-oauth)
+  :model 'gpt-5.6-sol
+  :stream t
+  :request-params '(:reasoning (:effort "high" :summary "auto"))
+  :include-reasoning 'ignore)
 
 (provide 'ai)
 ;;; ai.el ends here

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -248,6 +248,7 @@ With prefix argument LOCAL, apply only in the current buffer."
         gptel-confirm-tool-calls 'auto
         gptel-include-tool-results 'auto
         gptel-use-context 'system
+        gptel-context-restrict-to-project-files t
         gptel-include-reasoning 'ignore
         gptel-track-response t
         gptel-org-convert-response t

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -6,7 +6,14 @@
 * Defaults
 
 The local gptel stack defaults to Z.AI =glm-5.2=.  OpenAI
-=gpt-5.6-sol= is available as a first-class Responses API backend.
+=gpt-5.6-sol= is available through both the OpenAI Responses API and gptel's
+OpenAI subscription OAuth backend.
+
+The configuration tracks current upstream gptel instead of Doom's older pin.
+Modern defaults enable streaming, curl transport, tool use, per-tool automatic
+confirmation, automatic tool-result retention, Org response conversion,
+branching Org context, response tracking, and reasoning blocks that are shown
+but excluded from subsequent prompts.
 
 API keys are resolved from environment variables first and then
 =auth-source=:
@@ -35,23 +42,45 @@ The public =ai-agent= and =ai-agent-core= features use matching loader
 filenames.  Their implementations remain split into =agent.el= and
 =agent-core.el=.
 
+After pulling this configuration, update gptel and regenerate Doom's package
+state:
+
+#+begin_src shell
+doom sync -u
+#+end_src
+
 * Model switching
 
 #+begin_src emacs-lisp
 (ai/llm-use-glm-5.2)
 (ai/llm-use-gpt-5.6-sol)
+(ai/llm-use-openai-oauth)
 #+end_src
 
-The same switches are exposed as =M-x +llm/use-glm-5.2= and
-=M-x +llm/use-gpt-5.6-sol=.  A prefix argument makes the selection
-buffer-local.
+The same switches are exposed as =M-x +llm/use-glm-5.2=,
+=M-x +llm/use-gpt-5.6-sol=, and =M-x +llm/use-openai-oauth=.  A prefix
+argument makes the selection buffer-local.
 
 Available presets:
 
 - =@glm-5.2=
 - =@gpt-5.6-sol=
+- =@gpt-5.6-sol-oauth=
 - =@agent= — GLM-5.2 with the project agent tools
 - =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tools
+
+* OpenAI subscription OAuth
+
+Current gptel can authenticate a ChatGPT subscription without storing an API
+key.  Run:
+
+#+begin_src emacs-lisp
+M-x +llm/openai-login
+M-x +llm/use-openai-oauth
+#+end_src
+
+The normal browser authorization-code flow is used locally.  Over SSH, set
+=gptel-openai-oauth-login-method= to =device= before logging in.
 
 * Proxmox MCP
 


### PR DESCRIPTION
## What changed

- track current upstream `karthink/gptel` instead of Doom's older package pin
- keep the literate `packages.org` source and generated `packages.el` synchronized
- use gptel's current OpenAI Responses API backend and built-in GPT-5.6 model metadata
- update model capability names to current gptel (`reasoning`, `tool-use`, `responses-api` where supplied upstream)
- replace blanket tool confirmation with the current per-tool `auto` policy
- enable current tool-result retention, project-only context, Org response conversion, streaming, curl transport, and reasoning handling
- add optional OpenAI ChatGPT Plus/Pro OAuth login and model switching
- make the shared `lisp/llm/ai.el` settings authoritative after all Doom/use-package gptel callbacks
- preserve the existing directive and Org prefix customization while preventing its stale OpenRouter model/backend assignment from winning
- document the updated setup and required `doom sync -u`

## Root cause

The previous overhaul added agent loaders and newer model names but left two stale layers in place: Doom still selected an older pinned gptel package, and `.doom.d/config.org` still installed an active legacy OpenRouter backend when gptel loaded. That mixed current model configuration with stale capability names, duplicated OpenAI metadata, and omitted gptel's modern Responses/OAuth paths.

## Validation

- compared each configured option and constructor against current upstream gptel master
- confirmed current gptel automatically selects `/v1/responses` for `api.openai.com`
- confirmed current upstream includes GPT-5.6 Sol/Terra/Luna metadata and the OpenAI OAuth constructor
- verified the delayed finalizer runs after gptel's load callbacks, so the shared backend survives the legacy Doom block
- checked the modified Elisp files for balanced forms
- inspected the branch diff for unrelated file changes

Live Emacs execution is delegated to the repository's Nix CI because Emacs/Nix are not installed in the tool runtime.