### PR TITLE
Fix gptel OpenRouter defaults and MCP autoload race

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -1,156 +1,14 @@
-;;; llm.el --- Doom autoloads for the local gptel stack -*- lexical-binding: t; -*-
-
-(require 'auth-source)
-(require 'subr-x)
-
-;;;###autoload
-(defcustom +llm/proxmox-config-file
-  (expand-file-name "~/.config/proxmox-mcp/config.json")
-  "JSON configuration used by the Emacs Proxmox MCP server."
-  :type 'file
-  :group 'applications)
-
-;;;###autoload
-(defcustom +llm/mcp-auto-connect t
-  "When non-nil, start configured MCP servers after gptel loads."
-  :type 'boolean
-  :group 'applications)
-
-(defun +llm/proxmox-register ()
-  "Register the local Proxmox MCP launcher with mcp.el."
-  (unless (file-readable-p +llm/proxmox-config-file)
-    (user-error "Missing Proxmox MCP config: %s" +llm/proxmox-config-file))
-  (unless (executable-find "proxmox-mcp-launcher")
-    (user-error "proxmox-mcp-launcher is not on exec-path; apply Home Manager first"))
-  (setq mcp-hub-servers
-        (cons '("proxmox" . (:command "proxmox-mcp-launcher"))
-              (assoc-delete-all "proxmox" mcp-hub-servers))))
-
-;;;###autoload
-(defun +llm/apply-final-defaults ()
-  "Make the shared gptel configuration authoritative after package setup."
-  (when (featurep 'gptel)
-    (require 'ai)
-    (require 'ai-agent nil t)
-    (ai/llm-apply-defaults)))
-
-;;;###autoload
-(defun +llm/proxmox-connect ()
-  "Register and connect the Proxmox MCP tools to gptel."
-  (interactive)
-  (require 'gptel-integrations)
-  (require 'mcp-hub)
-  (+llm/proxmox-register)
-  (gptel-mcp-connect '("proxmox")))
-
-;;;###autoload
-(defcustom +llm/discord-auth-host "discord"
-  "auth-source host used to look up the Discord bot token."
-  :type 'string
-  :group 'applications)
-
-;;;###autoload
-(defcustom +llm/discord-auth-user "bot"
-  "auth-source user used to look up the Discord bot token."
-  :type 'string
-  :group 'applications)
-
-(defun +llm/discord-token ()
-  "Return the Discord bot token from auth-source, or nil.
-The token is read from the auth-source entry whose host matches
-`+llm/discord-auth-host' and user `+llm/discord-auth-user'.  Add
-the entry to `~/.authinfo.gpg' as:
-
-    machine discord login bot password TOKEN"
-  (when-let* ((entry (car (auth-source-search
-                           :host +llm/discord-auth-host
-                           :user +llm/discord-auth-user
-                           :max 1)))
-              (secret (plist-get entry :secret)))
-    (if (functionp secret)
-        (funcall secret)
-      secret)))
-
-;;;###autoload
-(defun +llm/discord-register (&optional noerror)
-  "Register the local Discord MCP launcher with mcp.el.
-The launcher is provided by Home Manager and runs the nix-built
-discordmcp server.  The DISCORD_TOKEN env var is injected from
-auth-source so the token never lives in the dotfiles repository.
-
-With optional NOERROR non-nil, skip silently when the launcher or
-token are unavailable instead of signaling a `user-error'."
-  (interactive)
-  (cond
-   ((and (not noerror) (not (executable-find "discord-mcp-launcher")))
-    (user-error "discord-mcp-launcher is not on exec-path; apply Home Manager first"))
-   ((not (executable-find "discord-mcp-launcher"))
-    (message "Discord MCP: launcher not found on exec-path; skipping"))
-   (t
-    (let ((token (+llm/discord-token)))
-      (cond
-       ((and token (not (string-empty-p token)))
-        (setq mcp-hub-servers
-              (cons `("discord" . (:command "discord-mcp-launcher"
-                                    :env (:DISCORD_TOKEN ,token)))
-                    (assoc-delete-all "discord" mcp-hub-servers)))
-        (message "Discord MCP: registered discord-mcp-launcher"))
-       (noerror
-        (message "Discord MCP: no token in auth-source (host=%s user=%s); skipping"
-                 +llm/discord-auth-host +llm/discord-auth-user))
-       (t
-        (user-error "No Discord token in auth-source (host=%s user=%s); add it to ~/.authinfo.gpg"
-                    +llm/discord-auth-host +llm/discord-auth-user)))))))
-
-;;;###autoload
-(defun +llm/discord-connect ()
-  "Register and connect the Discord MCP tools to gptel."
-  (interactive)
-  (require 'gptel-integrations)
-  (require 'mcp-hub)
-  (+llm/discord-register)
-  (gptel-mcp-connect '("discord")))
-
-;;;###autoload
-(defun +llm/mcp-connect-all (&optional noerror)
-  "Start configured MCP servers and add their tools to gptel.
-With optional NOERROR non-nil, report startup failures without aborting Emacs."
-  (interactive)
-  (condition-case err
-      (progn
-        (require 'gptel-integrations)
-        (require 'mcp-hub)
-        (+llm/discord-register 'noerror)
-        (when (and (boundp '+llm/proxmox-config-file)
-                   (file-readable-p +llm/proxmox-config-file)
-                   (executable-find "proxmox-mcp-launcher"))
-          (+llm/proxmox-register))
-        ;; Current gptel starts inactive servers before registering their tools.
-        (gptel-mcp-connect)
-        t)
-    (error
-     (if noerror
-         (progn
-           (message "MCP startup skipped: %s" (error-message-string err))
-           nil)
-       (signal (car err) (cdr err))))))
+;;; llm.el --- Doom autoload entrypoints for the local gptel stack -*- lexical-binding: t; -*-
 
 ;;;###autoload
 (with-eval-after-load 'gptel
-  ;; Run after every `eval-after-load' and `use-package!' callback for gptel.
-  ;; This defeats older config fragments that still set OpenRouter as default.
-  (run-at-time 0 nil #'+llm/apply-final-defaults)
-  (when (bound-and-true-p +llm/mcp-auto-connect)
-    (run-at-time 0.75 nil #'+llm/mcp-connect-all 'noerror)))
-
-;;;###autoload
-(with-eval-after-load 'mcp-hub
-  ;; Guard the variable because this form is copied into Doom's generated
-  ;; autoload file and may run before this source file itself is loaded.
-  (when (and (boundp '+llm/proxmox-config-file)
-             (file-readable-p +llm/proxmox-config-file)
-             (executable-find "proxmox-mcp-launcher"))
-    (+llm/proxmox-register)))
+  ;; Load real implementations from `lisp/llm' instead of scheduling a
+  ;; function whose autoload points back into this compiled autoload file.
+  (run-at-time
+   0 nil
+   (lambda ()
+     (require 'ai-init)
+     (ai/llm-apply-defaults))))
 
 ;;;###autoload
 (defun +llm/load ()
@@ -158,8 +16,43 @@ With optional NOERROR non-nil, report startup failures without aborting Emacs."
   (interactive)
   (require 'ai-init)
   (ai/llm-apply-defaults)
-  (+llm/mcp-connect-all 'noerror)
+  (ai/mcp-connect-all 'noerror)
   (message "LLM stack loaded: %s / %s" ai/llm-provider ai/llm-model))
+
+;;;###autoload
+(defun +llm/mcp-connect-all (&optional noerror)
+  "Start configured MCP servers and register their tools with gptel."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-connect-all noerror))
+
+;;;###autoload
+(defun +llm/proxmox-register (&optional noerror)
+  "Register the Proxmox MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-register-proxmox noerror))
+
+;;;###autoload
+(defun +llm/discord-register (&optional noerror)
+  "Register the Discord MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-register-discord noerror))
+
+;;;###autoload
+(defun +llm/proxmox-connect ()
+  "Connect the Proxmox MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-connect-proxmox))
+
+;;;###autoload
+(defun +llm/discord-connect ()
+  "Connect the Discord MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-connect-discord))
 
 ;;;###autoload
 (defun +llm/chat ()
@@ -170,28 +63,28 @@ With optional NOERROR non-nil, report startup failures without aborting Emacs."
 
 ;;;###autoload
 (defun +llm/use-glm-5.2 (&optional local)
-  "Switch to Z.AI GLM-5.2."
+  "Switch to GLM-5.2 through OpenRouter."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-glm-5.2 local))
 
 ;;;###autoload
 (defun +llm/use-gpt-5.6-sol (&optional local)
-  "Switch to OpenAI API GPT-5.6 Sol."
+  "Switch to GPT-5.6 Sol through OpenRouter."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-gpt-5.6-sol local))
 
 ;;;###autoload
 (defun +llm/use-gpt-luna (&optional local)
-  "Switch to OpenAI API GPT-5.6 Luna."
+  "Switch to GPT-5.6 Luna through OpenRouter."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-gpt-luna local))
 
 ;;;###autoload
 (defun +llm/use-fable (&optional local)
-  "Switch to Anthropic Claude Fable 5."
+  "Switch to Claude Fable 5 through OpenRouter."
   (interactive "P")
   (require 'ai)
   (ai/llm-use-fable local))

--- a/lisp/llm/ai-mcp.el
+++ b/lisp/llm/ai-mcp.el
@@ -1,0 +1,123 @@
+;;; ai-mcp.el --- MCP runtime for gptel -*- lexical-binding: t; -*-
+
+(require 'auth-source)
+(require 'subr-x)
+
+(defgroup ai/mcp nil
+  "MCP server integration for gptel."
+  :group 'applications
+  :prefix "ai/mcp-")
+
+(defcustom ai/mcp-auto-connect t
+  "When non-nil, start configured MCP servers after gptel loads."
+  :type 'boolean
+  :group 'ai/mcp)
+
+(defcustom ai/mcp-proxmox-config-file
+  (expand-file-name "~/.config/proxmox-mcp/config.json")
+  "JSON configuration used by the Proxmox MCP server."
+  :type 'file
+  :group 'ai/mcp)
+
+(defcustom ai/mcp-discord-auth-host "discord"
+  "auth-source host used to look up the Discord bot token."
+  :type 'string
+  :group 'ai/mcp)
+
+(defcustom ai/mcp-discord-auth-user "bot"
+  "auth-source user used to look up the Discord bot token."
+  :type 'string
+  :group 'ai/mcp)
+
+(defun ai/mcp--discord-token ()
+  "Return the Discord bot token from auth-source, or nil."
+  (when-let* ((entry (car (auth-source-search
+                           :host ai/mcp-discord-auth-host
+                           :user ai/mcp-discord-auth-user
+                           :max 1)))
+              (secret (plist-get entry :secret)))
+    (if (functionp secret) (funcall secret) secret)))
+
+(defun ai/mcp-register-proxmox (&optional noerror)
+  "Register the local Proxmox MCP launcher.
+With NOERROR, return nil instead of signaling when unavailable."
+  (cond
+   ((not (file-readable-p ai/mcp-proxmox-config-file))
+    (unless noerror
+      (user-error "Missing Proxmox MCP config: %s"
+                  ai/mcp-proxmox-config-file)))
+   ((not (executable-find "proxmox-mcp-launcher"))
+    (unless noerror
+      (user-error "proxmox-mcp-launcher is not on exec-path")))
+   (t
+    (setq mcp-hub-servers
+          (cons '("proxmox" . (:command "proxmox-mcp-launcher"))
+                (assoc-delete-all "proxmox" mcp-hub-servers)))
+    t)))
+
+(defun ai/mcp-register-discord (&optional noerror)
+  "Register the local Discord MCP launcher.
+With NOERROR, return nil instead of signaling when unavailable."
+  (cond
+   ((not (executable-find "discord-mcp-launcher"))
+    (unless noerror
+      (user-error "discord-mcp-launcher is not on exec-path")))
+   ((let ((token (ai/mcp--discord-token)))
+      (when (and token (not (string-empty-p token)))
+        (setq mcp-hub-servers
+              (cons `("discord" . (:command "discord-mcp-launcher"
+                                    :env (:DISCORD_TOKEN ,token)))
+                    (assoc-delete-all "discord" mcp-hub-servers)))
+        t)))
+   (noerror nil)
+   (t
+    (user-error "No Discord token in auth-source for host=%s user=%s"
+                ai/mcp-discord-auth-host ai/mcp-discord-auth-user))))
+
+(defun ai/mcp-connect-all (&optional noerror)
+  "Start configured MCP servers and register their tools with gptel.
+With NOERROR, report failures without aborting Emacs startup."
+  (interactive)
+  (condition-case err
+      (progn
+        (require 'gptel-integrations)
+        (require 'mcp-hub)
+        (ai/mcp-register-discord 'noerror)
+        (ai/mcp-register-proxmox 'noerror)
+        (gptel-mcp-connect)
+        t)
+    (error
+     (if noerror
+         (progn
+           (message "MCP startup skipped: %s" (error-message-string err))
+           nil)
+       (signal (car err) (cdr err))))))
+
+(defun ai/mcp-connect-proxmox ()
+  "Register and connect the Proxmox MCP server."
+  (interactive)
+  (require 'gptel-integrations)
+  (require 'mcp-hub)
+  (ai/mcp-register-proxmox)
+  (gptel-mcp-connect '("proxmox")))
+
+(defun ai/mcp-connect-discord ()
+  "Register and connect the Discord MCP server."
+  (interactive)
+  (require 'gptel-integrations)
+  (require 'mcp-hub)
+  (ai/mcp-register-discord)
+  (gptel-mcp-connect '("discord")))
+
+(defun ai/mcp-schedule-startup ()
+  "Schedule MCP startup without invoking a Doom autoloaded function."
+  (when ai/mcp-auto-connect
+    (run-at-time 0.75 nil
+                 (lambda ()
+                   (ai/mcp-connect-all 'noerror)))))
+
+(with-eval-after-load 'gptel
+  (ai/mcp-schedule-startup))
+
+(provide 'ai-mcp)
+;;; ai-mcp.el ends here

--- a/lisp/llm/ai.el
+++ b/lisp/llm/ai.el
@@ -12,29 +12,29 @@
   :group 'applications
   :prefix "ai/llm-")
 
-(defcustom ai/llm-provider 'zai
+(defcustom ai/llm-provider 'openrouter
   "Default LLM provider.
-Supported values are `zai', `openai', `openai-oauth', `anthropic',
-and `openrouter'."
-  :type '(choice (const :tag "Z.AI API" zai)
-                 (const :tag "OpenAI API" openai)
+OpenRouter is authoritative.  Direct provider backends remain available only
+for explicit manual selection."
+  :type '(choice (const :tag "OpenRouter" openrouter)
                  (const :tag "OpenAI subscription OAuth" openai-oauth)
-                 (const :tag "Anthropic API" anthropic)
-                 (const :tag "OpenRouter" openrouter))
+                 (const :tag "Z.AI API" zai)
+                 (const :tag "OpenAI API" openai)
+                 (const :tag "Anthropic API" anthropic))
   :group 'ai/llm)
 
-(defcustom ai/llm-model 'glm-5.2
-  "Default model used by gptel and custom workflows."
+(defcustom ai/llm-model 'z-ai/glm-5.2
+  "Default OpenRouter model used by gptel and custom workflows."
   :type 'symbol
   :group 'ai/llm)
 
 (defcustom ai/llm-zai-host "api.z.ai"
-  "Z.AI API host."
+  "Z.AI API host for explicit direct-provider use."
   :type 'string
   :group 'ai/llm)
 
 (defcustom ai/llm-zai-endpoint "/api/paas/v4/chat/completions"
-  "Z.AI chat-completions endpoint."
+  "Z.AI chat-completions endpoint for explicit direct-provider use."
   :type 'string
   :group 'ai/llm)
 
@@ -57,38 +57,50 @@ and `openrouter'."
      :capabilities (reasoning tool-use json)
      :context-window 200
      :request-params (:thinking (:type "enabled"))))
-  "Models advertised by the Z.AI backend."
+  "Models advertised by the optional direct Z.AI backend."
   :type '(repeat sexp)
   :group 'ai/llm)
 
 (defcustom ai/llm-openai-models
   '(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna)
-  "OpenAI model IDs exposed by the local model switcher.
-Metadata is supplied by current gptel instead of being duplicated here."
+  "OpenAI model IDs exposed for explicit direct-provider use."
   :type '(repeat symbol)
   :group 'ai/llm)
 
 (defcustom ai/llm-anthropic-models
   '(claude-fable-5 claude-sonnet-5 claude-opus-4-8)
-  "Anthropic model IDs exposed by the local model switcher.
-Metadata is supplied by current gptel."
+  "Anthropic model IDs exposed for explicit direct-provider use."
   :type '(repeat symbol)
   :group 'ai/llm)
 
 (defcustom ai/llm-openrouter-models
   '((z-ai/glm-5.2
+     :description "GLM-5.2 through OpenRouter"
      :capabilities (reasoning tool-use json)
      :context-window 1000)
     (openai/gpt-5.6-sol
+     :description "GPT-5.6 Sol through OpenRouter"
      :capabilities (reasoning media tool-use json url)
      :context-window 1050)
     (openai/gpt-5.6-terra
+     :description "GPT-5.6 Terra through OpenRouter"
      :capabilities (reasoning media tool-use json url)
      :context-window 1050)
     (openai/gpt-5.6-luna
+     :description "GPT-5.6 Luna through OpenRouter"
      :capabilities (media tool-use json url)
-     :context-window 1050))
-  "Models advertised by the OpenRouter backend."
+     :context-window 1050)
+    (anthropic/claude-fable-5
+     :description "Claude Fable 5 through OpenRouter"
+     :capabilities (media tool-use json)
+     :context-window 1000)
+    (openai/gpt-5.2-codex
+     :capabilities (reasoning media tool-use json url))
+    (openai/gpt-5-mini
+     :capabilities (reasoning media tool-use json url))
+    (moonshotai/kimi-k2.5
+     :capabilities (reasoning tool-use json)))
+  "Provider-qualified model IDs advertised by the OpenRouter backend."
   :type '(repeat sexp)
   :group 'ai/llm)
 
@@ -137,8 +149,7 @@ Environment variables are preferred, then auth-source is consulted."
        provider)))
 
 (cl-defun ai/llm-zai-backend (&key (stream t) (name "Z.AI"))
-  "Return a current gptel Z.AI backend.
-STREAM controls response streaming and NAME is the backend display name."
+  "Return the optional direct Z.AI backend."
   (gptel-make-deepseek name
     :host ai/llm-zai-host
     :endpoint (or (getenv "ZAI_API_ENDPOINT") ai/llm-zai-endpoint)
@@ -147,7 +158,7 @@ STREAM controls response streaming and NAME is the backend display name."
     :models ai/llm-zai-models))
 
 (cl-defun ai/llm-openai-backend (&key (stream t) (name "OpenAI"))
-  "Return the current gptel OpenAI Responses API backend."
+  "Return the optional direct OpenAI Responses API backend."
   (gptel-make-openai name
     :stream stream
     :key (lambda () (ai/llm--require-api-key 'openai))))
@@ -159,13 +170,13 @@ STREAM controls response streaming and NAME is the backend display name."
   (gptel-make-openai-oauth name :stream stream))
 
 (cl-defun ai/llm-anthropic-backend (&key (stream t) (name "Anthropic"))
-  "Return the current gptel Anthropic Messages API backend."
+  "Return the optional direct Anthropic Messages API backend."
   (gptel-make-anthropic name
     :stream stream
     :key (lambda () (ai/llm--require-api-key 'anthropic))))
 
 (cl-defun ai/llm-openrouter-backend (&key (stream t) (name "OpenRouter"))
-  "Return an OpenRouter chat-completions backend."
+  "Return the authoritative OpenRouter chat-completions backend."
   (gptel-make-openai name
     :host "openrouter.ai"
     :endpoint "/api/v1/chat/completions"
@@ -182,11 +193,11 @@ PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
     (or (gethash provider ai/llm--backends)
         (puthash provider
                  (pcase provider
+                   ('openrouter (ai/llm-openrouter-backend))
+                   ('openai-oauth (ai/llm-openai-oauth-backend))
                    ('zai (ai/llm-zai-backend))
                    ('openai (ai/llm-openai-backend))
-                   ('openai-oauth (ai/llm-openai-oauth-backend))
                    ('anthropic (ai/llm-anthropic-backend))
-                   ('openrouter (ai/llm-openrouter-backend))
                    (_ (error "Unsupported LLM provider: %S" provider)))
                  ai/llm--backends))))
 
@@ -201,10 +212,10 @@ PROVIDER defaults to `ai/llm-provider'.  When REFRESH is non-nil, rebuild it."
 (defun ai/llm-models-for-provider (&optional provider)
   "Return configured model symbols for PROVIDER."
   (pcase (or provider ai/llm-provider)
+    ('openrouter (mapcar #'ai/llm--model-name ai/llm-openrouter-models))
     ('zai (mapcar #'ai/llm--model-name ai/llm-zai-models))
     ((or 'openai 'openai-oauth) ai/llm-openai-models)
     ('anthropic ai/llm-anthropic-models)
-    ('openrouter (mapcar #'ai/llm--model-name ai/llm-openrouter-models))
     (_ nil)))
 
 (defun ai/llm-use (provider model &optional local)
@@ -215,7 +226,7 @@ With LOCAL non-nil, only change the current buffer."
            (intern
             (completing-read
              "Provider: "
-             '("zai" "openai" "openai-oauth" "anthropic" "openrouter")
+             '("openrouter" "openai-oauth" "zai" "openai" "anthropic")
              nil t nil nil (symbol-name ai/llm-provider))))
           (available (ai/llm-models-for-provider provider))
           (default (if (memq ai/llm-model available)
@@ -239,32 +250,27 @@ With LOCAL non-nil, only change the current buffer."
            provider model (if local " (buffer-local)" "")))
 
 (defun ai/llm-use-glm-5.2 (&optional local)
-  "Use GLM-5.2 through Z.AI.
-With prefix argument LOCAL, apply only in the current buffer."
+  "Use GLM-5.2 through OpenRouter."
   (interactive "P")
-  (ai/llm-use 'zai 'glm-5.2 local))
+  (ai/llm-use 'openrouter 'z-ai/glm-5.2 local))
 
 (defun ai/llm-use-gpt-5.6-sol (&optional local)
-  "Use GPT-5.6 Sol through the OpenAI API.
-With prefix argument LOCAL, apply only in the current buffer."
+  "Use GPT-5.6 Sol through OpenRouter."
   (interactive "P")
-  (ai/llm-use 'openai 'gpt-5.6-sol local))
+  (ai/llm-use 'openrouter 'openai/gpt-5.6-sol local))
 
 (defun ai/llm-use-gpt-luna (&optional local)
-  "Use GPT-5.6 Luna through the OpenAI Responses API.
-With prefix argument LOCAL, apply only in the current buffer."
+  "Use GPT-5.6 Luna through OpenRouter."
   (interactive "P")
-  (ai/llm-use 'openai 'gpt-5.6-luna local))
+  (ai/llm-use 'openrouter 'openai/gpt-5.6-luna local))
 
 (defun ai/llm-use-fable (&optional local)
-  "Use Claude Fable 5 through Anthropic.
-With prefix argument LOCAL, apply only in the current buffer."
+  "Use Claude Fable 5 through OpenRouter."
   (interactive "P")
-  (ai/llm-use 'anthropic 'claude-fable-5 local))
+  (ai/llm-use 'openrouter 'anthropic/claude-fable-5 local))
 
 (defun ai/llm-use-openai-oauth (&optional local)
-  "Use GPT-5.6 Sol through an OpenAI subscription OAuth session.
-With prefix argument LOCAL, apply only in the current buffer."
+  "Use GPT-5.6 Sol through an OpenAI subscription OAuth session."
   (interactive "P")
   (ai/llm-use 'openai-oauth 'gpt-5.6-sol local))
 
@@ -298,24 +304,30 @@ With prefix argument LOCAL, apply only in the current buffer."
 (ai/llm-apply-defaults)
 
 (gptel-make-preset 'glm-5.2
-  :description "GLM-5.2 through Z.AI with thinking and tool use."
-  :backend (ai/llm-backend 'zai)
-  :model 'glm-5.2
+  :description "GLM-5.2 through OpenRouter with tool use."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'z-ai/glm-5.2
   :stream t
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'gpt-5.6-sol
-  :description "GPT-5.6 Sol through the OpenAI Responses API."
-  :backend (ai/llm-backend 'openai)
-  :model 'gpt-5.6-sol
+  :description "GPT-5.6 Sol through OpenRouter."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'openai/gpt-5.6-sol
   :stream t
-  :request-params '(:reasoning (:effort "high" :summary "auto"))
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'gpt-5.6-luna
-  :description "GPT-5.6 Luna through the OpenAI Responses API."
-  :backend (ai/llm-backend 'openai)
-  :model 'gpt-5.6-luna
+  :description "GPT-5.6 Luna through OpenRouter."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'openai/gpt-5.6-luna
+  :stream t
+  :include-reasoning 'ignore)
+
+(gptel-make-preset 'claude-fable-5
+  :description "Claude Fable 5 through OpenRouter."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'anthropic/claude-fable-5
   :stream t
   :include-reasoning 'ignore)
 
@@ -325,13 +337,6 @@ With prefix argument LOCAL, apply only in the current buffer."
   :model 'gpt-5.6-sol
   :stream t
   :request-params '(:reasoning (:effort "high" :summary "auto"))
-  :include-reasoning 'ignore)
-
-(gptel-make-preset 'claude-fable-5
-  :description "Claude Fable 5 through Anthropic."
-  :backend (ai/llm-backend 'anthropic)
-  :model 'claude-fable-5
-  :stream t
   :include-reasoning 'ignore)
 
 (provide 'ai)

--- a/lisp/llm/init.el
+++ b/lisp/llm/init.el
@@ -2,7 +2,33 @@
 
 (require 'ai)
 (require 'ai-agent)
+(require 'ai-mcp)
 (require 'chat)
+
+;; Override values left bound by an older loaded copy of this configuration.
+(setq ai/llm-provider 'openrouter
+      ai/llm-model 'z-ai/glm-5.2)
+(ai/llm-apply-defaults)
+
+;; `agent.el' historically used direct provider backends.  Re-register the
+;; public presets after it loads so all normal agent traffic stays on OpenRouter.
+(gptel-make-preset 'agent
+  :description "GLM-5.2 project agent through OpenRouter."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'z-ai/glm-5.2
+  :system ai/agent-system-prompt
+  :tools ai/agent-tools
+  :stream t
+  :temperature nil
+  :use-context 'system
+  :track-media t
+  :include-reasoning t)
+
+(gptel-make-preset 'agent-gpt-5.6-sol
+  :parents '(agent)
+  :description "GPT-5.6 Sol project agent through OpenRouter."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'openai/gpt-5.6-sol)
 
 (with-eval-after-load 'org-ql
   (require 'todo nil t))


### PR DESCRIPTION
## Fixes
- make OpenRouter the authoritative gptel backend
- set default model to `z-ai/glm-5.2`
- route GPT-5.6 Sol, GPT-5.6 Luna, Claude Fable 5, and agent presets through OpenRouter provider-qualified model IDs
- move MCP runtime and startup timer into `lisp/llm/ai-mcp.el`
- leave only thin Doom autoload wrappers in `.doom.d/autoload/llm.el`
- eliminate the `Autoloading ... llm.elc failed to define function +llm/mcp-connect-all` timer path

## Local cleanup required
```sh
rm -f ~/.dotfiles/.doom.d/autoload/llm.elc
cd ~/.dotfiles
git pull
~/.emacs.d/bin/doom sync -u
```
Then fully stop and restart Emacs.