### PR TITLE
Auto-start Qtile on Arch tty1 login

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-# write content below into ~/.profile, or ~/.bash_profile
+if [[ -f "$HOME/.bashrc" ]]; then
+    source "$HOME/.bashrc"
+fi
 
-# if running bash
-if [ -n "$BASH_VERSION" ]; then
-    # include .bashrc if it exists
-    if [ -f "$HOME/.bashrc" ]; then
-        . "$HOME/.bashrc"
-    fi
+# Start the X11 Qtile session after logging in on the first virtual terminal.
+if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
+    case "$(tty)" in
+        /dev/tty1)
+            exec startx
+            ;;
+    esac
 fi

--- a/.xinitrc
+++ b/.xinitrc
@@ -1,11 +1,33 @@
 #!/bin/sh
 
+if [ -d /etc/X11/xinit/xinitrc.d ]; then
+    for script in /etc/X11/xinit/xinitrc.d/?*.sh; do
+        [ -r "$script" ] && . "$script"
+    done
+    unset script
+fi
+
 export XDG_SESSION_TYPE=x11
 export XDG_CURRENT_DESKTOP=qtile
+export XDG_SESSION_DESKTOP=qtile
 export DESKTOP_SESSION=qtile
 
+if command -v dbus-update-activation-environment >/dev/null 2>&1; then
+    dbus-update-activation-environment --systemd \
+        DISPLAY \
+        XAUTHORITY \
+        XDG_SESSION_TYPE \
+        XDG_CURRENT_DESKTOP \
+        XDG_SESSION_DESKTOP \
+        DESKTOP_SESSION
+fi
+
 systemctl --user import-environment \
-  DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DESKTOP_SESSION
+    DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DESKTOP_SESSION
+
+if command -v gnome-keyring-daemon >/dev/null 2>&1; then
+    gnome-keyring-daemon --start --components=secrets
+fi
 
 "$HOME/.config/qtile/scripts/setup-monitors.sh"
 


### PR DESCRIPTION
## What changed

- start `startx` automatically for Bash logins on `/dev/tty1`
- add a direct `.xinitrc` that imports Arch X init hooks
- export the Qtile desktop session variables
- update the systemd/DBus activation environment before launching Qtile
- execute `qtile start` as the session process

## Why

This makes the stowed dotfiles boot directly into the existing Qtile configuration after a tty1 login, while keeping SSH, secondary TTYs, and existing graphical sessions untouched. The DBus environment export also allows Secret Service/keyring clients such as PyroVibes to discover the graphical session correctly.

## Validation

- `bash -n .bash_profile`
- `sh -n .xinitrc`
