### PR TITLE
Restore original Doom Babel bindings

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -276,7 +276,7 @@ The optional argument NEW-WINDOW is not used."
 
 (map! :leader
       :desc "Tangle a file"
-      "o b t" #'org-babel-tangle)
+      "b t" #'org-babel-tangle)
 
 (map! :leader
       :desc "Babel execute selected source block"
@@ -329,7 +329,7 @@ LANGUAGE is a string referring to one of orb-babel's supported languages.
 (map! :leader
       :after org
       :desc "Format Org Babel source blocks"
-      "o b f" #'format-elisp-src-blocks)
+      "b f" #'format-elisp-src-blocks)
 
 (with-eval-after-load 'org
   (require 'org-tempo)

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -578,7 +578,7 @@ Tangle a file
 #+begin_src emacs-lisp
 (map! :leader
       :desc "Tangle a file"
-      "o b t" #'org-babel-tangle)
+      "b t" #'org-babel-tangle)
 #+end_src
 
 Execute the selected source block (used for literate programming)
@@ -644,7 +644,7 @@ LANGUAGE is a string referring to one of orb-babel's supported languages.
 (map! :leader
       :after org
       :desc "Format Org Babel source blocks"
-      "o b f" #'format-elisp-src-blocks)
+      "b f" #'format-elisp-src-blocks)
 #+end_src
 *** Org Tempo templates
 I used to use some of these

--- a/.github/doom-babel-binding-trigger
+++ b/.github/doom-babel-binding-trigger
@@ -1,0 +1,1 @@
+restore original Doom Babel bindings


### PR DESCRIPTION
Restore the two original Org-Babel key sequences only: `SPC b t` for tangling and `SPC b f` for formatting. No other module, package, or keybinding changes.