### PR TITLE
Fix Dslide bindings and API collision

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -1194,17 +1194,39 @@ If COMPLETING-FN is nil default to `ezf-default'."
 ;; (after! vterm
 ;;   (setq vterm-shell-args '("-c" "STARSHIP_CONFIG=~/.config/starship-plain.toml exec bash")))
 
-;; Dslide: F5 starts any Org source as a slide deck.
-(use-package! dslide
-  :commands (dslide-deck-start dslide-deck-develop dslide-deck-present)
-  :init
-  (map! :map org-mode-map
-        "<f5>" #'dslide-deck-start)
-  :config
-  (map! :leader
-        :desc "Start Dslide deck" "o d s" #'dslide-deck-start
-        :desc "Develop Dslide deck" "o d d" #'dslide-deck-develop
-        :desc "Present Dslide deck" "o d p" #'dslide-deck-present))
+;; Dslide: clear stale pre-generic API cells before loading the current package.
+(defun +dslide/require ()
+  "Load Dslide without mixing it with the pre-generic implementation."
+  (require 'cl-generic)
+  (dolist (symbol '(dslide-next-child dslide-previous-child))
+    (when (and (fboundp symbol) (not (cl-generic-p symbol)))
+      (fmakunbound symbol)))
+  (require 'dslide))
+
+(defun +dslide/start ()
+  "Start the current Org document as a Dslide deck."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-start))
+
+(defun +dslide/develop ()
+  "Open the current Org document in Dslide's development layout."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-develop))
+
+(defun +dslide/present ()
+  "Present the current Org document through Dslide."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-present))
+
+(map! :map org-mode-map
+      "<f5>" #'+dslide/start
+      :leader
+      :desc "Start Dslide deck" "o D" #'+dslide/start
+      :desc "Develop Dslide deck" "o C" #'+dslide/develop
+      :desc "Present Dslide deck" "o V" #'+dslide/present)
 
 ;; StarIntel Social: optional external editorial workstation.
 (let ((root (getenv "STARINTEL_SOCIAL_ROOT")))

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -1903,17 +1903,39 @@ When the variable is unset, empty, or the checkout is absent, this config does
 nothing. The package exposes its command surface through =M-x starintel-social-menu=.
 
 #+begin_src emacs-lisp
-;; Dslide: F5 starts any Org source as a slide deck.
-(use-package! dslide
-  :commands (dslide-deck-start dslide-deck-develop dslide-deck-present)
-  :init
-  (map! :map org-mode-map
-        "<f5>" #'dslide-deck-start)
-  :config
-  (map! :leader
-        :desc "Start Dslide deck" "o d s" #'dslide-deck-start
-        :desc "Develop Dslide deck" "o d d" #'dslide-deck-develop
-        :desc "Present Dslide deck" "o d p" #'dslide-deck-present))
+;; Dslide: clear stale pre-generic API cells before loading the current package.
+(defun +dslide/require ()
+  "Load Dslide without mixing it with the pre-generic implementation."
+  (require 'cl-generic)
+  (dolist (symbol '(dslide-next-child dslide-previous-child))
+    (when (and (fboundp symbol) (not (cl-generic-p symbol)))
+      (fmakunbound symbol)))
+  (require 'dslide))
+
+(defun +dslide/start ()
+  "Start the current Org document as a Dslide deck."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-start))
+
+(defun +dslide/develop ()
+  "Open the current Org document in Dslide's development layout."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-develop))
+
+(defun +dslide/present ()
+  "Present the current Org document through Dslide."
+  (interactive)
+  (+dslide/require)
+  (dslide-deck-present))
+
+(map! :map org-mode-map
+      "<f5>" #'+dslide/start
+      :leader
+      :desc "Start Dslide deck" "o D" #'+dslide/start
+      :desc "Develop Dslide deck" "o C" #'+dslide/develop
+      :desc "Present Dslide deck" "o V" #'+dslide/present)
 
 ;; StarIntel Social: optional external editorial workstation.
 (let ((root (getenv "STARINTEL_SOCIAL_ROOT")))


### PR DESCRIPTION
Fixes the two startup failures:

- replaces invalid `SPC o d s/d/p` sequences (`SPC o d` is already a command) with single-key bindings: `SPC o D`, `SPC o C`, and `SPC o V`
- clears stale pre-generic Dslide function cells before requiring the current package, preventing `dslide-next-child` from colliding with Dslide's generic method definition

The change is mirrored in `config.org` and generated `config.el`.