### PR TITLE
Wire proxmox-mcp.env through launcher and Emacs

### DIFF
--- a/lisp/llm/ai-mcp.el
+++ b/lisp/llm/ai-mcp.el
@@ -19,6 +19,13 @@
   :type 'file
   :group 'ai/mcp)
 
+(defcustom ai/mcp-proxmox-env-file
+  (expand-file-name "~/.config/proxmox-mcp/proxmox-mcp.env")
+  "Shell env file sourced by the Proxmox MCP launcher before uvx.
+When readable, it is exported to the launcher via PROXMOX_MCP_ENV."
+  :type 'file
+  :group 'ai/mcp)
+
 (defcustom ai/mcp-discord-auth-host "discord"
   "auth-source host used to look up the Discord bot token."
   :type 'string
@@ -42,18 +49,22 @@
   "Register the local Proxmox MCP launcher.
 With NOERROR, return nil instead of signaling when unavailable."
   (cond
-   ((not (file-readable-p ai/mcp-proxmox-config-file))
+   ((not (or (file-readable-p ai/mcp-proxmox-config-file)
+             (file-readable-p ai/mcp-proxmox-env-file)))
     (unless noerror
-      (user-error "Missing Proxmox MCP config: %s"
-                  ai/mcp-proxmox-config-file)))
+      (user-error "Missing Proxmox MCP config: %s or %s"
+                  ai/mcp-proxmox-config-file ai/mcp-proxmox-env-file)))
    ((not (executable-find "proxmox-mcp-launcher"))
     (unless noerror
       (user-error "proxmox-mcp-launcher is not on exec-path")))
    (t
-    (setq mcp-hub-servers
-          (cons '("proxmox" . (:command "proxmox-mcp-launcher"))
-                (assoc-delete-all "proxmox" mcp-hub-servers)))
-    t)))
+    (let ((env (and (file-readable-p ai/mcp-proxmox-env-file)
+                    `(:PROXMOX_MCP_ENV ,ai/mcp-proxmox-env-file))))
+      (setq mcp-hub-servers
+            (cons `("proxmox" . (:command "proxmox-mcp-launcher"
+                                   ,@(when env (list :env env))))
+                  (assoc-delete-all "proxmox" mcp-hub-servers)))
+      t))))
 
 (defun ai/mcp-register-discord (&optional noerror)
   "Register the local Discord MCP launcher.

--- a/nix/home-manager/mods/proxmox-mcp.nix
+++ b/nix/home-manager/mods/proxmox-mcp.nix
@@ -12,45 +12,48 @@ let
       uv
     ];
     text = ''
+      env_file="''${PROXMOX_MCP_ENV:-${cfg.envFile}}"
+      if [ -r "$env_file" ]; then
+        set -a
+        # shellcheck disable=SC1090
+        . "$env_file"
+        set +a
+      fi
+
       config_file="''${PROXMOX_MCP_CONFIG:-${cfg.configFile}}"
 
-      if [ ! -r "$config_file" ]; then
-        echo "proxmox-mcp-launcher: configuration is missing or unreadable: $config_file" >&2
-        echo "Run proxmox-mcp-init, then replace the placeholder host and API token." >&2
-        exit 1
-      fi
+      if [ -r "$config_file" ]; then
+        host="$(jq -r '.proxmox.host // empty' "$config_file")"
+        user="$(jq -r '.auth.user // empty' "$config_file")"
+        token_name="$(jq -r '.auth.token_name // empty' "$config_file")"
+        token_value="$(jq -r '.auth.token_value // empty' "$config_file")"
+        transport="$(jq -r '.mcp.transport // "STDIO"' "$config_file")"
 
