### PR TITLE
Install Dslide in Doom

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -1194,6 +1194,18 @@ If COMPLETING-FN is nil default to `ezf-default'."
 ;; (after! vterm
 ;;   (setq vterm-shell-args '("-c" "STARSHIP_CONFIG=~/.config/starship-plain.toml exec bash")))
 
+;; Dslide: F5 starts any Org source as a slide deck.
+(use-package! dslide
+  :commands (dslide-deck-start dslide-deck-develop dslide-deck-present)
+  :init
+  (map! :map org-mode-map
+        "<f5>" #'dslide-deck-start)
+  :config
+  (map! :leader
+        :desc "Start Dslide deck" "o d s" #'dslide-deck-start
+        :desc "Develop Dslide deck" "o d d" #'dslide-deck-develop
+        :desc "Present Dslide deck" "o d p" #'dslide-deck-present))
+
 ;; StarIntel Social: optional external editorial workstation.
 (let ((root (getenv "STARINTEL_SOCIAL_ROOT")))
   (when (and root (not (string= root "")))

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -1903,6 +1903,18 @@ When the variable is unset, empty, or the checkout is absent, this config does
 nothing. The package exposes its command surface through =M-x starintel-social-menu=.
 
 #+begin_src emacs-lisp
+;; Dslide: F5 starts any Org source as a slide deck.
+(use-package! dslide
+  :commands (dslide-deck-start dslide-deck-develop dslide-deck-present)
+  :init
+  (map! :map org-mode-map
+        "<f5>" #'dslide-deck-start)
+  :config
+  (map! :leader
+        :desc "Start Dslide deck" "o d s" #'dslide-deck-start
+        :desc "Develop Dslide deck" "o d d" #'dslide-deck-develop
+        :desc "Present Dslide deck" "o d p" #'dslide-deck-present))
+
 ;; StarIntel Social: optional external editorial workstation.
 (let ((root (getenv "STARINTEL_SOCIAL_ROOT")))
   (when (and root (not (string= root "")))

--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -52,6 +52,8 @@
 (package! transient :recipe (:host github :repo "magit/transient"))
 
 (unpin! gptel)
+(package! dslide :recipe (:type git :host github :repo "positron-solutions/dslide"))
+
 (package! gptel
   :recipe (:host github :repo "karthink/gptel"
            :files ("*.el")))

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -111,6 +111,13 @@ Create Flashcards from
 (package! org-drill)
 #+end_src
 
+** dslide
+Programmable Org-mode presentations.  This is the actual Dslide runtime; the
+StarIntel presentation source is opened with `M-x dslide-deck-start` or `F5`.
+#+begin_src emacs-lisp
+(package! dslide :recipe (:type git :host github :repo "positron-solutions/dslide"))
+#+end_src
+
 * AI
 ** transient
 Current gptel requires a modern Transient.  Track it with gptel so Dirvish and


### PR DESCRIPTION
Installs `positron-solutions/dslide` through Doom and adds direct deck controls:

- `F5` starts an Org buffer as a Dslide deck
- `SPC o d s` starts the deck
- `SPC o d d` opens Dslide's development layout
- `SPC o d p` presents in a dedicated frame

Updated both literate sources and generated `.el` files. Verified the branch contains the Dslide package recipe and all three commands.