### PR TITLE
Fix missing Ubuntu keyboard and system icons

### DIFF
--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -20,7 +20,7 @@ Run from the dotfiles checkout while logged into Ubuntu GNOME:
 bash ~/.dotfiles/ubuntu/apply.sh apply
 ```
 
-The wrapper applies the main theme and then removes sidebar fills so Settings and other libadwaita applications inherit the window background. Selected sidebar rows keep the neon accent.
+The wrapper applies the main theme, restores GNOME-compatible keyboard/system icon rendering, and removes sidebar fills so Settings and other libadwaita applications inherit the window background. Selected sidebar rows keep the neon accent.
 
 The script changes the current user's GNOME/Ubuntu settings only. It creates a timestamped backup under:
 
@@ -34,7 +34,8 @@ It configures:
 - transparent application sidebars with accented active rows
 - GNOME Shell panels, menus, quick settings, notifications, overview, and dash
 - Yaru dark base theme with pink/purple accent selection where supported
-- Hack/Hack Nerd Font UI and terminal fonts when installed
+- Ubuntu Sans/Cantarell for GNOME interface text and Hack/Hack Nerd Font for monospace text when installed
+- a complete Yaru or Adwaita icon theme for keyboard and system glyph coverage
 - GNOME Terminal's full 16-color palette
 - a generated 4K Outrun wallpaper and lock-screen background
 - a compact translucent Ubuntu Dock
@@ -47,15 +48,21 @@ sudo apt install gnome-shell-extensions
 
 Then log out and back in after applying the theme.
 
-## Patch an existing application
+## Patch an existing installation
 
-When the main theme is already applied, update only the sidebar CSS:
+When the main theme is already applied, repair missing keyboard/system icons without rebuilding the theme:
+
+```bash
+bash ~/.dotfiles/ubuntu/fix-keyboard-icons.sh
+```
+
+Update only the sidebar CSS with:
 
 ```bash
 bash ~/.dotfiles/ubuntu/fix-transparent-sidebar.sh
 ```
 
-Close and reopen Settings afterward.
+Close and reopen Settings afterward. Log out and back in after the icon repair so GNOME Shell reloads its stylesheet and font choices.
 
 ## Restore
 

--- a/ubuntu/apply.sh
+++ b/ubuntu/apply.sh
@@ -7,6 +7,7 @@ readonly ACTION=${1:-apply}
 case "$ACTION" in
   apply)
     bash "$ROOT/apply-outrun.sh" apply
+    bash "$ROOT/fix-keyboard-icons.sh"
     bash "$ROOT/fix-transparent-sidebar.sh"
     ;;
   restore)

--- a/ubuntu/fix-keyboard-icons.sh
+++ b/ubuntu/fix-keyboard-icons.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly THEME_NAME='Outrun-Electric'
+readonly SHELL_CSS="${XDG_DATA_HOME:-$HOME/.local/share}/themes/$THEME_NAME/gnome-shell/gnome-shell.css"
+
+log() {
+  printf '[ubuntu-outrun] %s\n' "$*"
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+schema_exists() {
+  gsettings list-schemas | grep -Fxq "$1"
+}
+
+key_exists() {
+  schema_exists "$1" && gsettings list-keys "$1" | grep -Fxq "$2"
+}
+
+set_setting() {
+  local schema=$1 key=$2 value=$3
+  if key_exists "$schema" "$key"; then
+    gsettings set "$schema" "$key" "$value"
+  fi
+}
+
+font_matches() {
+  local candidate=$1 matched
+  have fc-match || return 1
+  matched=$(fc-match -f '%{family}\n' "$candidate" | head -n1)
+  [[ ${matched,,} == *${candidate,,}* ]]
+}
+
+interface_font_family() {
+  local candidate
+  for candidate in 'Ubuntu Sans' 'Ubuntu' 'Cantarell' 'Noto Sans' 'Sans'; do
+    if font_matches "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  printf '%s\n' 'Sans'
+}
+
+monospace_font_family() {
+  local candidate
+  for candidate in 'Hack Nerd Font' 'Hack Nerd Font Mono' 'Hack' 'Ubuntu Sans Mono' 'Ubuntu Mono' 'Monospace'; do
+    if font_matches "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  printf '%s\n' 'Monospace'
+}
+
+first_complete_icon_theme() {
+  local candidate root
+  for candidate in Yaru Adwaita; do
+    for root in /usr/share/icons "${XDG_DATA_HOME:-$HOME/.local/share}/icons" "$HOME/.icons"; do
+      if [[ -d "$root/$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  done
+  printf '%s\n' 'Adwaita'
+}
+
+restore_interface_defaults() {
+  local interface_font monospace_font icon_theme
+  interface_font=$(interface_font_family)
+  monospace_font=$(monospace_font_family)
+  icon_theme=$(first_complete_icon_theme)
+
+  set_setting org.gnome.desktop.interface font-name "'$interface_font 10'"
+  set_setting org.gnome.desktop.interface document-font-name "'$interface_font 10'"
+  set_setting org.gnome.desktop.interface monospace-font-name "'$monospace_font 11'"
+  set_setting org.gnome.desktop.interface icon-theme "'$icon_theme'"
+  set_setting org.gnome.desktop.wm.preferences titlebar-font "'$interface_font Bold 10'"
+
+  log "interface font: $interface_font"
+  log "monospace font: $monospace_font"
+  log "icon theme: $icon_theme"
+}
+
+remove_panel_font_override() {
+  [[ -f "$SHELL_CSS" ]] || return 0
+
+  sed -i '/^[[:space:]]*font-family: "Hack Nerd Font", "Hack", monospace;[[:space:]]*$/d' "$SHELL_CSS"
+  log "removed panel-wide Nerd Font override: $SHELL_CSS"
+}
+
+have gsettings || {
+  log 'warning: gsettings is unavailable; only the generated Shell CSS will be patched'
+  remove_panel_font_override
+  exit 0
+}
+
+restore_interface_defaults
+remove_panel_font_override
+log 'log out and back in to reload GNOME Shell and keyboard/system icons'


### PR DESCRIPTION
## What changed

- add `ubuntu/fix-keyboard-icons.sh`
- keep Hack/Hack Nerd Font limited to monospace and terminal text
- restore Ubuntu Sans/Cantarell/Noto Sans for GNOME interface text
- select the complete Yaru or Adwaita icon theme instead of an accent variant
- remove the generated GNOME Shell panel-wide Nerd Font override
- run the compatibility repair automatically from `ubuntu/apply.sh`
- document repairing an existing installation

## Root cause

The Outrun applicator assigned Hack Nerd Font to the whole GNOME interface and explicitly forced it on the Shell panel. That is too broad: keyboard shortcuts, input indicators, and other system glyphs depend on GNOME's normal font and icon fallbacks. The accent icon variant can also have incomplete coverage compared with base Yaru/Adwaita.

## Validation

- `bash -n ubuntu/fix-keyboard-icons.sh`
- compared branch against `master`; only the Ubuntu repair script, wrapper, and documentation changed

## Apply to an existing desktop

```bash
bash ~/.dotfiles/ubuntu/fix-keyboard-icons.sh
```

Log out and back in afterward so GNOME Shell reloads the corrected stylesheet and font settings.