### PR TITLE
Modernize gptel models and MCP startup

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -1,9 +1,19 @@
 ;;; llm.el --- Doom autoloads for the local gptel stack -*- lexical-binding: t; -*-
 
+(require 'auth-source)
+(require 'subr-x)
+
+;;;###autoload
 (defcustom +llm/proxmox-config-file
   (expand-file-name "~/.config/proxmox-mcp/config.json")
   "JSON configuration used by the Emacs Proxmox MCP server."
   :type 'file
+  :group 'applications)
+
+;;;###autoload
+(defcustom +llm/mcp-auto-connect t
+  "When non-nil, start configured MCP servers after gptel loads."
+  :type 'boolean
   :group 'applications)
 
 (defun +llm/proxmox-register ()
@@ -20,6 +30,7 @@
   "Make the shared gptel configuration authoritative after package setup."
   (when (featurep 'gptel)
     (require 'ai)
+    (require 'ai-agent nil t)
     (ai/llm-apply-defaults)))
 
 ;;;###autoload
@@ -32,23 +43,12 @@
   (gptel-mcp-connect '("proxmox")))
 
 ;;;###autoload
-(with-eval-after-load 'gptel
-  (require 'ai)
-  (require 'ai-agent)
-  ;; Run after every `eval-after-load' and `use-package!' callback for gptel.
-  (run-at-time 0 nil #'+llm/apply-final-defaults))
-
-;;;###autoload
-(with-eval-after-load 'mcp-hub
-  (when (and (file-readable-p +llm/proxmox-config-file)
-             (executable-find "proxmox-mcp-launcher"))
-    (+llm/proxmox-register)))
-
 (defcustom +llm/discord-auth-host "discord"
   "auth-source host used to look up the Discord bot token."
   :type 'string
   :group 'applications)
 
+;;;###autoload
 (defcustom +llm/discord-auth-user "bot"
   "auth-source user used to look up the Discord bot token."
   :type 'string
@@ -96,7 +96,7 @@ token are unavailable instead of signaling a `user-error'."
         (message "Discord MCP: registered discord-mcp-launcher"))
        (noerror
         (message "Discord MCP: no token in auth-source (host=%s user=%s); skipping"
-                  +llm/discord-auth-host +llm/discord-auth-user))
+                 +llm/discord-auth-host +llm/discord-auth-user))
        (t
         (user-error "No Discord token in auth-source (host=%s user=%s); add it to ~/.authinfo.gpg"
                     +llm/discord-auth-host +llm/discord-auth-user)))))))
@@ -111,11 +111,53 @@ token are unavailable instead of signaling a `user-error'."
   (gptel-mcp-connect '("discord")))
 
 ;;;###autoload
+(defun +llm/mcp-connect-all (&optional noerror)
+  "Start configured MCP servers and add their tools to gptel.
+With optional NOERROR non-nil, report startup failures without aborting Emacs."
+  (interactive)
+  (condition-case err
+      (progn
+        (require 'gptel-integrations)
+        (require 'mcp-hub)
+        (+llm/discord-register 'noerror)
+        (when (and (boundp '+llm/proxmox-config-file)
+                   (file-readable-p +llm/proxmox-config-file)
+                   (executable-find "proxmox-mcp-launcher"))
+          (+llm/proxmox-register))
+        ;; Current gptel starts inactive servers before registering their tools.
+        (gptel-mcp-connect)
+        t)
+    (error
+     (if noerror
+         (progn
+           (message "MCP startup skipped: %s" (error-message-string err))
+           nil)
+       (signal (car err) (cdr err))))))
+
+;;;###autoload
+(with-eval-after-load 'gptel
+  ;; Run after every `eval-after-load' and `use-package!' callback for gptel.
+  ;; This defeats older config fragments that still set OpenRouter as default.
+  (run-at-time 0 nil #'+llm/apply-final-defaults)
+  (when (bound-and-true-p +llm/mcp-auto-connect)
+    (run-at-time 0.75 nil #'+llm/mcp-connect-all 'noerror)))
+
+;;;###autoload
+(with-eval-after-load 'mcp-hub
+  ;; Guard the variable because this form is copied into Doom's generated
+  ;; autoload file and may run before this source file itself is loaded.
+  (when (and (boundp '+llm/proxmox-config-file)
+             (file-readable-p +llm/proxmox-config-file)
+             (executable-find "proxmox-mcp-launcher"))
+    (+llm/proxmox-register)))
+
+;;;###autoload
 (defun +llm/load ()
   "Load the complete local LLM configuration."
   (interactive)
   (require 'ai-init)
   (ai/llm-apply-defaults)
+  (+llm/mcp-connect-all 'noerror)
   (message "LLM stack loaded: %s / %s" ai/llm-provider ai/llm-model))
 
 ;;;###autoload
@@ -138,6 +180,20 @@ token are unavailable instead of signaling a `user-error'."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-gpt-5.6-sol local))
+
+;;;###autoload
+(defun +llm/use-gpt-luna (&optional local)
+  "Switch to OpenAI API GPT-5.6 Luna."
+  (interactive "P")
+  (require 'ai)
+  (ai/llm-use-gpt-luna local))
+
+;;;###autoload
+(defun +llm/use-fable (&optional local)
+  "Switch to Anthropic Claude Fable 5."
+  (interactive "P")
+  (require 'ai)
+  (ai/llm-use-fable local))
 
 ;;;###autoload
 (defun +llm/use-openai-oauth (&optional local)

--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -26,6 +26,7 @@
         (cons '("proxmox" . (:command "proxmox-mcp-launcher"))
               (assoc-delete-all "proxmox" mcp-hub-servers))))
 
+;;;###autoload
 (defun +llm/apply-final-defaults ()
   "Make the shared gptel configuration authoritative after package setup."
   (when (featurep 'gptel)

--- a/.doom.d/autoload/org-agenda-compat.el
+++ b/.doom.d/autoload/org-agenda-compat.el
@@ -1,0 +1,16 @@
+;;; org-agenda-compat.el --- Doom startup compatibility -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; `setq!' validates user options through their Customize widget.  Current
+;; org-super-agenda declares `org-super-agenda-groups' too narrowly for valid
+;; nested selectors such as :and/:not and selector value lists.  Treat the
+;; option as a general Lisp expression before config.el assigns it.
+
+;;; Code:
+
+;;;###autoload
+(with-eval-after-load 'org-super-agenda
+  (put 'org-super-agenda-groups 'custom-type 'sexp))
+
+(provide '+org-agenda-compat)
+;;; org-agenda-compat.el ends here

--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -89,7 +89,7 @@
 
 (package! podman.el :recipe (:type git :host github :repo "akirak/podman.el"))
 
-(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode.el"))
+(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
 
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 
@@ -123,7 +123,7 @@
 
 (package! org-contrib)
 
-(package! ppcre2el :recipe (:type git :host github :repo "joddie/ppcre2el"))
+(package! ppcre2el :recipe (:type git :host github :repo "joddie/pcre2el"))
 
 (package! rx)
 

--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -111,7 +111,7 @@
 
 (package! dash :recipe (:type git :host github :repo "magnars/dash.el"))
 
-(package! s.el :recipe (:type git :host github :repo "magnars/s.el"))
+(package! s :recipe (:type git :host github :repo "magnars/s.el"))
 
 (package! alert :recipe (:type git :host github :repo "jwiegley/alert"))
 

--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -46,6 +46,11 @@
 
 (package! org-drill)
 
+;; Current gptel requires a modern Transient.  Keep Transient and Dirvish on
+;; the same rebuild path to avoid EIEIO class/slot ABI mismatches.
+(unpin! transient)
+(package! transient :recipe (:host github :repo "magit/transient"))
+
 (unpin! gptel)
 (package! gptel
   :recipe (:host github :repo "karthink/gptel"
@@ -84,7 +89,7 @@
 
 (package! podman.el :recipe (:type git :host github :repo "akirak/podman.el"))
 
-(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
+(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode.el"))
 
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 
@@ -106,7 +111,7 @@
 
 (package! dash :recipe (:type git :host github :repo "magnars/dash.el"))
 
-(package! s :recipe (:type git :host github :repo "magnars/s.el"))
+(package! s.el :recipe (:type git :host github :repo "magnars/s.el"))
 
 (package! alert :recipe (:type git :host github :repo "jwiegley/alert"))
 
@@ -118,7 +123,7 @@
 
 (package! org-contrib)
 
-(package! ppcre2el :recipe (:type git :host github :repo "joddie/pcre2el"))
+(package! ppcre2el :recipe (:type git :host github :repo "joddie/ppcre2el"))
 
 (package! rx)
 

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -112,6 +112,13 @@ Create Flashcards from
 #+end_src
 
 * AI
+** transient
+Current gptel requires a modern Transient.  Tracking it with gptel ensures
+Dirvish and gptel are rebuilt against the same EIEIO class definitions.
+#+begin_src emacs-lisp
+(unpin! transient)
+(package! transient :recipe (:host github :repo "magit/transient"))
+#+end_src
 ** gptel
 Interact with LLMs from Org mode and expose current tool, reasoning, Responses
 API, and OpenAI subscription OAuth support.  Track upstream gptel instead of
@@ -129,17 +136,16 @@ GPTEL supports MCP.
 #+end_src
 * Development
 ** envrc
-A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in those files. This allows different versions of linters and other tools to be used in each project if desired.
-
+A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed in the context of that project's .envrc.
 #+begin_src emacs-lisp
 (package! envrc :recipe (:type git :host github :repo "purcell/envrc"))
 #+end_src
 
 ** protobufs
-
 #+begin_src emacs-lisp
 ;(package! protobuf-mode)
 #+end_src
+
 ** Langauges
 **** Nim lang
 ***** Nim Mode
@@ -149,7 +155,7 @@ Doom's Version is way too old.
 ;(unpin! nim-mode :pin "1338e5b0d5e111ad932efb77d3cad680cc3b86c9")
 #+end_src
 ***** flycheck-nim
-Flycheck-nim is a syntax checker definition for flycheck which supports the Nim programming language using the nim compiler as the backend.
+Flycheck-nim is a syntax checker definition for Nim.
 #+begin_src emacs-lisp
 ;;(package! flycheck-nim :recipe (:type git :host github :repo "ALSchwalm/flycheck-nim"))
 #+end_src
@@ -163,8 +169,7 @@ major mode for gforth
 #+begin_src emacs-lisp
 ;(package! gforth.el :recipe (:type git :host github :repo "smtlaissezfaire/gforth.el"))
 #+end_src
-
-**** nix
+***** nix
 **** Python
 #+begin_src emacs-lisp
 (package! lsp-pyright :recipe (:type git :host github :repo "emacs-lsp/lsp-pyright"))
@@ -191,6 +196,7 @@ Org babel functions for prolog.
 #+end_src
 ** Magit
 *** Magit Todos
+Show TODOs in Magit.
 #+begin_src emacs-lisp
 (package! magit-todos :recipe (:type git :host github :repo "alphapapa/magit-todos"))
 #+end_src
@@ -208,51 +214,46 @@ paste your buffer to a pastebin like service.
 (package! webpaste :recipe (:type git :host github :repo "etu/webpaste.el"))
 #+end_src
 ** Burly
-This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows, the windows’ layout, and their buffers.
-
+Save and restore frame and window configurations.
 #+begin_src emacs-lisp
 (package! burly :recipe (:type git :host github :repo "alphapapa/burly.el"))
 #+end_src
 ** podman.el
-Manage podman containers
+Manage podman containers from Emacs.
 #+begin_src emacs-lisp
 (package! podman.el :recipe (:type git :host github :repo "akirak/podman.el"))
 #+end_src
 
 ** pcap-mode.el
-A major mode for view pcap capture files
+A major mode to view pcap files.
 #+begin_src emacs-lisp
-(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
+(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode.el"))
 #+end_src
 ** exec-path-from-shell
-A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user's shell.
+Import shell environment variables into Emacs.
 #+begin_src emacs-lisp
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 #+end_src
 
 ** cheat-sh
-get cheatsheets
+Get cheatsheets.
 #+begin_src emacs-lisp
 (package! cheat-sh :recipe (:type git :host github :repo "davep/cheat-sh.el"))
 #+end_src
 
 ** activity watch
-keep track of time.
+Track time in Emacs.
 #+begin_src emacs-lisp
 (package! activity-watch-mode :recipe (:type git :host github :repo "pauldub/activity-watch-mode"))
 #+end_src
 
 ** Discover
-Find more of emacs using context menus
+Context menus for discovering commands.
 #+begin_src emacs-lisp
 (package! discover :recipe (:type git :host github :repo "mickeynp/discover.el"))
 #+end_src
 ** atomic-chrome
-This is the Emacs version of Atomic Chrome which is an extension for Google
-Chrome browser that allows you to edit text areas of the browser in Emacs.
-
-It's similar to Edit with Emacs, but has some advantages as below with the
-help of websocket.
+Edit browser text areas in Emacs.
 #+begin_src emacs-lisp
 (package! atomic-chrome)
 #+end_src
@@ -266,8 +267,6 @@ help of websocket.
 ** yassnippets collection
 #+begin_src emacs-lisp :tangle yes
 (package! yasnippet-snippets)
-
-
 #+end_src
 ** skeletor.el
 #+begin_src emacs-lisp
@@ -275,55 +274,51 @@ help of websocket.
 #+end_src
 * Lib packages
 ** plz
-plz is an HTTP library for Emacs. It uses curl as a backend, which avoids some of the issues with using Emacs’s built-in url library.
+HTTP library using curl.
 #+begin_src emacs-lisp
 (package! plz :recipe (:type git :host github :repo "alphapapa/plz.el"))
 #+end_src
 
 ** dash
-A modern list API for Emacs. No 'cl required.
+Modern list API.
 #+begin_src emacs-lisp
 (package! dash :recipe (:type git :host github :repo "magnars/dash.el"))
 #+end_src
 ** s.el
-Long lost string manipulation lib.
+String library.
 #+begin_src emacs-lisp
 (package! s :recipe (:type git :host github :repo "magnars/s.el"))
 #+end_src
 ** alert
-Send alerts
+Send alerts.
 #+begin_src emacs-lisp
 (package! alert :recipe (:type git :host github :repo "jwiegley/alert"))
 #+end_src
 ** f.el
-Modern api for files. I use this in my code, i find this library suitable for quick url hacks like joining great.
+Modern file API.
 #+begin_src emacs-lisp
 (package! f)
 #+end_src
 ** Async
-Async.el is for doing async processing in emacs. I use it for hack-mode.el
-Looks likes its already in doom emacs...
+Async processing in Emacs.
 #+begin_src emacs-lisp
 (package! emacs-async :recipe (:type git :host github :repo "jwiegley/emacs-async"))
 #+end_src
 
 ** jeison
-Parsing json in a declarative manner
-Personally i find in other languages like nim creating a type then marshaling json into it is the best way to deal with json IMO
+Parse JSON declaratively.
 #+begin_src emacs-lisp
 ;(package! jeison)
 #+end_src
 ** org-contrib
-
 #+begin_src emacs-lisp
 (package! org-contrib)
 #+end_src
-** REGEX
-Required By magit todos.
-pcre2el: convert between PCRE, Emacs and rx regexp syntax
 
+** REGEX
+Required by magit-todos.
 #+begin_src emacs-lisp
-(package! ppcre2el :recipe (:type git :host github :repo "joddie/pcre2el"))
+(package! ppcre2el :recipe (:type git :host github :repo "joddie/ppcre2el"))
 #+end_src
 
 #+begin_src emacs-lisp

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -113,8 +113,8 @@ Create Flashcards from
 
 * AI
 ** transient
-Current gptel requires a modern Transient.  Tracking it with gptel ensures
-Dirvish and gptel are rebuilt against the same EIEIO class definitions.
+Current gptel requires a modern Transient.  Track it with gptel so Dirvish and
+gptel are rebuilt against the same EIEIO class definitions.
 #+begin_src emacs-lisp
 (unpin! transient)
 (package! transient :recipe (:host github :repo "magit/transient"))
@@ -136,16 +136,17 @@ GPTEL supports MCP.
 #+end_src
 * Development
 ** envrc
-A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed in the context of that project's .envrc.
+A GNU Emacs library which uses direnv to set environment variables on a per-buffer basis. This means that when you work across multiple projects which have .envrc files, all processes launched from the buffers "in" those projects will be executed with the environment variables specified in those files. This allows different versions of linters and other tools to be used in each project if desired.
+
 #+begin_src emacs-lisp
 (package! envrc :recipe (:type git :host github :repo "purcell/envrc"))
 #+end_src
 
 ** protobufs
+
 #+begin_src emacs-lisp
 ;(package! protobuf-mode)
 #+end_src
-
 ** Langauges
 **** Nim lang
 ***** Nim Mode
@@ -155,7 +156,7 @@ Doom's Version is way too old.
 ;(unpin! nim-mode :pin "1338e5b0d5e111ad932efb77d3cad680cc3b86c9")
 #+end_src
 ***** flycheck-nim
-Flycheck-nim is a syntax checker definition for Nim.
+Flycheck-nim is a syntax checker definition for flycheck which supports the Nim programming language using the nim compiler as the backend.
 #+begin_src emacs-lisp
 ;;(package! flycheck-nim :recipe (:type git :host github :repo "ALSchwalm/flycheck-nim"))
 #+end_src
@@ -169,7 +170,8 @@ major mode for gforth
 #+begin_src emacs-lisp
 ;(package! gforth.el :recipe (:type git :host github :repo "smtlaissezfaire/gforth.el"))
 #+end_src
-***** nix
+
+**** nix
 **** Python
 #+begin_src emacs-lisp
 (package! lsp-pyright :recipe (:type git :host github :repo "emacs-lsp/lsp-pyright"))
@@ -196,7 +198,6 @@ Org babel functions for prolog.
 #+end_src
 ** Magit
 *** Magit Todos
-Show TODOs in Magit.
 #+begin_src emacs-lisp
 (package! magit-todos :recipe (:type git :host github :repo "alphapapa/magit-todos"))
 #+end_src
@@ -214,46 +215,51 @@ paste your buffer to a pastebin like service.
 (package! webpaste :recipe (:type git :host github :repo "etu/webpaste.el"))
 #+end_src
 ** Burly
-Save and restore frame and window configurations.
+This package provides tools to save and restore frame and window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore one or more frames, including their windows, the windows’ layout, and their buffers.
+
 #+begin_src emacs-lisp
 (package! burly :recipe (:type git :host github :repo "alphapapa/burly.el"))
 #+end_src
 ** podman.el
-Manage podman containers from Emacs.
+Manage podman containers
 #+begin_src emacs-lisp
 (package! podman.el :recipe (:type git :host github :repo "akirak/podman.el"))
 #+end_src
 
 ** pcap-mode.el
-A major mode to view pcap files.
+A major mode for view pcap capture files
 #+begin_src emacs-lisp
-(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode.el"))
+(package! pcap-mode.el :recipe (:type git :host github :repo "orgcandman/pcap-mode"))
 #+end_src
 ** exec-path-from-shell
-Import shell environment variables into Emacs.
+A GNU Emacs library to ensure environment variables inside Emacs look the same as in the user's shell.
 #+begin_src emacs-lisp
 (package! exec-path-from-shell  :recipe (:type git :host github :repo "purcell/exec-path-from-shell"))
 #+end_src
 
 ** cheat-sh
-Get cheatsheets.
+get cheatsheets
 #+begin_src emacs-lisp
 (package! cheat-sh :recipe (:type git :host github :repo "davep/cheat-sh.el"))
 #+end_src
 
 ** activity watch
-Track time in Emacs.
+keep track of time.
 #+begin_src emacs-lisp
 (package! activity-watch-mode :recipe (:type git :host github :repo "pauldub/activity-watch-mode"))
 #+end_src
 
 ** Discover
-Context menus for discovering commands.
+Find more of emacs using context menus
 #+begin_src emacs-lisp
 (package! discover :recipe (:type git :host github :repo "mickeynp/discover.el"))
 #+end_src
 ** atomic-chrome
-Edit browser text areas in Emacs.
+This is the Emacs version of Atomic Chrome which is an extension for Google
+Chrome browser that allows you to edit text areas of the browser in Emacs.
+
+It's similar to Edit with Emacs, but has some advantages as below with the
+help of websocket.
 #+begin_src emacs-lisp
 (package! atomic-chrome)
 #+end_src
@@ -267,6 +273,8 @@ Edit browser text areas in Emacs.
 ** yassnippets collection
 #+begin_src emacs-lisp :tangle yes
 (package! yasnippet-snippets)
+
+
 #+end_src
 ** skeletor.el
 #+begin_src emacs-lisp
@@ -274,51 +282,55 @@ Edit browser text areas in Emacs.
 #+end_src
 * Lib packages
 ** plz
-HTTP library using curl.
+plz is an HTTP library for Emacs. It uses curl as a backend, which avoids some of the issues with using Emacs’s built-in url library.
 #+begin_src emacs-lisp
 (package! plz :recipe (:type git :host github :repo "alphapapa/plz.el"))
 #+end_src
 
 ** dash
-Modern list API.
+A modern list API for Emacs. No 'cl required.
 #+begin_src emacs-lisp
 (package! dash :recipe (:type git :host github :repo "magnars/dash.el"))
 #+end_src
 ** s.el
-String library.
+Long lost string manipulation lib.
 #+begin_src emacs-lisp
 (package! s :recipe (:type git :host github :repo "magnars/s.el"))
 #+end_src
 ** alert
-Send alerts.
+Send alerts
 #+begin_src emacs-lisp
 (package! alert :recipe (:type git :host github :repo "jwiegley/alert"))
 #+end_src
 ** f.el
-Modern file API.
+Modern api for files. I use this in my code, i find this library suitable for quick url hacks like joining great.
 #+begin_src emacs-lisp
 (package! f)
 #+end_src
 ** Async
-Async processing in Emacs.
+Async.el is for doing async processing in emacs. I use it for hack-mode.el
+Looks likes its already in doom emacs...
 #+begin_src emacs-lisp
 (package! emacs-async :recipe (:type git :host github :repo "jwiegley/emacs-async"))
 #+end_src
 
 ** jeison
-Parse JSON declaratively.
+Parsing json in a declarative manner
+Personally i find in other languages like nim creating a type then marshaling json into it is the best way to deal with json IMO
 #+begin_src emacs-lisp
 ;(package! jeison)
 #+end_src
 ** org-contrib
+
 #+begin_src emacs-lisp
 (package! org-contrib)
 #+end_src
-
 ** REGEX
-Required by magit-todos.
+Required By magit todos.
+pcre2el: convert between PCRE, Emacs and rx regexp syntax
+
 #+begin_src emacs-lisp
-(package! ppcre2el :recipe (:type git :host github :repo "joddie/ppcre2el"))
+(package! ppcre2el :recipe (:type git :host github :repo "joddie/pcre2el"))
 #+end_src
 
 #+begin_src emacs-lisp

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -86,11 +86,8 @@ Metadata is supplied by current gptel."
      :capabilities (reasoning media tool-use json url)
      :context-window 1050)
     (openai/gpt-5.6-luna
-     :capabilities (reasoning media tool-use json url)
-     :context-window 1050)
-    (anthropic/claude-fable-5
-     :capabilities (media tool-use cache)
-     :context-window 1000))
+     :capabilities (media tool-use json url)
+     :context-window 1050))
   "Models advertised by the OpenRouter backend."
   :type '(repeat sexp)
   :group 'ai/llm)
@@ -320,7 +317,6 @@ With prefix argument LOCAL, apply only in the current buffer."
   :backend (ai/llm-backend 'openai)
   :model 'gpt-5.6-luna
   :stream t
-  :request-params '(:reasoning (:effort "medium" :summary "auto"))
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'gpt-5.6-sol-oauth

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -3,6 +3,8 @@
 (require 'auth-source)
 (require 'cl-lib)
 (require 'gptel)
+(require 'gptel-anthropic)
+(require 'gptel-openai-extras)
 (require 'subr-x)
 
 (defgroup ai/llm nil
@@ -12,10 +14,12 @@
 
 (defcustom ai/llm-provider 'zai
   "Default LLM provider.
-Supported values are `zai', `openai', `openai-oauth', and `openrouter'."
+Supported values are `zai', `openai', `openai-oauth', `anthropic',
+and `openrouter'."
   :type '(choice (const :tag "Z.AI API" zai)
                  (const :tag "OpenAI API" openai)
                  (const :tag "OpenAI subscription OAuth" openai-oauth)
+                 (const :tag "Anthropic API" anthropic)
                  (const :tag "OpenRouter" openrouter))
   :group 'ai/llm)
 
@@ -30,7 +34,7 @@ Supported values are `zai', `openai', `openai-oauth', and `openrouter'."
   :group 'ai/llm)
 
 (defcustom ai/llm-zai-endpoint "/api/paas/v4/chat/completions"
-  "OpenAI-compatible Z.AI chat-completions endpoint."
+  "Z.AI chat-completions endpoint."
   :type 'string
   :group 'ai/llm)
 
@@ -64,6 +68,13 @@ Metadata is supplied by current gptel instead of being duplicated here."
   :type '(repeat symbol)
   :group 'ai/llm)
 
+(defcustom ai/llm-anthropic-models
+  '(claude-fable-5 claude-sonnet-5 claude-opus-4-8)
+  "Anthropic model IDs exposed by the local model switcher.
+Metadata is supplied by current gptel."
+  :type '(repeat symbol)
+  :group 'ai/llm)
+
 (defcustom ai/llm-openrouter-models
   '((z-ai/glm-5.2
      :capabilities (reasoning tool-use json)
@@ -76,7 +87,10 @@ Metadata is supplied by current gptel instead of being duplicated here."
      :context-window 1050)
     (openai/gpt-5.6-luna
      :capabilities (reasoning media tool-use json url)
-     :context-window 1050))
+     :context-window 1050)
+    (anthropic/claude-fable-5
+     :capabilities (media tool-use cache)
+     :context-window 1000))
   "Models advertised by the OpenRouter backend."
   :type '(repeat sexp)
   :group 'ai/llm)
@@ -106,6 +120,11 @@ Environment variables are preferred, then auth-source is consulted."
          (and (fboundp 'nsa/auth-source-get)
               (ignore-errors (nsa/auth-source-get :host "api.openai.com")))
          (ai/llm--auth-source-secret "api.openai.com")))
+    ('anthropic
+     (or (getenv "ANTHROPIC_API_KEY")
+         (and (fboundp 'nsa/auth-source-get)
+              (ignore-errors (nsa/auth-source-get :host "api.anthropic.com")))
+         (ai/llm--auth-source-secret "api.anthropic.com")))
     ('openrouter
      (or (getenv "OPENROUTER_API_KEY")
          (and (fboundp 'nsa/auth-source-get)
@@ -121,9 +140,9 @@ Environment variables are preferred, then auth-source is consulted."
        provider)))
 
 (cl-defun ai/llm-zai-backend (&key (stream t) (name "Z.AI"))
-  "Return a Z.AI OpenAI-compatible backend.
+  "Return a current gptel Z.AI backend.
 STREAM controls response streaming and NAME is the backend display name."
-  (gptel-make-openai name
+  (gptel-make-deepseek name
     :host ai/llm-zai-host
     :endpoint (or (getenv "ZAI_API_ENDPOINT") ai/llm-zai-endpoint)
     :stream stream
@@ -141,6 +160,12 @@ STREAM controls response streaming and NAME is the backend display name."
   "Return gptel's OpenAI subscription OAuth backend."
   (require 'gptel-openai-oauth)
   (gptel-make-openai-oauth name :stream stream))
+
+(cl-defun ai/llm-anthropic-backend (&key (stream t) (name "Anthropic"))
+  "Return the current gptel Anthropic Messages API backend."
+  (gptel-make-anthropic name
+    :stream stream
+    :key (lambda () (ai/llm--require-api-key 'anthropic))))
 
 (cl-defun ai/llm-openrouter-backend (&key (stream t) (name "OpenRouter"))
   "Return an OpenRouter chat-completions backend."
@@ -163,6 +188,7 @@ PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
                    ('zai (ai/llm-zai-backend))
                    ('openai (ai/llm-openai-backend))
                    ('openai-oauth (ai/llm-openai-oauth-backend))
+                   ('anthropic (ai/llm-anthropic-backend))
                    ('openrouter (ai/llm-openrouter-backend))
                    (_ (error "Unsupported LLM provider: %S" provider)))
                  ai/llm--backends))))
@@ -180,6 +206,7 @@ PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
   (pcase (or provider ai/llm-provider)
     ('zai (mapcar #'ai/llm--model-name ai/llm-zai-models))
     ((or 'openai 'openai-oauth) ai/llm-openai-models)
+    ('anthropic ai/llm-anthropic-models)
     ('openrouter (mapcar #'ai/llm--model-name ai/llm-openrouter-models))
     (_ nil)))
 
@@ -190,7 +217,8 @@ With LOCAL non-nil, only change the current buffer."
    (let* ((provider
            (intern
             (completing-read
-             "Provider: " '("zai" "openai" "openai-oauth" "openrouter")
+             "Provider: "
+             '("zai" "openai" "openai-oauth" "anthropic" "openrouter")
              nil t nil nil (symbol-name ai/llm-provider))))
           (available (ai/llm-models-for-provider provider))
           (default (if (memq ai/llm-model available)
@@ -225,6 +253,18 @@ With prefix argument LOCAL, apply only in the current buffer."
   (interactive "P")
   (ai/llm-use 'openai 'gpt-5.6-sol local))
 
+(defun ai/llm-use-gpt-luna (&optional local)
+  "Use GPT-5.6 Luna through the OpenAI Responses API.
+With prefix argument LOCAL, apply only in the current buffer."
+  (interactive "P")
+  (ai/llm-use 'openai 'gpt-5.6-luna local))
+
+(defun ai/llm-use-fable (&optional local)
+  "Use Claude Fable 5 through Anthropic.
+With prefix argument LOCAL, apply only in the current buffer."
+  (interactive "P")
+  (ai/llm-use 'anthropic 'claude-fable-5 local))
+
 (defun ai/llm-use-openai-oauth (&optional local)
   "Use GPT-5.6 Sol through an OpenAI subscription OAuth session.
 With prefix argument LOCAL, apply only in the current buffer."
@@ -243,6 +283,7 @@ With prefix argument LOCAL, apply only in the current buffer."
         gptel-model ai/llm-model
         gptel-default-mode 'org-mode
         gptel-stream t
+        gptel-temperature nil
         gptel-use-curl t
         gptel-use-tools t
         gptel-confirm-tool-calls 'auto
@@ -250,7 +291,9 @@ With prefix argument LOCAL, apply only in the current buffer."
         gptel-use-context 'system
         gptel-context-restrict-to-project-files t
         gptel-include-reasoning 'ignore
+        gptel-track-media t
         gptel-track-response t
+        gptel-cache '(system tool)
         gptel-org-convert-response t
         gptel-org-branching-context t
         gptel-use-header-line t))
@@ -272,12 +315,27 @@ With prefix argument LOCAL, apply only in the current buffer."
   :request-params '(:reasoning (:effort "high" :summary "auto"))
   :include-reasoning 'ignore)
 
+(gptel-make-preset 'gpt-5.6-luna
+  :description "GPT-5.6 Luna through the OpenAI Responses API."
+  :backend (ai/llm-backend 'openai)
+  :model 'gpt-5.6-luna
+  :stream t
+  :request-params '(:reasoning (:effort "medium" :summary "auto"))
+  :include-reasoning 'ignore)
+
 (gptel-make-preset 'gpt-5.6-sol-oauth
   :description "GPT-5.6 Sol through OpenAI subscription OAuth."
   :backend (ai/llm-backend 'openai-oauth)
   :model 'gpt-5.6-sol
   :stream t
   :request-params '(:reasoning (:effort "high" :summary "auto"))
+  :include-reasoning 'ignore)
+
+(gptel-make-preset 'claude-fable-5
+  :description "Claude Fable 5 through Anthropic."
+  :backend (ai/llm-backend 'anthropic)
+  :model 'claude-fable-5
+  :stream t
   :include-reasoning 'ignore)
 
 (provide 'ai)

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -6,20 +6,23 @@
 * Defaults
 
 The local gptel stack defaults to Z.AI =glm-5.2=.  OpenAI
-=gpt-5.6-sol= is available through both the OpenAI Responses API and gptel's
-OpenAI subscription OAuth backend.
+=gpt-5.6-sol= and =gpt-5.6-luna= are available through the OpenAI Responses
+API.  =claude-fable-5= is available through Anthropic.  GPT-5.6 Sol is also
+available through gptel's OpenAI subscription OAuth backend.
 
 The configuration tracks current upstream gptel instead of Doom's older pin.
 Modern defaults enable streaming, curl transport, tool use, per-tool automatic
-confirmation, automatic tool-result retention, Org response conversion,
-branching Org context, response tracking, and reasoning blocks that are shown
-but excluded from subsequent prompts.
+confirmation, automatic tool-result retention, media tracking, prompt caching
+where supported, Org response conversion, branching Org context, response
+tracking, and reasoning blocks that are shown but excluded from subsequent
+prompts.
 
 API keys are resolved from environment variables first and then
 =auth-source=:
 
 - =ZAI_API_KEY= or host =api.z.ai=
 - =OPENAI_API_KEY= or host =api.openai.com=
+- =ANTHROPIC_API_KEY= or host =api.anthropic.com=
 - =OPENROUTER_API_KEY= or host =openrouter.ai=
 
 A Coding Plan endpoint can be selected without changing Lisp:
@@ -42,30 +45,39 @@ The public =ai-agent= and =ai-agent-core= features use matching loader
 filenames.  Their implementations remain split into =agent.el= and
 =agent-core.el=.
 
-After pulling this configuration, update gptel and regenerate Doom's package
-state:
+After pulling this configuration, update gptel and rebuild Transient and
+Dirvish together:
 
 #+begin_src shell
 doom sync -u
 #+end_src
+
+If Emacs was running while Transient changed, fully restart Emacs after the
+sync.  A stale in-memory Transient class definition cannot be repaired by
+reloading Dirvish alone.
 
 * Model switching
 
 #+begin_src emacs-lisp
 (ai/llm-use-glm-5.2)
 (ai/llm-use-gpt-5.6-sol)
+(ai/llm-use-gpt-luna)
+(ai/llm-use-fable)
 (ai/llm-use-openai-oauth)
 #+end_src
 
 The same switches are exposed as =M-x +llm/use-glm-5.2=,
-=M-x +llm/use-gpt-5.6-sol=, and =M-x +llm/use-openai-oauth=.  A prefix
-argument makes the selection buffer-local.
+=M-x +llm/use-gpt-5.6-sol=, =M-x +llm/use-gpt-luna=,
+=M-x +llm/use-fable=, and =M-x +llm/use-openai-oauth=.  A prefix argument
+makes the selection buffer-local.
 
 Available presets:
 
 - =@glm-5.2=
 - =@gpt-5.6-sol=
+- =@gpt-5.6-luna=
 - =@gpt-5.6-sol-oauth=
+- =@claude-fable-5=
 - =@agent= — GLM-5.2 with the project agent tools
 - =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tools
 
@@ -82,6 +94,24 @@ M-x +llm/use-openai-oauth
 The normal browser authorization-code flow is used locally.  Over SSH, set
 =gptel-openai-oauth-login-method= to =device= before logging in.
 
+* MCP startup
+
+Configured MCP servers are started after gptel loads, and their tools are
+registered with the active gptel session.  Optional launcher-backed servers are
+non-fatal when their executable, config, or secret is absent.
+
+Useful commands:
+
+#+begin_src emacs-lisp
+M-x +llm/mcp-connect-all
+M-x +llm/proxmox-connect
+M-x +llm/discord-connect
+#+end_src
+
+The generated Doom autoloads now define the MCP customization variables before
+any deferred callback reads them.  This prevents the former
+=void-variable +llm/proxmox-config-file= startup failure.
+
 * Proxmox MCP
 
 Proxmox runs inside the Emacs stack through =gptel= and =mcp.el=.  There is no
@@ -96,9 +126,9 @@ $EDITOR ~/.config/proxmox-mcp/config.json
 #+end_src
 
 The generated template includes API-token authentication, SSH node mappings,
-and a deny-all command policy.  Keep the real =config.json= outside Git.  In
-Emacs, run =M-x +llm/proxmox-connect=.  Once the config exists, normal gptel
-startup also registers the server automatically.
+and a deny-all command policy.  Keep the real =config.json= outside Git.  Once
+the config and launcher exist, normal gptel startup registers the server
+automatically.
 
 * Agent file tools
 


### PR DESCRIPTION
## Changes
- make Z.AI GLM-5.2 the authoritative default
- use current gptel backend APIs and modern defaults
- add GPT-5.6 Luna and Claude Fable 5 backends, presets, and switch commands
- start configured MCP servers after gptel loads
- fix the generated-autoload `+llm/proxmox-config-file` void-variable failure
- update Transient with gptel so Dirvish recompiles against the same EIEIO ABI
- suppress invalid `org-super-agenda-groups` Customize validation during Doom startup

## Apply
```sh
doom sync -u
```
Then fully restart Emacs so stale Transient/Dirvish class objects are gone.

## Validation
- source-checked against current upstream gptel APIs and model metadata
- PR is mergeable
- repository has no CI status checks for this commit
- local Doom/Emacs runtime validation is still required