### PR TITLE
Keep Dslide in insert state and add effects

### DIFF
--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -1201,7 +1201,32 @@ If COMPLETING-FN is nil default to `ezf-default'."
   (dolist (symbol '(dslide-next-child dslide-previous-child))
     (when (and (fboundp symbol) (not (cl-generic-p symbol)))
       (fmakunbound symbol)))
-  (require 'dslide))
+  (require 'dslide)
+  (setq dslide-slide-in-effect t
+        dslide-animation-duration 0.25
+        dslide-slide-in-blank-lines 8
+        dslide-default-actions
+        '(dslide-action-hide-markup
+          dslide-action-propertize
+          dslide-action-kmacro
+          dslide-action-babel
+          dslide-action-image
+          dslide-action-item-reveal)))
+
+(defun +dslide/insert-state ()
+  "Keep Dslide presentation buffers in Evil insert state."
+  (when (fboundp 'evil-insert-state)
+    (evil-insert-state)))
+
+(defun +dslide/setup-effects ()
+  "Apply presentation-only spacing and cursor behavior."
+  (setq-local line-spacing 0.2)
+  (setq-local cursor-type nil)
+  (+dslide/insert-state))
+
+(add-hook 'dslide-start-hook #'+dslide/setup-effects)
+(add-hook 'dslide-develop-hook #'+dslide/setup-effects)
+(add-hook 'dslide-present-hook #'+dslide/setup-effects)
 
 (defun +dslide/start ()
   "Start the current Org document as a Dslide deck."

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -1910,7 +1910,32 @@ nothing. The package exposes its command surface through =M-x starintel-social-m
   (dolist (symbol '(dslide-next-child dslide-previous-child))
     (when (and (fboundp symbol) (not (cl-generic-p symbol)))
       (fmakunbound symbol)))
-  (require 'dslide))
+  (require 'dslide)
+  (setq dslide-slide-in-effect t
+        dslide-animation-duration 0.25
+        dslide-slide-in-blank-lines 8
+        dslide-default-actions
+        '(dslide-action-hide-markup
+          dslide-action-propertize
+          dslide-action-kmacro
+          dslide-action-babel
+          dslide-action-image
+          dslide-action-item-reveal)))
+
+(defun +dslide/insert-state ()
+  "Keep Dslide presentation buffers in Evil insert state."
+  (when (fboundp 'evil-insert-state)
+    (evil-insert-state)))
+
+(defun +dslide/setup-effects ()
+  "Apply presentation-only spacing and cursor behavior."
+  (setq-local line-spacing 0.2)
+  (setq-local cursor-type nil)
+  (+dslide/insert-state))
+
+(add-hook 'dslide-start-hook #'+dslide/setup-effects)
+(add-hook 'dslide-develop-hook #'+dslide/setup-effects)
+(add-hook 'dslide-present-hook #'+dslide/setup-effects)
 
 (defun +dslide/start ()
   "Start the current Org document as a Dslide deck."


### PR DESCRIPTION
Makes Dslide usable with Evil and gives every slide visual progression:

- presentation, development, and dedicated-frame buffers enter Evil insert state
- enables fast slide-in transitions
- reveals list items one at a time as the deck advances
- applies presentation-only spacing and hides the cursor

Mirrors the change in `config.org` and generated `config.el`.