### PR TITLE
Switch Emacs image tools to GPT Image 2

### DIFF
--- a/lisp/llm/ai-image.el
+++ b/lisp/llm/ai-image.el
@@ -23,7 +23,7 @@
   :type 'string
   :group 'ai/image)
 
-(defcustom ai/image-model "gpt-image-1.5"
+(defcustom ai/image-model "gpt-image-2"
   "Image model passed to the OpenAI image-generation tool."
   :type 'string
   :group 'ai/image)

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -112,7 +112,7 @@ of routing through OpenRouter.  They therefore require =OPENAI_API_KEY= or an
 through Emacs =url.el=; the API key is sent as an HTTP header rather than being
 placed in a shell command line.
 
-The defaults use =gpt-5.2= to invoke the hosted tool and =gpt-image-1.5= as the
+The defaults use =gpt-5.2= to invoke the hosted tool and =gpt-image-2= as the
 image model.  Both are customizable with =ai/image-responses-model= and
 =ai/image-model=.
 


### PR DESCRIPTION
## What changed
- change the default image model from `gpt-image-1.5` to `gpt-image-2`
- update the Emacs LLM documentation to match

OpenAI's current model catalog lists GPT Image 2 as the recommended state-of-the-art image generation/editing model, while GPT Image 1.5 is deprecated.