### PR TITLE
add Whisper fallback to YouTube context

### DIFF
--- a/lisp/llm/youtube-context.el
+++ b/lisp/llm/youtube-context.el
@@ -2,7 +2,8 @@
 
 ;;; Commentary:
 ;; Fetch English subtitles with yt-dlp, normalize them to plain text, and copy
-;; a compact context packet to the kill ring/system clipboard.
+;; a compact context packet to the kill ring/system clipboard.  If captions are
+;; unavailable, download the audio and transcribe it locally with OpenAI Whisper.
 
 ;;; Code:
 
@@ -15,13 +16,33 @@
   :group 'applications)
 
 (defcustom ai/youtube-context-program "yt-dlp"
-  "yt-dlp executable used to fetch subtitles."
+  "yt-dlp executable used to fetch subtitles and audio."
   :type 'string
   :group 'ai/youtube-context)
 
 (defcustom ai/youtube-context-sub-langs "en.*,en"
   "yt-dlp subtitle language selector used for transcript context."
   :type 'string
+  :group 'ai/youtube-context)
+
+(defcustom ai/youtube-context-whisper-program "whisper"
+  "OpenAI Whisper executable used when a video has no usable captions."
+  :type 'string
+  :group 'ai/youtube-context)
+
+(defcustom ai/youtube-context-whisper-model "base.en"
+  "Whisper model used for local English audio transcription."
+  :type 'string
+  :group 'ai/youtube-context)
+
+(defcustom ai/youtube-context-whisper-language "en"
+  "Language passed to Whisper for local audio transcription."
+  :type 'string
+  :group 'ai/youtube-context)
+
+(defcustom ai/youtube-context-whisper-threads 16
+  "CPU threads passed to Whisper during local transcription."
+  :type 'integer
   :group 'ai/youtube-context)
 
 (defun ai/youtube--clipboard-text ()
@@ -38,7 +59,7 @@
     url))
 
 (defun ai/youtube--normalize-text (text)
-  "Normalize subtitle TEXT into compact plain text."
+  "Normalize subtitle or transcription TEXT into compact plain text."
   (string-trim
    (replace-regexp-in-string
     "[[:space:]]+" " "
@@ -120,7 +141,8 @@
     (string-trim (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun ai/youtube--download-subtitle (program url directory)
-  "Use PROGRAM to download subtitles for URL into DIRECTORY."
+  "Use PROGRAM to download subtitles for URL into DIRECTORY.
+Return the preferred subtitle file, or nil when no matching subtitles exist."
   (let ((default-directory directory)
         (buffer (generate-new-buffer " *yt-dlp-context*")))
     (unwind-protect
@@ -136,10 +158,86 @@
                 "--output" "%(id)s.%(ext)s"
                 url)))
           (unless (eq status 0)
-            (error "yt-dlp failed: %s" (ai/youtube--process-output buffer)))
-          (or (ai/youtube--best-subtitle directory)
-              (error "yt-dlp found no English subtitles for this video")))
+            (error "yt-dlp subtitle fetch failed: %s"
+                   (ai/youtube--process-output buffer)))
+          (ai/youtube--best-subtitle directory))
       (kill-buffer buffer))))
+
+(defun ai/youtube--subtitle-transcript (program url directory)
+  "Return a non-empty caption transcript for URL, or nil."
+  (when-let ((subtitle (ai/youtube--download-subtitle program url directory)))
+    (let ((transcript
+           (if (string-suffix-p ".json3" subtitle)
+               (ai/youtube--json3-transcript subtitle)
+             (ai/youtube--vtt-transcript subtitle))))
+      (unless (string-empty-p transcript)
+        transcript))))
+
+(defun ai/youtube--download-audio (program url directory)
+  "Use yt-dlp PROGRAM to download best audio for URL into DIRECTORY."
+  (let ((default-directory directory)
+        (buffer (generate-new-buffer " *yt-dlp-audio*")))
+    (unwind-protect
+        (let ((status
+               (process-file
+                program nil buffer nil
+                "--no-playlist"
+                "--format" "bestaudio/best"
+                "--output" "audio.%(ext)s"
+                url)))
+          (unless (eq status 0)
+            (error "yt-dlp audio download failed: %s"
+                   (ai/youtube--process-output buffer)))
+          (or (car (directory-files directory t "\\`audio\\.[^.]+\\'"))
+              (error "yt-dlp completed without producing an audio file")))
+      (kill-buffer buffer))))
+
+(defun ai/youtube--read-text-file (file)
+  "Return normalized text contents of FILE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (ai/youtube--normalize-text (buffer-string))))
+
+(defun ai/youtube--whisper-transcript (yt-dlp-program url directory)
+  "Download URL audio with YT-DLP-PROGRAM and transcribe it in DIRECTORY."
+  (let ((whisper (executable-find ai/youtube-context-whisper-program)))
+    (unless whisper
+      (user-error
+       "No usable captions and %s is not available in PATH"
+       ai/youtube-context-whisper-program))
+    (unless (executable-find "ffmpeg")
+      (user-error "No usable captions and ffmpeg is required by Whisper"))
+    (let* ((audio (ai/youtube--download-audio yt-dlp-program url directory))
+           (output (expand-file-name
+                    (concat (file-name-base audio) ".txt")
+                    directory))
+           (buffer (generate-new-buffer " *whisper-context*")))
+      (message "No usable captions; transcribing audio locally with Whisper %s..."
+               ai/youtube-context-whisper-model)
+      (unwind-protect
+          (let ((status
+                 (process-file
+                  whisper nil buffer nil
+                  audio
+                  "--model" ai/youtube-context-whisper-model
+                  "--device" "cpu"
+                  "--language" ai/youtube-context-whisper-language
+                  "--task" "transcribe"
+                  "--output_format" "txt"
+                  "--output_dir" directory
+                  "--verbose" "False"
+                  "--fp16" "False"
+                  "--threads" (number-to-string ai/youtube-context-whisper-threads))))
+            (unless (eq status 0)
+              (error "Whisper transcription failed: %s"
+                     (ai/youtube--process-output buffer)))
+            (unless (file-exists-p output)
+              (error "Whisper completed without producing %s" output))
+            (let ((transcript (ai/youtube--read-text-file output)))
+              (when (string-empty-p transcript)
+                (error "Whisper produced an empty transcript"))
+              transcript))
+        (kill-buffer buffer)))))
 
 (defun ai/youtube--video-title (program url)
   "Return the title for URL using PROGRAM, or nil on failure."
@@ -158,10 +256,12 @@
 
 ;;;###autoload
 (defun ai/youtube-context (url)
-  "Fetch URL subtitles with yt-dlp and copy plain transcript context.
+  "Copy a transcript context packet for video URL.
 
-The prompt defaults to an HTTP URL currently in the clipboard.  The copied
-packet contains the video title, URL, and normalized transcript text."
+English human or automatic captions are preferred.  If no usable captions are
+available, download the audio with yt-dlp and transcribe it locally with
+OpenAI Whisper.  The prompt defaults to an HTTP URL currently in the clipboard.
+The copied packet contains the video title, URL, transcript source, and text."
   (interactive
    (list
     (read-string "Video URL: " (or (ai/youtube--clipboard-url) ""))))
@@ -172,22 +272,27 @@ packet contains the video title, URL, and normalized transcript text."
       (user-error "Expected an http(s) video URL"))
     (let ((directory (make-temp-file "yt-dlp-context-" t)))
       (unwind-protect
-          (let* ((subtitle (ai/youtube--download-subtitle program url directory))
+          (let* ((caption-transcript
+                  (ai/youtube--subtitle-transcript program url directory))
+                 (source
+                  (if caption-transcript
+                      "video captions"
+                    (format "local Whisper (%s)"
+                            ai/youtube-context-whisper-model)))
                  (transcript
-                  (if (string-suffix-p ".json3" subtitle)
-                      (ai/youtube--json3-transcript subtitle)
-                    (ai/youtube--vtt-transcript subtitle)))
+                  (or caption-transcript
+                      (ai/youtube--whisper-transcript program url directory)))
                  (title (or (ai/youtube--video-title program url) "Video"))
                  (context
-                  (format "Title: %s\nURL: %s\n\nTranscript:\n%s"
-                          title url transcript))
+                  (format
+                   "Title: %s\nURL: %s\nTranscript source: %s\n\nTranscript:\n%s"
+                   title url source transcript))
                  (words (length (split-string transcript "[[:space:]]+" t))))
-            (when (string-empty-p transcript)
-              (user-error "Downloaded subtitles contained no transcript text"))
             (kill-new context)
             (when (fboundp 'gui-set-selection)
               (ignore-errors (gui-set-selection 'CLIPBOARD context)))
-            (message "Copied YouTube context: %d words from %s" words title))
+            (message "Copied YouTube context: %d words from %s via %s"
+                     words title source))
         (delete-directory directory t)))))
 
 (provide 'youtube-context)

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -26,6 +26,7 @@
       #codex
       espeak-ng
       sox
+      ffmpeg
       alsa-utils
 
       # GUI and notification utilities


### PR DESCRIPTION
Extends the YouTube context command so missing captions no longer stop the workflow.

- prefer human/auto English captions as before
- if captions are missing or empty, download best audio with `yt-dlp`
- transcribe locally with OpenAI Whisper using `base.en`, CPU, FP32, and 16 threads
- include transcript source in the copied context packet
- make Whisper model/language/thread settings customizable
- ensure `ffmpeg` is explicitly installed with the LLM Home Manager module

The same `SPC y v`, `M-x +llm/youtube-context`, and `M-x +llm/yt-dlp-context` entrypoints continue to work.