### PR TITLE
Add reusable prompt templates and OpenAI image tools

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -10,9 +10,23 @@
 (autoload #'ai/youtube-context "youtube-context" "Copy yt-dlp transcript context." t)
 
 ;;;###autoload
+(autoload #'ai/prompt-menu "ai-prompts" "Open reusable prompt and image commands." t)
+
+;;;###autoload
+(autoload #'ai/image-generate "ai-image" "Generate an image with OpenAI's image tool." t)
+
+;;;###autoload
+(autoload #'ai/image-generate-template "ai-image" "Generate an image from a reusable prompt template." t)
+
+;;;###autoload
+(autoload #'ai/image-edit "ai-image" "Edit an image with OpenAI's image tool." t)
+
+;;;###autoload
 (defun +llm/bind-keys ()
   "Bind the local LLM entrypoints after Doom finishes loading."
+  (define-key doom-leader-map (kbd "y i") #'+llm/image-generate)
   (define-key doom-leader-map (kbd "y m") #'ai/meme-generate)
+  (define-key doom-leader-map (kbd "y p") #'+llm/prompt-menu)
   (define-key doom-leader-map (kbd "y v") #'+llm/youtube-context)
   (define-key doom-leader-map (kbd "y y") #'ai/chat))
 
@@ -85,6 +99,34 @@
   (call-interactively #'ai/youtube-context))
 
 (defalias '+llm/yt-dlp-context #'+llm/youtube-context)
+
+;;;###autoload
+(defun +llm/prompt-menu ()
+  "Open the reusable prompt-template and image-generation menu."
+  (interactive)
+  (require 'ai-prompts)
+  (ai/prompt-menu))
+
+;;;###autoload
+(defun +llm/image-generate ()
+  "Generate an image from the active region or a minibuffer prompt."
+  (interactive)
+  (require 'ai-image)
+  (call-interactively #'ai/image-generate))
+
+;;;###autoload
+(defun +llm/image-generate-template ()
+  "Generate an image from a reusable prompt template."
+  (interactive)
+  (require 'ai-image)
+  (call-interactively #'ai/image-generate-template))
+
+;;;###autoload
+(defun +llm/image-edit ()
+  "Edit an image using OpenAI's image-generation tool."
+  (interactive)
+  (require 'ai-image)
+  (call-interactively #'ai/image-edit))
 
 ;;;###autoload
 (defun +llm/use-glm-5.2 (&optional local)

--- a/lisp/llm/ai-image.el
+++ b/lisp/llm/ai-image.el
@@ -1,0 +1,227 @@
+;;; ai-image.el --- OpenAI image-generation tools for Emacs -*- lexical-binding: t; -*-
+
+(require 'ai)
+(require 'ai-prompts)
+(require 'cl-lib)
+(require 'json)
+(require 'subr-x)
+(require 'url)
+(require 'url-http)
+
+(defgroup ai/image nil
+  "OpenAI image generation and editing."
+  :group 'applications
+  :prefix "ai/image-")
+
+(defcustom ai/image-responses-endpoint "https://api.openai.com/v1/responses"
+  "OpenAI Responses API endpoint used for image-tool calls."
+  :type 'string
+  :group 'ai/image)
+
+(defcustom ai/image-responses-model "gpt-5.2"
+  "OpenAI model that invokes the hosted image-generation tool."
+  :type 'string
+  :group 'ai/image)
+
+(defcustom ai/image-model "gpt-image-1.5"
+  "Image model passed to the OpenAI image-generation tool."
+  :type 'string
+  :group 'ai/image)
+
+(defcustom ai/image-size "1024x1024"
+  "Default generated image size."
+  :type '(choice (const "1024x1024")
+                 (const "1024x1536")
+                 (const "1536x1024")
+                 (const "auto"))
+  :group 'ai/image)
+
+(defcustom ai/image-quality "high"
+  "Default generated image quality."
+  :type '(choice (const "low")
+                 (const "medium")
+                 (const "high")
+                 (const "auto"))
+  :group 'ai/image)
+
+(defcustom ai/image-output-format "png"
+  "Default generated image format."
+  :type '(choice (const "png") (const "webp") (const "jpeg"))
+  :group 'ai/image)
+
+(defcustom ai/image-output-directory
+  (expand-file-name "ai/" (or (getenv "XDG_PICTURES_DIR") "~/Pictures/"))
+  "Directory where generated images are written."
+  :type 'directory
+  :group 'ai/image)
+
+(defcustom ai/image-open-after-generate t
+  "When non-nil, open a generated image after saving it."
+  :type 'boolean
+  :group 'ai/image)
+
+(defun ai/image--prompt ()
+  "Return an image prompt from the active region or minibuffer."
+  (if (use-region-p)
+      (buffer-substring-no-properties (region-beginning) (region-end))
+    (read-string "Image prompt: ")))
+
+(defun ai/image--filename (&optional stem)
+  "Return a fresh output filename using optional STEM."
+  (make-directory ai/image-output-directory t)
+  (expand-file-name
+   (format "%s-%s.%s"
+           (or stem "image")
+           (format-time-string "%Y%m%d-%H%M%S-%3N")
+           ai/image-output-format)
+   ai/image-output-directory))
+
+(defun ai/image--tool (&optional action)
+  "Return the image-generation tool declaration for ACTION."
+  (append
+   `((type . "image_generation")
+     (model . ,ai/image-model)
+     (size . ,ai/image-size)
+     (quality . ,ai/image-quality)
+     (background . "auto")
+     (output_format . ,ai/image-output-format))
+   (when action `((action . ,action)))
+   (when (equal action "edit") '((input_fidelity . "high")))))
+
+(defun ai/image--request-body (input &optional action)
+  "Build a Responses API body from INPUT and optional image ACTION."
+  `((model . ,ai/image-responses-model)
+    (input . ,input)
+    (tools . ,(vector (ai/image--tool action)))
+    (tool_choice . ((type . "image_generation")))))
+
+(defun ai/image--read-json-response ()
+  "Read the JSON body from the current URL response buffer."
+  (goto-char (point-min))
+  (unless (re-search-forward "\r?\n\r?\n" nil t)
+    (error "Malformed HTTP response"))
+  (let ((json-object-type 'alist)
+        (json-array-type 'list)
+        (json-key-type 'symbol)
+        (json-false nil)
+        (json-null nil))
+    (json-read)))
+
+(defun ai/image--api-error (payload)
+  "Return a useful API error string from PAYLOAD."
+  (or (alist-get 'message (alist-get 'error payload))
+      (alist-get 'error payload)
+      "OpenAI image request failed"))
+
+(defun ai/image--result (payload)
+  "Return the base64 image result from Responses API PAYLOAD."
+  (when-let ((call
+              (cl-find-if
+               (lambda (item)
+                 (equal (alist-get 'type item) "image_generation_call"))
+               (alist-get 'output payload))))
+    (alist-get 'result call)))
+
+(defun ai/image--write-result (encoded file)
+  "Decode base64 ENCODED image data and write it to FILE."
+  (let ((data (base64-decode-string encoded)))
+    (make-directory (file-name-directory file) t)
+    (with-temp-buffer
+      (set-buffer-multibyte nil)
+      (insert data)
+      (let ((coding-system-for-write 'no-conversion))
+        (write-region (point-min) (point-max) file nil 'silent))))
+  file)
+
+(defun ai/image--response-callback (status output-file callback)
+  "Handle image HTTP STATUS, writing OUTPUT-FILE and invoking CALLBACK."
+  (unwind-protect
+      (condition-case err
+          (let* ((http-status (and (boundp 'url-http-response-status)
+                                   url-http-response-status))
+                 (payload (ai/image--read-json-response)))
+            (when (or (plist-get status :error)
+                      (and http-status (>= http-status 400)))
+              (error "%s" (ai/image--api-error payload)))
+            (let ((result (ai/image--result payload)))
+              (unless result
+                (error "OpenAI response contained no image_generation_call result"))
+              (ai/image--write-result result output-file)
+              (when ai/image-open-after-generate
+                (find-file-other-window output-file))
+              (when callback
+                (funcall callback output-file))
+              (message "Image saved: %s" output-file)))
+        (error
+         (message "Image generation failed: %s" (error-message-string err))))
+    (kill-buffer (current-buffer))))
+
+(defun ai/image--request (input output-file &optional action callback)
+  "Send image INPUT and asynchronously write OUTPUT-FILE.
+ACTION is nil for generation or \="edit\=" for image editing.  CALLBACK is
+called with OUTPUT-FILE after a successful request."
+  (let* ((key (ai/llm--require-api-key 'openai))
+         (url-request-method "POST")
+         (url-request-extra-headers
+          `(("Authorization" . ,(concat "Bearer " key))
+            ("Content-Type" . "application/json")))
+         (url-request-data
+          (encode-coding-string
+           (json-encode (ai/image--request-body input action)) 'utf-8)))
+    (url-retrieve ai/image-responses-endpoint
+                  #'ai/image--response-callback
+                  (list output-file callback)
+                  t t)
+    (message "Generating image with %s / %s..."
+             ai/image-responses-model ai/image-model)))
+
+(defun ai/image-generate (prompt &optional output-file)
+  "Generate an image from PROMPT using OpenAI's image-generation tool."
+  (interactive (list (ai/image--prompt)))
+  (unless (and prompt (not (string-empty-p (string-trim prompt))))
+    (user-error "Image prompt is empty"))
+  (ai/image--request prompt (or output-file (ai/image--filename))))
+
+(defun ai/image-generate-template (&optional name)
+  "Fill reusable prompt template NAME and generate an image from it."
+  (interactive)
+  (ai/image-generate (ai/prompt-template-render name)))
+
+(defun ai/image--mime-type (file)
+  "Return a supported image MIME type for FILE."
+  (pcase (downcase (or (file-name-extension file) ""))
+    ("png" "image/png")
+    ((or "jpg" "jpeg") "image/jpeg")
+    ("webp" "image/webp")
+    (_ (user-error "Unsupported image format: %s" file))))
+
+(defun ai/image--data-url (file)
+  "Return FILE encoded as an image data URL."
+  (unless (file-readable-p file)
+    (user-error "Image is not readable: %s" file))
+  (let ((mime (ai/image--mime-type file)))
+    (with-temp-buffer
+      (set-buffer-multibyte nil)
+      (insert-file-contents-literally file)
+      (format "data:%s;base64,%s"
+              mime (base64-encode-string (buffer-string) t)))))
+
+(defun ai/image-edit (file prompt &optional output-file)
+  "Edit image FILE according to PROMPT using OpenAI's image-generation tool."
+  (interactive
+   (list (read-file-name "Image to edit: " nil nil t)
+         (ai/image--prompt)))
+  (unless (and prompt (not (string-empty-p (string-trim prompt))))
+    (user-error "Image edit prompt is empty"))
+  (let ((input
+         (vector
+          `((role . "user")
+            (content . ,(vector
+                         `((type . "input_text") (text . ,prompt))
+                         `((type . "input_image")
+                           (image_url . ,(ai/image--data-url file)))))))))
+    (ai/image--request input (or output-file (ai/image--filename "edit"))
+                       "edit")))
+
+(provide 'ai-image)
+;;; ai-image.el ends here

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -1,6 +1,8 @@
 ;;; ai-init.el --- Load the Emacs LLM stack -*- lexical-binding: t; -*-
 
 (require 'ai)
+(require 'ai-prompts)
+(require 'ai-image)
 (require 'meme)
 (require 'ai-agent)
 (require 'ai-mcp)

--- a/lisp/llm/ai-prompts.el
+++ b/lisp/llm/ai-prompts.el
@@ -1,0 +1,168 @@
+;;; ai-prompts.el --- Reusable prompt templates for the LLM stack -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'subr-x)
+(require 'transient)
+
+(defgroup ai/prompts nil
+  "Reusable prompt templates."
+  :group 'applications
+  :prefix "ai/prompt-")
+
+(defconst ai/prompt--module-directory
+  (file-name-directory (or load-file-name buffer-file-name user-emacs-directory)))
+
+(defcustom ai/prompt-template-directory
+  (expand-file-name "prompts/" ai/prompt--module-directory)
+  "Directory containing reusable prompt templates."
+  :type 'directory
+  :group 'ai/prompts)
+
+(defcustom ai/prompt-template-extension ".prompt"
+  "Filename extension used by prompt templates."
+  :type 'string
+  :group 'ai/prompts)
+
+(defconst ai/prompt--field-regexp
+  "{{\\([[:alnum:]_.-]+\\)\\(?:|\\([^}\n]*\\)\\)?}}")
+
+(defun ai/prompt-template-files ()
+  "Return prompt template files in `ai/prompt-template-directory'."
+  (when (file-directory-p ai/prompt-template-directory)
+    (directory-files
+     ai/prompt-template-directory t
+     (concat (regexp-quote ai/prompt-template-extension) "\\'") t)))
+
+(defun ai/prompt-template-names ()
+  "Return available prompt template names."
+  (mapcar #'file-name-base (ai/prompt-template-files)))
+
+(defun ai/prompt-template-read-name (&optional prompt)
+  "Read an existing template name using PROMPT."
+  (let ((names (ai/prompt-template-names)))
+    (unless names
+      (user-error "No prompt templates in %s" ai/prompt-template-directory))
+    (completing-read (or prompt "Prompt template: ") names nil t)))
+
+(defun ai/prompt-template-path (name)
+  "Return the path for template NAME."
+  (expand-file-name (concat name ai/prompt-template-extension)
+                    ai/prompt-template-directory))
+
+(defun ai/prompt-template--read (name)
+  "Read template NAME as text."
+  (let ((file (ai/prompt-template-path name)))
+    (unless (file-readable-p file)
+      (user-error "Prompt template does not exist: %s" name))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (buffer-string))))
+
+(defun ai/prompt-template--fields (template)
+  "Return unique placeholder fields from TEMPLATE in appearance order."
+  (let ((start 0)
+        fields)
+    (while (string-match ai/prompt--field-regexp template start)
+      (let ((name (match-string 1 template))
+            (default (match-string 2 template)))
+        (unless (assoc-string name fields)
+          (setq fields (append fields (list (cons name default)))))
+        (setq start (match-end 0))))
+    fields))
+
+(defun ai/prompt-template--ask-values (template)
+  "Prompt for every placeholder value in TEMPLATE."
+  (mapcar
+   (lambda (field)
+     (let* ((name (car field))
+            (default (cdr field))
+            (label (replace-regexp-in-string "[_-]+" " " name))
+            (prompt (if (and default (not (string-empty-p default)))
+                        (format "%s [%s]: " label default)
+                      (format "%s: " label))))
+       (cons name (read-string prompt nil nil default))))
+   (ai/prompt-template--fields template)))
+
+(defun ai/prompt-template-render-string (template values)
+  "Render TEMPLATE using placeholder VALUES.
+VALUES is an alist mapping placeholder names to strings."
+  (let ((rendered template)
+        (start 0))
+    (while (string-match ai/prompt--field-regexp rendered start)
+      (let* ((name (match-string 1 rendered))
+             (default (or (match-string 2 rendered) ""))
+             (entry (assoc-string name values))
+             (value (or (cdr entry) default)))
+        (setq rendered (replace-match value t t rendered))
+        (setq start (+ (match-beginning 0) (length value)))))
+    rendered))
+
+(defun ai/prompt-template-render (&optional name)
+  "Fill and return prompt template NAME.
+When called interactively, show the rendered prompt in a preview buffer."
+  (interactive)
+  (let* ((name (or name (ai/prompt-template-read-name)))
+         (template (ai/prompt-template--read name))
+         (rendered (ai/prompt-template-render-string
+                    template (ai/prompt-template--ask-values template))))
+    (when (called-interactively-p 'interactive)
+      (with-current-buffer (get-buffer-create "*AI Prompt Preview*")
+        (erase-buffer)
+        (insert rendered)
+        (goto-char (point-min))
+        (text-mode)
+        (pop-to-buffer (current-buffer))))
+    rendered))
+
+(defun ai/prompt-template-copy (&optional name)
+  "Fill template NAME and copy the result to the kill ring."
+  (interactive)
+  (let ((rendered (ai/prompt-template-render name)))
+    (kill-new rendered)
+    (message "Prompt copied (%d chars)" (length rendered))))
+
+(defun ai/prompt-template-insert (&optional name)
+  "Fill template NAME and insert the result at point."
+  (interactive)
+  (insert (ai/prompt-template-render name)))
+
+(defun ai/prompt-template-edit (&optional name)
+  "Open template NAME for editing."
+  (interactive)
+  (find-file (ai/prompt-template-path
+              (or name (ai/prompt-template-read-name "Edit template: ")))))
+
+(defun ai/prompt-template-new (name &optional initial)
+  "Create prompt template NAME, optionally seeded with INITIAL text."
+  (interactive
+   (list (read-string "New template name: ")
+         (when (use-region-p)
+           (buffer-substring-no-properties (region-beginning) (region-end)))))
+  (unless (string-match-p "\\`[[:alnum:]_.-]+\\'" name)
+    (user-error "Template names may contain only letters, numbers, ., _, and -"))
+  (make-directory ai/prompt-template-directory t)
+  (let ((file (ai/prompt-template-path name)))
+    (when (file-exists-p file)
+      (user-error "Prompt template already exists: %s" name))
+    (write-region (or initial "") nil file nil 'silent)
+    (find-file file)))
+
+(declare-function ai/image-generate "ai-image")
+(declare-function ai/image-generate-template "ai-image")
+(declare-function ai/image-edit "ai-image")
+
+(transient-define-prefix ai/prompt-menu ()
+  "Prompt-template and image-generation commands."
+  [["Prompt templates"
+    ("c" "Copy filled prompt" ai/prompt-template-copy)
+    ("i" "Insert filled prompt" ai/prompt-template-insert)
+    ("p" "Preview filled prompt" ai/prompt-template-render)
+    ("e" "Edit template" ai/prompt-template-edit)
+    ("n" "New template" ai/prompt-template-new)]
+   ["OpenAI image tools"
+    ("g" "Generate from prompt" ai/image-generate)
+    ("t" "Generate from template" ai/image-generate-template)
+    ("x" "Edit image" ai/image-edit)]])
+
+(provide 'ai-prompts)
+;;; ai-prompts.el ends here

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -81,6 +81,60 @@ Available presets:
 - =@agent= — GLM-5.2 with the project agent tools
 - =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tools
 
+* Reusable prompt templates
+
+Reusable plain-text prompts live under =lisp/llm/prompts/= with a =.prompt=
+extension.  Fields use ={{NAME}}= syntax.  Defaults use
+={{NAME|default value}}=.  Repeated fields are asked once and reused anywhere
+that field appears in the template.
+
+The included =starintel-visual.prompt= captures the black/gold StarIntel
+infographic design language as a reusable design-system prompt.
+
+Useful commands:
+
+#+begin_src emacs-lisp
+M-x ai/prompt-menu
+M-x ai/prompt-template-render
+M-x ai/prompt-template-copy
+M-x ai/prompt-template-insert
+M-x ai/prompt-template-new
+M-x ai/prompt-template-edit
+#+end_src
+
+Doom binds =SPC y p= to the prompt/image Transient menu.
+
+* OpenAI image tools
+
+=image-generation= calls use the hosted OpenAI Responses API image tool instead
+of routing through OpenRouter.  They therefore require =OPENAI_API_KEY= or an
+=auth-source= entry for =api.openai.com=.  Image requests run asynchronously
+through Emacs =url.el=; the API key is sent as an HTTP header rather than being
+placed in a shell command line.
+
+The defaults use =gpt-5.2= to invoke the hosted tool and =gpt-image-1.5= as the
+image model.  Both are customizable with =ai/image-responses-model= and
+=ai/image-model=.
+
+Generated files default to =~/Pictures/ai/= and open automatically when the
+request completes.
+
+#+begin_src emacs-lisp
+M-x ai/image-generate
+M-x ai/image-generate-template
+M-x ai/image-edit
+#+end_src
+
+=ai/image-generate= uses the active region as the prompt when a region is
+selected.  =ai/image-generate-template= fills one of the reusable templates and
+sends the rendered prompt directly to the image tool.  =ai/image-edit= sends a
+local PNG, JPEG, or WebP as an image input and requests an edit with high input
+fidelity.
+
+Doom binds =SPC y i= directly to image generation.  The =SPC y p= Transient
+also exposes generation from a raw prompt, generation from a template, and
+image editing.
+
 * OpenAI subscription OAuth
 
 Current gptel can authenticate a ChatGPT subscription without storing an API
@@ -167,6 +221,8 @@ Chats are stored below =~/Documents/Notes/org/roam/llm/=.
 * Source files
 
 #+INCLUDE: "ai.el" src emacs-lisp
+#+INCLUDE: "ai-prompts.el" src emacs-lisp
+#+INCLUDE: "ai-image.el" src emacs-lisp
 #+INCLUDE: "ai-agent-core.el" src emacs-lisp
 #+INCLUDE: "agent-core.el" src emacs-lisp
 #+INCLUDE: "ai-agent.el" src emacs-lisp

--- a/lisp/llm/prompts/starintel-visual.prompt
+++ b/lisp/llm/prompts/starintel-visual.prompt
@@ -1,0 +1,138 @@
+Create a polished technical product infographic using the following visual system.
+
+STYLE / BRAND
+- Premium cyber-intelligence / distributed-systems aesthetic.
+- Near-black matte background (#050606 to #0A0A09).
+- Metallic gold as the primary accent: warm yellow-gold, roughly #EAB52E / #F1BD38.
+- White and very light gray for secondary text.
+- Extremely subtle dark gray grid texture in the background.
+- Sparse graph/network visualization around the outer edges:
+  - small circular nodes
+  - thin connecting lines
+  - occasional gold-highlighted nodes and edges
+  - low opacity so the graph never competes with the content.
+- The overall appearance should feel like distributed systems architecture + intelligence graph + premium engineering documentation.
+- Serious, technical, restrained.
+- No generic neon cyberpunk.
+- No blue/purple gradients.
+- No excessive glow.
+- No fake 3D dashboards.
+- No stock-photo imagery.
+
+CANVAS
+- Square social-media infographic.
+- Approximately 1:1 aspect ratio.
+- High resolution.
+- Generous margins.
+- Strong vertical hierarchy.
+- Keep all important text comfortably inside the safe area.
+
+HEADER
+- Huge uppercase product name: "{{PRODUCT_NAME|STARINTEL}}"
+- Heavy geometric condensed sans-serif.
+- Metallic/brushed gold appearance with subtle texture.
+- Wide tracking.
+- Centered.
+- Under the title, add a thin horizontal gold rule.
+- Break the rule at the center with a small four-point star / diamond glyph.
+- Below that, use a smaller uppercase white section heading: "{{SECTION_TITLE|WHAT IT IS}}"
+- Section heading should use widely spaced characters.
+
+CONTENT CARDS
+Create four vertically stacked rounded rectangular cards.
+
+Each card:
+- Black / charcoal interior.
+- Very thin gold outline.
+- Rounded corners, but not overly soft.
+- Large icon area on the left.
+- Thin vertical gold divider after the icon.
+- Text content on the right.
+- Consistent card height, spacing, alignment, and padding.
+
+ICON STYLE
+- Custom-looking technical line icons.
+- Gold outline.
+- Minimal, geometric, monoline construction.
+- Icons should visually match each feature rather than using generic symbols.
+
+CARD TYPOGRAPHY
+Feature title:
+- Gold.
+- Bold condensed sans-serif.
+- Large but smaller than the main title.
+- Sentence case.
+
+Feature description:
+- White/light gray.
+- Narrow sans-serif.
+- One or two short lines.
+- High readability.
+- Avoid marketing fluff.
+- Describe concrete system behavior.
+
+CARD CONTENT
+
+1.
+Title: {{FEATURE_1_TITLE|Actor-model distributed system}}
+Description: {{FEATURE_1_DESCRIPTION|Decentralized actors collaborate and exchange messages across a dynamic graph.}}
+Icon concept: {{FEATURE_1_ICON|actor/message graph}}
+
+2.
+Title: {{FEATURE_2_TITLE|Structured intelligence documents}}
+Description: {{FEATURE_2_DESCRIPTION|Typed, linked documents capture context, observations, and relationships.}}
+Icon concept: {{FEATURE_2_ICON|linked document}}
+
+3.
+Title: {{FEATURE_3_TITLE|Storage and search}}
+Description: {{FEATURE_3_DESCRIPTION|Durable storage with rich indexing for fast, relational discovery.}}
+Icon concept: {{FEATURE_3_ICON|search and index}}
+
+4.
+Title: {{FEATURE_4_TITLE|External actor services}}
+Description: {{FEATURE_4_DESCRIPTION|Plug-in collectors, analyzers, and tools extend system capabilities.}}
+Icon concept: {{FEATURE_4_ICON|distributed service}}
+
+BOTTOM SECTION
+Below the feature cards, add a centered technical tagline:
+"{{TAGLINE|Framework first. Interface evolving.}}"
+
+Place small gold code-bracket / terminal-style glyphs on both sides of the tagline.
+
+Then add one final compact outlined status/product card:
+- Gold thin outline.
+- Dark interior.
+- Small gold line icon on left.
+- Product/component name in bold gold.
+- Status/description in white.
+
+Text:
+"{{COMPONENT_NAME|Quasar}}: {{COMPONENT_STATUS|POC operator workspace}}"
+
+BACKGROUND COMPOSITION
+- Put the most visible network graph clusters in the top-right and bottom-left corners.
+- Allow a few nodes to extend partially off-canvas.
+- Use faint dotted matrices or tiny dot patterns in otherwise empty corners.
+- Add barely visible engineering grid lines behind the central content.
+- The background should imply a much larger graph continuing outside the poster.
+
+COMPOSITION RULES
+- Symmetrical central layout.
+- Very clean alignment.
+- High information density without clutter.
+- Gold is reserved for hierarchy, borders, icons, and highlighted graph relationships.
+- White is reserved for explanatory text.
+- Dark gray is reserved for decorative/background information.
+- Keep visual noise away from text.
+- Strong contrast.
+- Technical, credible, architectural.
+- Make it look suitable for LinkedIn, project documentation, GitHub announcements, and engineering launch material.
+
+IMPORTANT
+- Preserve exact supplied wording.
+- Spell all technical terms correctly.
+- Do not invent additional claims or capabilities.
+- Do not add call-to-action marketing copy.
+- Do not add random UI windows.
+- Do not turn this into a generic SaaS advertisement.
+- The framework/system architecture is the subject.


### PR DESCRIPTION
## What changed
- add file-backed `.prompt` templates with `{{FIELD}}` and `{{FIELD|default}}` placeholders
- add a Transient prompt/image menu
- seed the StarIntel black/gold visual design as `starintel-visual.prompt`
- add async OpenAI Responses API image generation and image editing
- save generated images under `~/Pictures/ai/` and open them in Emacs
- add Doom bindings: `SPC y p` for the prompt/image menu and `SPC y i` for direct image generation
- document the workflow in `lisp/llm/llm.org`

## Image path
The image commands use the OpenAI hosted `image_generation` tool through `/v1/responses`, with configurable invoking and image models. The default image tool model is `gpt-image-1.5`.

## Auth
Image generation intentionally uses the direct OpenAI API key path (`OPENAI_API_KEY` / `auth-source`) rather than OpenRouter or ChatGPT subscription OAuth.