### PR TITLE
feat(discord-mcp): add Discord MCP server for doom emacs

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -44,6 +44,72 @@
              (executable-find "proxmox-mcp-launcher"))
     (+llm/proxmox-register)))
 
+(defcustom +llm/discord-auth-host "discord"
+  "auth-source host used to look up the Discord bot token."
+  :type 'string
+  :group 'applications)
+
+(defcustom +llm/discord-auth-user "bot"
+  "auth-source user used to look up the Discord bot token."
+  :type 'string
+  :group 'applications)
+
+(defun +llm/discord-token ()
+  "Return the Discord bot token from auth-source, or nil.
+The token is read from the auth-source entry whose host matches
+`+llm/discord-auth-host' and user `+llm/discord-auth-user'.  Add
+the entry to `~/.authinfo.gpg' as:
+
+    machine discord login bot password TOKEN"
+  (when-let* ((entry (car (auth-source-search
+                           :host +llm/discord-auth-host
+                           :user +llm/discord-auth-user
+                           :max 1)))
+              (secret (plist-get entry :secret)))
+    (if (functionp secret)
+        (funcall secret)
+      secret)))
+
+;;;###autoload
+(defun +llm/discord-register (&optional noerror)
+  "Register the local Discord MCP launcher with mcp.el.
+The launcher is provided by Home Manager and runs the nix-built
+discordmcp server.  The DISCORD_TOKEN env var is injected from
+auth-source so the token never lives in the dotfiles repository.
+
+With optional NOERROR non-nil, skip silently when the launcher or
+token are unavailable instead of signaling a `user-error'."
+  (interactive)
+  (cond
+   ((and (not noerror) (not (executable-find "discord-mcp-launcher")))
+    (user-error "discord-mcp-launcher is not on exec-path; apply Home Manager first"))
+   ((not (executable-find "discord-mcp-launcher"))
+    (message "Discord MCP: launcher not found on exec-path; skipping"))
+   (t
+    (let ((token (+llm/discord-token)))
+      (cond
+       ((and token (not (string-empty-p token)))
+        (setq mcp-hub-servers
+              (cons `("discord" . (:command "discord-mcp-launcher"
+                                    :env (:DISCORD_TOKEN ,token)))
+                    (assoc-delete-all "discord" mcp-hub-servers)))
+        (message "Discord MCP: registered discord-mcp-launcher"))
+       (noerror
+        (message "Discord MCP: no token in auth-source (host=%s user=%s); skipping"
+                  +llm/discord-auth-host +llm/discord-auth-user))
+       (t
+        (user-error "No Discord token in auth-source (host=%s user=%s); add it to ~/.authinfo.gpg"
+                    +llm/discord-auth-host +llm/discord-auth-user)))))))
+
+;;;###autoload
+(defun +llm/discord-connect ()
+  "Register and connect the Discord MCP tools to gptel."
+  (interactive)
+  (require 'gptel-integrations)
+  (require 'mcp-hub)
+  (+llm/discord-register)
+  (gptel-mcp-connect '("discord")))
+
 ;;;###autoload
 (defun +llm/load ()
   "Load the complete local LLM configuration."

--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -935,6 +935,9 @@ strings."
   :config
   (require 'gptel-integrations)
   (require 'mcp-hub)
+  ;; Register launcher-backed MCP servers.  Discord reads its token
+  ;; from auth-source; it is a no-op until the launcher exists.
+  (+llm/discord-register 'noerror)
   (gptel-mcp-connect))
 
 (map!

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -1404,6 +1404,20 @@ Start a todo chat with tools needed
 *** MCP Configuration
 
 
+The =mcp= package ([[https://github.com/lizqwerscott/mcp.el][lizqwerscott/mcp.el]]) wires MCP servers into gptel.  The built-in servers are declared via =:custom=; launcher-backed servers (Proxmox, Discord) register themselves through autoloads in =autoload/llm.el= so their secrets stay out of the repo.
+
+**** Discord MCP
+
+The Discord MCP server ([[https://github.com/v-3/discordmcp][v-3/discordmcp]]) is built by Home Manager as a nix derivation ([[../nix/home-manager/mods/discord-mcp.nix][discord-mcp.nix]]) and exposed on =exec-path= as =discord-mcp-launcher=.  It talks stdio and exposes =send-message= / =read-messages= tools.
+
+The =DISCORD_TOKEN= is injected from [[https://www.gnu.org/software/emacs/manual/html_mono/auth.html][auth-source]] (kept in =~/.authinfo.gpg=) so the bot token never lands in version control.  Add the entry once:
+
+#+begin_example
+machine discord login bot password YOUR_BOT_TOKEN_HERE
+#+end_example
+
+The host and user are customizable via =+llm/discord-auth-host= and =+llm/discord-auth-user=.  Registration is deferred to =mcp-hub= load time and skipped (non-fatal) when the launcher or token are missing, so a fresh checkout still boots.
+
 #+begin_src emacs-lisp
  (use-package! mcp
   :after gptel
@@ -1420,6 +1434,9 @@ Start a todo chat with tools needed
   :config
   (require 'gptel-integrations)
   (require 'mcp-hub)
+  ;; Register launcher-backed MCP servers.  Discord reads its token
+  ;; from auth-source; it is a no-op until the launcher exists.
+  (+llm/discord-register 'noerror)
   (gptel-mcp-connect))
 #+end_src
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 tmp/
 *discord*
+!nix/home-manager/mods/discord-mcp.nix
 *.pyc
 *;;
 .config/starintel/*.ini

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -14,5 +14,6 @@
     ./pentesting.nix
     ./llm.nix
     ./proxmox-mcp.nix
+    ./discord-mcp.nix
   ];
 }

--- a/nix/home-manager/mods/discord-mcp.nix
+++ b/nix/home-manager/mods/discord-mcp.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.discordMcp;
+
+  discordMcp = pkgs.buildNpmPackage {
+    pname = "discord-mcp-server";
+    version = "1.0.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "v-3";
+      repo = "discordmcp";
+      rev = cfg.rev;
+      hash = cfg.hash;
+    };
+    npmDepsHash = cfg.npmDepsHash;
+  };
+
+  discordMcpIndex =
+    "${discordMcp}/lib/node_modules/discord-mcp-server/build/index.js";
+
+  discordMcpLauncher = pkgs.writeShellApplication {
+    name = "discord-mcp-launcher";
+    runtimeInputs = [ pkgs.nodejs_22 ];
+    text = ''
+      if [ -z "''${DISCORD_TOKEN:-}" ]; then
+        echo "discord-mcp-launcher: DISCORD_TOKEN is not set in the environment." >&2
+        echo "The Emacs client injects it via mcp.el :env from auth-source." >&2
+        exit 1
+      fi
+      exec node "${discordMcpIndex}" "$@"
+    '';
+  };
+in
+{
+  options.discordMcp = {
+    enable = lib.mkEnableOption "Emacs-native Discord MCP integration";
+
+    rev = lib.mkOption {
+      type = lib.types.str;
+      default = "39622af0333bcd324e811a2390146927517fb03d";
+      description = "Pinned upstream discordmcp revision to build.";
+    };
+
+    hash = lib.mkOption {
+      type = lib.types.str;
+      default = "sha256-zmWU9zDEJDvH0ywW990DgbDTdlxyQ8OIQ1okEUQNIuY=";
+      description = "SRI hash of the upstream discordmcp source tarball.";
+    };
+
+    npmDepsHash = lib.mkOption {
+      type = lib.types.str;
+      default = "sha256-ONRO9smF8JSD1C5Xr4q3sET+83OaRqTbGxRbiryYg9A=";
+      description = "SRI hash of the discordmcp npm dependency closure.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ discordMcpLauncher ];
+  };
+}

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -24,6 +24,10 @@
     enable = true;
   };
 
+  discordMcp = {
+    enable = true;
+  };
+
   emacs = {
     enable = true;
     # I mostly use magit hence configured in the ./nixos/mods/emacs.nix module


### PR DESCRIPTION
Builds [`v-3/discordmcp`](https://github.com/v-3/discordmcp) as a nix derivation (`buildNpmPackage`) and exposes it as a Home Manager-managed `discord-mcp-launcher` on `exec-path`, then wires it into doom's `mcp.el` / gptel stack.

## Nix
- `nix/home-manager/mods/discord-mcp.nix`: builds discordmcp from a pinned upstream rev via `buildNpmPackage` and ships a `discord-mcp-launcher` shell wrapper that injects `DISCORD_TOKEN` and execs `node build/index.js`.
- Registered in `mods/default.nix` and enabled in `systems/desktop/home.nix` (mirrors the existing `proxmoxMcp` module).
- `buildNpmPackage` hash + `npmDepsHash` are pinned; `nix build .#unseen-home` succeeds.

## Emacs (doom)
- `autoload/llm.el`:
  - `+llm/discord-token` reads the bot token from **auth-source** (`~/.authinfo.gpg`), so the secret never enters the repo. Entry format: `machine discord login bot password <TOKEN>`
  - `+llm/discord-register` adds the server to `mcp-hub-servers` with `:env (:DISCORD_TOKEN <token>)`, which `mcp.el` forwards to the process via `setenv`.
  - Registration is deferred to `mcp-hub` load time and **non-fatal** when the launcher or token are missing, so a fresh checkout still boots.
  - `+llm/discord-connect` for interactive `M-x` use.
- `config.org` (literate source of truth) + `config.el` (tangled): call `(+llm/discord-register 'noerror)` in the `mcp` `:config` block.

## Verification
- `nix build .#unseen-home` succeeds; `discord-mcp-launcher` installs on the path.
- Launcher rejects a missing `DISCORD_TOKEN`, and passes a present token through to `discord.js` (verified `TokenInvalid` on a dummy).
- `autoload/llm.el` byte-compiles with only pre-existing free-variable warnings.
- Traced `mcp-connect-server` to confirm the `:env` plist shape (`(:DISCORD_TOKEN "<token>")` -> env var `DISCORD_TOKEN`) is what mcp.el expects.

## Post-merge setup
Add to `~/.authinfo.gpg`:
```
machine discord login bot password YOUR_BOT_TOKEN
```
Then rebuild Home Manager and restart emacs.