### PR TITLE
Fix Logos username as useen

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
           disko.packages.${system}.disko-install
           pkgs.coreutils
           pkgs.gnugrep
+          pkgs.gnused
           pkgs.jq
           pkgs.openssl
           pkgs.util-linux
@@ -56,7 +57,7 @@
           export LOGOS_DEFAULT_FLAKE='${self.outPath}#logos'
           export LOGOS_SOURCE='${self.outPath}'
           export DISKO_INSTALL='${disko.packages.${system}.disko-install}/bin/disko-install'
-          exec '${pkgs.bash}/bin/bash' '${./scripts/install-logos.sh}' "$@"
+          exec '${pkgs.bash}/bin/bash' '${./scripts/install-logos-useen.sh}' "$@"
         '';
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.extraSpecialArgs = homeArgs;
-            home-manager.users.unseen = import ./nix/home-manager/systems/desktop/home.nix;
+            home-manager.users.useen = import ./nix/home-manager/systems/logos/home.nix;
           }
           ./nix/nixos/hosts/logos
         ];
@@ -99,11 +99,11 @@
       };
 
       homeConfigurations = {
-        "unseen@logos" = home-manager.lib.homeManagerConfiguration {
+        "useen@logos" = home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = homeArgs;
           modules = [
-            ./nix/home-manager/systems/desktop/home.nix
+            ./nix/home-manager/systems/logos/home.nix
           ];
         };
         "unseen@flake" = home-manager.lib.homeManagerConfiguration {
@@ -155,7 +155,7 @@
         install-logos = installLogos;
         install-logos-gui = installLogosGui;
         inherit flash-logos;
-        unseen-home = homeConfigurations."unseen@logos".activationPackage;
+        useen-home = homeConfigurations."useen@logos".activationPackage;
       };
 
       apps.${system} = {
@@ -172,7 +172,7 @@
       checks.${system} = {
         logos = logos.config.system.build.toplevel;
         install-logos = installLogos;
-        unseen-home = homeConfigurations."unseen@logos".activationPackage;
+        useen-home = homeConfigurations."useen@logos".activationPackage;
       };
 
       formatter.${system} = pkgs.nixfmt-rfc-style;

--- a/nix/nixos/hosts/logos/default.nix
+++ b/nix/nixos/hosts/logos/default.nix
@@ -102,9 +102,9 @@
     autoPrune.enable = true;
   };
 
-  users.users.unseen = {
+  users.users.useen = {
     isNormalUser = true;
-    description = "unseen";
+    description = "useen";
     extraGroups = [
       "wheel"
       "networkmanager"
@@ -127,7 +127,7 @@
     };
   };
 
-  fileSystems."/home/unseen/share" = {
+  fileSystems."/home/useen/share" = {
     device = "//storage.lost.system/unseen";
     fsType = "cifs";
     options = [
@@ -137,7 +137,7 @@
       "x-systemd.device-timeout=5s"
       "x-systemd.mount-timeout=5s"
       "uid=1000"
-      "credentials=/home/unseen/.config/smb-creds"
+      "credentials=/home/useen/.config/smb-creds"
     ];
   };
 

--- a/scripts/install-logos-gui.sh
+++ b/scripts/install-logos-gui.sh
@@ -54,10 +54,10 @@ flake="$(
 
 [[ "$flake" == *#* ]] || fail_dialog "The flake must include a configuration fragment, such as /etc/logos#logos."
 
-password="$(zenity --password --title="Logos User Password" --text="Password for the unseen user:")" || exit 0
+password="$(zenity --password --title="Logos User Password" --text="Password for the useen user:")" || exit 0
 [[ -n "$password" ]] || fail_dialog "The password cannot be empty."
 
-password_confirmation="$(zenity --password --title="Confirm Password" --text="Enter the unseen user password again:")" || exit 0
+password_confirmation="$(zenity --password --title="Confirm Password" --text="Enter the useen user password again:")" || exit 0
 [[ "$password" == "$password_confirmation" ]] || fail_dialog "The passwords do not match."
 unset password_confirmation
 

--- a/scripts/install-logos-useen.sh
+++ b/scripts/install-logos-useen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+temporary_script="$(mktemp)"
+trap 'rm -f -- "$temporary_script"' EXIT
+
+sed 's/\bunseen\b/useen/g' "$script_dir/install-logos.sh" > "$temporary_script"
+bash "$temporary_script" "$@"


### PR DESCRIPTION
## What changed
- declare the Logos NixOS user as `useen`
- add a Logos-specific Home Manager module targeting `/home/useen`
- expose the `useen@logos` Home Manager configuration and `useen-home` package/check
- route the installer through a compatibility wrapper that rewrites its legacy `unseen` target to `useen`
- update the GUI password prompts

## Why
The Logos configuration currently produces `unseen@logos`; the expected account is `useen@logos`.

## Validation
- compared the branch against `master`; changes are limited to the Logos identity and installer paths
- `bash -n` passes for the new installer wrapper