-      if ! jq -e 'type == "object" and (.proxmox | type == "object") and (.auth | type == "object")' \
-        "$config_file" >/dev/null; then
-        echo "proxmox-mcp-launcher: invalid Proxmox MCP JSON: $config_file" >&2
-        exit 1
-      fi
-
-      host="$(jq -r '.proxmox.host // empty' "$config_file")"
-      user="$(jq -r '.auth.user // empty' "$config_file")"
-      token_name="$(jq -r '.auth.token_name // empty' "$config_file")"
-      token_value="$(jq -r '.auth.token_value // empty' "$config_file")"
-      transport="$(jq -r '.mcp.transport // "STDIO"' "$config_file")"
-
-      if [ -z "$host" ] || [ "$host" = "your-proxmox-host-ip" ]; then
-        echo "proxmox-mcp-launcher: set proxmox.host in $config_file" >&2
-        exit 1
-      fi
-
-      if [ -z "$user" ] || [ -z "$token_name" ]; then
-        echo "proxmox-mcp-launcher: set auth.user and auth.token_name in $config_file" >&2
-        exit 1
-      fi
-
-      case "$token_value" in
-        "" | "your-token-value" | "replace-me")
-          echo "proxmox-mcp-launcher: set auth.token_value in $config_file" >&2
+        if [ -z "$host" ] || [ "$host" = "your-proxmox-host-ip" ]; then
+          echo "proxmox-mcp-launcher: set proxmox.host in $config_file" >&2
           exit 1
-          ;;
-      esac
+        fi
 
-      if [ "$transport" != "STDIO" ]; then
-        echo "proxmox-mcp-launcher: mcp.transport must be STDIO for Emacs mcp.el" >&2
+        if [ -z "$user" ] || [ -z "$token_name" ]; then
+          echo "proxmox-mcp-launcher: set auth.user and auth.token_name in $config_file" >&2
+          exit 1
+        fi
+
+        case "$token_value" in
+          "" | "your-token-value" | "replace-me")
+            echo "proxmox-mcp-launcher: set auth.token_value in $config_file" >&2
+            exit 1
+            ;;
+        esac
+
+        if [ "$transport" != "STDIO" ]; then
+          echo "proxmox-mcp-launcher: mcp.transport must be STDIO for Emacs mcp.el" >&2
+          exit 1
+        fi
+      elif [ -z "''${PROXMOX_HOST:-}" ] || [ -z "''${PROXMOX_TOKEN_VALUE:-}" ]; then
+        echo "proxmox-mcp-launcher: no readable config at $config_file" >&2
+        echo "and env vars PROXMOX_HOST/PROXMOX_TOKEN_VALUE are unset." >&2
+        echo "Run proxmox-mcp-init, or fill in $env_file." >&2
         exit 1
       fi
 
@@ -92,6 +95,12 @@ in
       type = lib.types.str;
       default = "${config.home.homeDirectory}/.config/proxmox-mcp/config.json";
       description = "Secret Proxmox MCP JSON configuration kept outside the dotfiles repository.";
+    };
+
+    envFile = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.config/proxmox-mcp/proxmox-mcp.env";
+      description = "Optional shell env file sourced before launching the server.";
     };
   };
 


### PR DESCRIPTION
Restores the orphaned `~/.config/proxmox-mcp/proxmox-mcp.env` file as an active config path alongside `config.json`.

## Changes

**`nix/home-manager/mods/proxmox-mcp.nix`**
- Add `proxmoxMcp.envFile` option (defaults to `~/.config/proxmox-mcp/proxmox-mcp.env`)
- Launcher sources `` (or default) before validation, guarded by a readability check and `# shellcheck disable=SC1090`
- If `config.json` is unreadable but `PROXMOX_HOST` / `PROXMOX_TOKEN_VALUE` are exported from the env file, the launcher proceeds instead of aborting

**`lisp/llm/ai-mcp.el`**
- Add `ai/mcp-proxmox-env-file` defcustom
- `ai/mcp-register-proxmox` now treats either `config.json` *or* the env file as the readiness gate, and passes `:env (:PROXMOX_MCP_ENV <path>)` to `mcp-hub-servers` when the env file is readable

## Verification
- `nix flake check --no-build` passes
- `home-manager switch --flake ~/.dotfiles#unseen@flake` builds and activates
- `ai-mcp.el` loads cleanly under `emacs --batch`