### PR TITLE
Render OpenRouter image generation inline in gptel chat

### DIFF
--- a/lisp/llm/ai-image-tools.el
+++ b/lisp/llm/ai-image-tools.el
@@ -19,13 +19,13 @@ Image and prompt-template rules:
   (when (fboundp 'gptel-get-tool)
     (ignore-errors (setf (gptel-get-tool name) nil))))
 
-(defun ai/image-chat-generate (prompt callback)
+(defun ai/image-chat-generate (callback prompt)
   "Validate PROMPT, then generate an image and invoke CALLBACK."
   (if (string-empty-p (string-trim (or prompt "")))
       (funcall callback "ERROR: Image prompt is empty")
     (ai/image-tool-generate prompt callback)))
 
-(defun ai/image-chat-edit (file prompt callback)
+(defun ai/image-chat-edit (callback file prompt)
   "Validate FILE and PROMPT, then edit the image and invoke CALLBACK."
   (cond
    ((string-empty-p (string-trim (or prompt "")))
@@ -89,7 +89,7 @@ Image and prompt-template rules:
     (dolist (name '("GenerateImage" "EditImage"
                     "ListPromptTemplates" "ReadPromptTemplate"))
       (cl-pushnew name ai/agent-tools :test #'equal)))
-  ai/agent-tools)
+  (and (boundp 'ai/agent-tools) ai/agent-tools))
 
 (provide 'ai-image-tools)
 ;;; ai-image-tools.el ends here

--- a/lisp/llm/ai-image-tools.el
+++ b/lisp/llm/ai-image-tools.el
@@ -1,0 +1,78 @@
+;;; ai-image-tools.el --- gptel tools for inline image generation -*- lexical-binding: t; -*-
+
+(require 'ai-image)
+(require 'cl-lib)
+(require 'gptel)
+
+(defconst ai/image-agent-instructions
+  "
+
+Image and prompt-template rules:
+- When the user asks to create, draw, render, generate, redesign, or edit an image, use GenerateImage or EditImage instead of only describing what the image should look like.
+- Use ListPromptTemplates and ReadPromptTemplate when the user refers to a reusable visual prompt or named design system. Preserve the template's supplied wording and constraints when building the final image prompt.
+- GenerateImage and EditImage return an Org file link. Include that exact [[file:...]] link in the final response. Do not replace it with a pathname or Markdown link. The chat UI renders the Org link inline.
+- Do not claim an image was generated until the image tool returns successfully.")
+
+(defun ai/image--clear-gptel-tool (name)
+  "Remove an existing gptel tool named NAME before re-registering it."
+  (when (fboundp 'gptel-get-tool)
+    (ignore-errors (setf (gptel-get-tool name) nil))))
+
+(defun ai/image-register-gptel-tools ()
+  "Register image generation, editing, and prompt-template tools with gptel."
+  (dolist (name '("GenerateImage" "EditImage"
+                  "ListPromptTemplates" "ReadPromptTemplate"))
+    (ai/image--clear-gptel-tool name))
+
+  (gptel-make-tool
+   :name "GenerateImage"
+   :function #'ai/image-tool-generate
+   :category "image"
+   :description
+   "Generate a finished image from a complete prompt with GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."
+   :args '((:name "prompt"
+            :type string
+            :description "Complete image-generation prompt"))
+   :async t
+   :include t)
+
+  (gptel-make-tool
+   :name "EditImage"
+   :function #'ai/image-tool-edit
+   :category "image"
+   :description
+   "Edit a local PNG, JPEG, or WebP from a complete edit instruction using GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."
+   :args '((:name "file"
+            :type string
+            :description "Absolute or expanded local image path")
+           (:name "prompt"
+            :type string
+            :description "Complete image-edit instruction"))
+   :async t
+   :include t)
+
+  (gptel-make-tool
+   :name "ListPromptTemplates"
+   :function #'ai/image-tool-list-templates
+   :category "image"
+   :description "List reusable .prompt template names available to the Emacs image workflow."
+   :include t)
+
+  (gptel-make-tool
+   :name "ReadPromptTemplate"
+   :function #'ai/image-tool-read-template
+   :category "image"
+   :description "Read one reusable .prompt template verbatim before composing an image prompt."
+   :args '((:name "name"
+            :type string
+            :description "Template name without the .prompt extension"))
+   :include t)
+
+  (when (boundp 'ai/agent-tools)
+    (dolist (name '("GenerateImage" "EditImage"
+                    "ListPromptTemplates" "ReadPromptTemplate"))
+      (cl-pushnew name ai/agent-tools :test #'equal)))
+  ai/agent-tools)
+
+(provide 'ai-image-tools)
+;;; ai-image-tools.el ends here

--- a/lisp/llm/ai-image-tools.el
+++ b/lisp/llm/ai-image-tools.el
@@ -3,6 +3,7 @@
 (require 'ai-image)
 (require 'cl-lib)
 (require 'gptel)
+(require 'subr-x)
 
 (defconst ai/image-agent-instructions
   "
@@ -18,6 +19,22 @@ Image and prompt-template rules:
   (when (fboundp 'gptel-get-tool)
     (ignore-errors (setf (gptel-get-tool name) nil))))
 
+(defun ai/image-chat-generate (prompt callback)
+  "Validate PROMPT, then generate an image and invoke CALLBACK."
+  (if (string-empty-p (string-trim (or prompt "")))
+      (funcall callback "ERROR: Image prompt is empty")
+    (ai/image-tool-generate prompt callback)))
+
+(defun ai/image-chat-edit (file prompt callback)
+  "Validate FILE and PROMPT, then edit the image and invoke CALLBACK."
+  (cond
+   ((string-empty-p (string-trim (or prompt "")))
+    (funcall callback "ERROR: Image edit prompt is empty"))
+   ((not (file-readable-p (expand-file-name file)))
+    (funcall callback (format "ERROR: Image is not readable: %s" file)))
+   (t
+    (ai/image-tool-edit (expand-file-name file) prompt callback))))
+
 (defun ai/image-register-gptel-tools ()
   "Register image generation, editing, and prompt-template tools with gptel."
   (dolist (name '("GenerateImage" "EditImage"
@@ -26,7 +43,7 @@ Image and prompt-template rules:
 
   (gptel-make-tool
    :name "GenerateImage"
-   :function #'ai/image-tool-generate
+   :function #'ai/image-chat-generate
    :category "image"
    :description
    "Generate a finished image from a complete prompt with GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."
@@ -38,7 +55,7 @@ Image and prompt-template rules:
 
   (gptel-make-tool
    :name "EditImage"
-   :function #'ai/image-tool-edit
+   :function #'ai/image-chat-edit
    :category "image"
    :description
    "Edit a local PNG, JPEG, or WebP from a complete edit instruction using GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."

--- a/lisp/llm/ai-image.el
+++ b/lisp/llm/ai-image.el
@@ -1,39 +1,32 @@
-;;; ai-image.el --- OpenAI image-generation tools for Emacs -*- lexical-binding: t; -*-
+;;; ai-image.el --- OpenRouter image-generation tools for Emacs -*- lexical-binding: t; -*-
 
 (require 'ai)
 (require 'ai-prompts)
 (require 'cl-lib)
 (require 'json)
+(require 'org)
 (require 'subr-x)
 (require 'url)
 (require 'url-http)
 
 (defgroup ai/image nil
-  "OpenAI image generation and editing."
+  "OpenRouter image generation and editing."
   :group 'applications
   :prefix "ai/image-")
 
-(defcustom ai/image-responses-endpoint "https://api.openai.com/v1/responses"
-  "OpenAI Responses API endpoint used for image-tool calls."
+(defcustom ai/image-endpoint "https://openrouter.ai/api/v1/images"
+  "OpenRouter dedicated image-generation endpoint."
   :type 'string
   :group 'ai/image)
 
-(defcustom ai/image-responses-model "gpt-5.2"
-  "OpenAI model that invokes the hosted image-generation tool."
-  :type 'string
-  :group 'ai/image)
-
-(defcustom ai/image-model "gpt-image-2"
-  "Image model passed to the OpenAI image-generation tool."
+(defcustom ai/image-model "openai/gpt-image-2"
+  "OpenRouter image model used for generation and editing."
   :type 'string
   :group 'ai/image)
 
 (defcustom ai/image-size "1024x1024"
   "Default generated image size."
-  :type '(choice (const "1024x1024")
-                 (const "1024x1536")
-                 (const "1536x1024")
-                 (const "auto"))
+  :type 'string
   :group 'ai/image)
 
 (defcustom ai/image-quality "high"
@@ -56,7 +49,7 @@
   :group 'ai/image)
 
 (defcustom ai/image-open-after-generate t
-  "When non-nil, open a generated image after saving it."
+  "When non-nil, open interactively generated images outside Org buffers."
   :type 'boolean
   :group 'ai/image)
 
@@ -75,117 +68,6 @@
            (format-time-string "%Y%m%d-%H%M%S-%3N")
            ai/image-output-format)
    ai/image-output-directory))
-
-(defun ai/image--tool (&optional action)
-  "Return the image-generation tool declaration for ACTION."
-  (append
-   `((type . "image_generation")
-     (model . ,ai/image-model)
-     (size . ,ai/image-size)
-     (quality . ,ai/image-quality)
-     (background . "auto")
-     (output_format . ,ai/image-output-format))
-   (when action `((action . ,action)))
-   (when (equal action "edit") '((input_fidelity . "high")))))
-
-(defun ai/image--request-body (input &optional action)
-  "Build a Responses API body from INPUT and optional image ACTION."
-  `((model . ,ai/image-responses-model)
-    (input . ,input)
-    (tools . ,(vector (ai/image--tool action)))
-    (tool_choice . ((type . "image_generation")))))
-
-(defun ai/image--read-json-response ()
-  "Read the JSON body from the current URL response buffer."
-  (goto-char (point-min))
-  (unless (re-search-forward "\r?\n\r?\n" nil t)
-    (error "Malformed HTTP response"))
-  (let ((json-object-type 'alist)
-        (json-array-type 'list)
-        (json-key-type 'symbol)
-        (json-false nil)
-        (json-null nil))
-    (json-read)))
-
-(defun ai/image--api-error (payload)
-  "Return a useful API error string from PAYLOAD."
-  (or (alist-get 'message (alist-get 'error payload))
-      (alist-get 'error payload)
-      "OpenAI image request failed"))
-
-(defun ai/image--result (payload)
-  "Return the base64 image result from Responses API PAYLOAD."
-  (when-let ((call
-              (cl-find-if
-               (lambda (item)
-                 (equal (alist-get 'type item) "image_generation_call"))
-               (alist-get 'output payload))))
-    (alist-get 'result call)))
-
-(defun ai/image--write-result (encoded file)
-  "Decode base64 ENCODED image data and write it to FILE."
-  (let ((data (base64-decode-string encoded)))
-    (make-directory (file-name-directory file) t)
-    (with-temp-buffer
-      (set-buffer-multibyte nil)
-      (insert data)
-      (let ((coding-system-for-write 'no-conversion))
-        (write-region (point-min) (point-max) file nil 'silent))))
-  file)
-
-(defun ai/image--response-callback (status output-file callback)
-  "Handle image HTTP STATUS, writing OUTPUT-FILE and invoking CALLBACK."
-  (unwind-protect
-      (condition-case err
-          (let* ((http-status (and (boundp 'url-http-response-status)
-                                   url-http-response-status))
-                 (payload (ai/image--read-json-response)))
-            (when (or (plist-get status :error)
-                      (and http-status (>= http-status 400)))
-              (error "%s" (ai/image--api-error payload)))
-            (let ((result (ai/image--result payload)))
-              (unless result
-                (error "OpenAI response contained no image_generation_call result"))
-              (ai/image--write-result result output-file)
-              (when ai/image-open-after-generate
-                (find-file-other-window output-file))
-              (when callback
-                (funcall callback output-file))
-              (message "Image saved: %s" output-file)))
-        (error
-         (message "Image generation failed: %s" (error-message-string err))))
-    (kill-buffer (current-buffer))))
-
-(defun ai/image--request (input output-file &optional action callback)
-  "Send image INPUT and asynchronously write OUTPUT-FILE.
-ACTION is nil for generation or \="edit\=" for image editing.  CALLBACK is
-called with OUTPUT-FILE after a successful request."
-  (let* ((key (ai/llm--require-api-key 'openai))
-         (url-request-method "POST")
-         (url-request-extra-headers
-          `(("Authorization" . ,(concat "Bearer " key))
-            ("Content-Type" . "application/json")))
-         (url-request-data
-          (encode-coding-string
-           (json-encode (ai/image--request-body input action)) 'utf-8)))
-    (url-retrieve ai/image-responses-endpoint
-                  #'ai/image--response-callback
-                  (list output-file callback)
-                  t t)
-    (message "Generating image with %s / %s..."
-             ai/image-responses-model ai/image-model)))
-
-(defun ai/image-generate (prompt &optional output-file)
-  "Generate an image from PROMPT using OpenAI's image-generation tool."
-  (interactive (list (ai/image--prompt)))
-  (unless (and prompt (not (string-empty-p (string-trim prompt))))
-    (user-error "Image prompt is empty"))
-  (ai/image--request prompt (or output-file (ai/image--filename))))
-
-(defun ai/image-generate-template (&optional name)
-  "Fill reusable prompt template NAME and generate an image from it."
-  (interactive)
-  (ai/image-generate (ai/prompt-template-render name)))
 
 (defun ai/image--mime-type (file)
   "Return a supported image MIME type for FILE."
@@ -206,22 +88,208 @@ called with OUTPUT-FILE after a successful request."
       (format "data:%s;base64,%s"
               mime (base64-encode-string (buffer-string) t)))))
 
+(defun ai/image--request-body (prompt &optional reference-file)
+  "Build an OpenRouter image request for PROMPT and optional REFERENCE-FILE."
+  (append
+   `((model . ,ai/image-model)
+     (prompt . ,prompt)
+     (n . 1)
+     (size . ,ai/image-size)
+     (quality . ,ai/image-quality)
+     (output_format . ,ai/image-output-format)
+     (background . "auto"))
+   (when reference-file
+     `((input_references
+        . ,(vector
+            `((type . "image_url")
+              (image_url . ((url . ,(ai/image--data-url reference-file)))))))))))
+
+(defun ai/image--read-json-response ()
+  "Read JSON from the current URL response buffer."
+  (goto-char (or (and (boundp 'url-http-end-of-headers)
+                      url-http-end-of-headers)
+                 (point-min)))
+  (let ((json-object-type 'alist)
+        (json-array-type 'list)
+        (json-key-type 'symbol)
+        (json-false nil)
+        (json-null nil))
+    (json-read)))
+
+(defun ai/image--api-error (payload)
+  "Return a useful OpenRouter API error string from PAYLOAD."
+  (let ((error-object (alist-get 'error payload)))
+    (cond
+     ((and (listp error-object) (alist-get 'message error-object))
+      (alist-get 'message error-object))
+     (error-object (format "%S" error-object))
+     (t "OpenRouter image request failed"))))
+
+(defun ai/image--result (payload)
+  "Return base64 image data from OpenRouter PAYLOAD."
+  (when-let ((image (car (alist-get 'data payload))))
+    (alist-get 'b64_json image)))
+
+(defun ai/image--cost (payload)
+  "Return reported USD cost from OpenRouter PAYLOAD, or nil."
+  (alist-get 'cost (alist-get 'usage payload)))
+
+(defun ai/image--write-result (encoded file)
+  "Decode base64 ENCODED image data and write it to FILE."
+  (make-directory (file-name-directory file) t)
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert (base64-decode-string encoded))
+    (let ((coding-system-for-write 'no-conversion))
+      (write-region (point-min) (point-max) file nil 'silent)))
+  file)
+
+(defun ai/image--org-link (file)
+  "Return an Org file link for FILE."
+  (format "[[file:%s]]" (expand-file-name file)))
+
+(defun ai/image--tool-result (file payload)
+  "Return a gptel tool result for generated FILE and PAYLOAD."
+  (let ((cost (ai/image--cost payload)))
+    (concat
+     (format "Generated image with %s" ai/image-model)
+     (if (numberp cost) (format " (USD %.4f)" cost) "")
+     ". Include the exact Org link below in your final response so it renders inline.\n"
+     (ai/image--org-link file))))
+
+(defun ai/image--insert-org-image (buffer marker file)
+  "Insert FILE at MARKER in Org BUFFER and display it inline."
+  (when (and (buffer-live-p buffer)
+             marker
+             (marker-buffer marker))
+    (with-current-buffer buffer
+      (when (derived-mode-p 'org-mode)
+        (save-excursion
+          (goto-char marker)
+          (unless (bolp)
+            (insert "\n"))
+          (insert (ai/image--org-link file) "\n")
+          (org-display-inline-images))))))
+
+(defun ai/image--response-callback
+    (status output-file callback origin-buffer insertion-marker open-after)
+  "Handle OpenRouter STATUS and write OUTPUT-FILE.
+CALLBACK receives the tool result string.  ORIGIN-BUFFER and INSERTION-MARKER
+are used by interactive Org commands.  OPEN-AFTER opens non-Org results."
+  (unwind-protect
+      (condition-case err
+          (let* ((http-status (and (boundp 'url-http-response-status)
+                                   url-http-response-status))
+                 (payload (ai/image--read-json-response)))
+            (when (or (plist-get status :error)
+                      (and http-status (>= http-status 400)))
+              (error "%s" (ai/image--api-error payload)))
+            (let ((result (ai/image--result payload)))
+              (unless result
+                (error "OpenRouter returned no image data"))
+              (ai/image--write-result result output-file)
+              (ai/image--insert-org-image origin-buffer insertion-marker output-file)
+              (when (and open-after
+                         (not (and (buffer-live-p origin-buffer)
+                                   (with-current-buffer origin-buffer
+                                     (derived-mode-p 'org-mode)))))
+                (find-file-other-window output-file))
+              (when callback
+                (funcall callback (ai/image--tool-result output-file payload)))
+              (message "Image saved: %s" output-file)))
+        (error
+         (let ((message-text
+                (format "Image generation failed: %s" (error-message-string err))))
+           (when callback
+             (funcall callback (concat "ERROR: " message-text)))
+           (message "%s" message-text))))
+    (when insertion-marker
+      (set-marker insertion-marker nil))
+    (kill-buffer (current-buffer))))
+
+(defun ai/image--request
+    (prompt output-file &optional reference-file callback origin-buffer insertion-marker open-after)
+  "Generate an image for PROMPT and asynchronously write OUTPUT-FILE.
+REFERENCE-FILE performs image-to-image generation.  CALLBACK is used by async
+gptel tools.  ORIGIN-BUFFER and INSERTION-MARKER support inline Org display."
+  (let* ((key (ai/llm--require-api-key 'openrouter))
+         (url-request-method "POST")
+         (url-request-extra-headers
+          `(("Authorization" . ,(concat "Bearer " key))
+            ("Content-Type" . "application/json")
+            ("X-Title" . "Emacs gptel image tools")))
+         (url-request-data
+          (encode-coding-string
+           (json-encode (ai/image--request-body prompt reference-file)) 'utf-8)))
+    (url-retrieve
+     ai/image-endpoint
+     #'ai/image--response-callback
+     (list output-file callback origin-buffer insertion-marker open-after)
+     t t)
+    (message "Generating image with %s..." ai/image-model)))
+
+(defun ai/image--interactive-target ()
+  "Return origin-buffer and insertion marker for an interactive request."
+  (let ((buffer (current-buffer)))
+    (list buffer
+          (when (derived-mode-p 'org-mode)
+            (copy-marker (if (use-region-p) (region-end) (point)) t)))))
+
+(defun ai/image-generate (prompt &optional output-file)
+  "Generate an image from PROMPT using OpenRouter."
+  (interactive (list (ai/image--prompt)))
+  (unless (and prompt (not (string-empty-p (string-trim prompt))))
+    (user-error "Image prompt is empty"))
+  (pcase-let ((`(,origin-buffer ,marker) (ai/image--interactive-target)))
+    (deactivate-mark)
+    (ai/image--request
+     prompt
+     (or output-file (ai/image--filename))
+     nil nil origin-buffer marker ai/image-open-after-generate)))
+
+(defun ai/image-generate-template (&optional name)
+  "Fill reusable prompt template NAME and generate an image from it."
+  (interactive)
+  (ai/image-generate (ai/prompt-template-render name)))
+
 (defun ai/image-edit (file prompt &optional output-file)
-  "Edit image FILE according to PROMPT using OpenAI's image-generation tool."
+  "Edit image FILE according to PROMPT using OpenRouter."
   (interactive
    (list (read-file-name "Image to edit: " nil nil t)
          (ai/image--prompt)))
   (unless (and prompt (not (string-empty-p (string-trim prompt))))
     (user-error "Image edit prompt is empty"))
-  (let ((input
-         (vector
-          `((role . "user")
-            (content . ,(vector
-                         `((type . "input_text") (text . ,prompt))
-                         `((type . "input_image")
-                           (image_url . ,(ai/image--data-url file)))))))))
-    (ai/image--request input (or output-file (ai/image--filename "edit"))
-                       "edit")))
+  (pcase-let ((`(,origin-buffer ,marker) (ai/image--interactive-target)))
+    (deactivate-mark)
+    (ai/image--request
+     prompt
+     (or output-file (ai/image--filename "edit"))
+     file nil origin-buffer marker ai/image-open-after-generate)))
+
+(defun ai/image-tool-generate (prompt callback)
+  "Async gptel tool: generate an image for PROMPT and invoke CALLBACK."
+  (unless (and prompt (not (string-empty-p (string-trim prompt))))
+    (funcall callback "ERROR: Image prompt is empty"))
+  (ai/image--request
+   prompt (ai/image--filename "chat-image") nil callback nil nil nil))
+
+(defun ai/image-tool-edit (file prompt callback)
+  "Async gptel tool: edit FILE according to PROMPT and invoke CALLBACK."
+  (if (not (file-readable-p file))
+      (funcall callback (format "ERROR: Image is not readable: %s" file))
+    (ai/image--request
+     prompt (ai/image--filename "chat-edit") file callback nil nil nil)))
+
+(defun ai/image-tool-list-templates ()
+  "Return available reusable prompt-template names."
+  (let ((names (ai/prompt-template-names)))
+    (if names
+        (mapconcat #'identity names "\n")
+      "No reusable prompt templates are installed.")))
+
+(defun ai/image-tool-read-template (name)
+  "Return raw reusable prompt template NAME."
+  (ai/prompt-template--read name))
 
 (provide 'ai-image)
 ;;; ai-image.el ends here

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -9,15 +9,16 @@
 (require 'ai-mcp)
 (require 'chat)
 
-(unless (assq 'openai/gpt-5.6-sol-pro:exacto ai/llm-openrouter-models)
-  (push '(openai/gpt-5.6-sol-pro:exacto
-          :description "GPT-5.6 Sol Pro through OpenRouter Exacto"
-          :capabilities (reasoning media tool-use json url)
-          :context-window 1050)
+(unless (assq 'anthropic/claude-opus-5:exacto ai/llm-openrouter-models)
+  (push '(anthropic/claude-opus-5:exacto
+          :description "Claude Opus 5 through OpenRouter Exacto"
+          :capabilities (reasoning media tool-use json)
+          :context-window 1000
+          :request-params (:reasoning (:effort "max")))
         ai/llm-openrouter-models))
 
 (setq ai/llm-provider 'openrouter
-      ai/llm-model 'openai/gpt-5.6-sol-pro:exacto)
+      ai/llm-model 'anthropic/claude-opus-5:exacto)
 (ai/llm-backend 'openrouter t)
 (ai/llm-apply-defaults)
 
@@ -27,21 +28,23 @@
         (concat ai/agent-system-prompt ai/image-agent-instructions)))
 (setq ai/chat-system-prompt ai/agent-system-prompt)
 
-(gptel-make-preset 'gpt-5.6-sol-pro
-  :description "GPT-5.6 Sol Pro through OpenRouter Exacto."
+(gptel-make-preset 'claude-opus-5
+  :description "Claude Opus 5 through OpenRouter Exacto at max reasoning effort."
   :backend (ai/llm-backend 'openrouter)
-  :model 'openai/gpt-5.6-sol-pro:exacto
+  :model 'anthropic/claude-opus-5:exacto
   :stream t
+  :request-params '(:reasoning (:effort "max"))
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'agent
-  :description "GPT-5.6 Sol Pro project agent through OpenRouter Exacto."
+  :description "Claude Opus 5 project agent through OpenRouter Exacto."
   :backend (ai/llm-backend 'openrouter)
-  :model 'openai/gpt-5.6-sol-pro:exacto
+  :model 'anthropic/claude-opus-5:exacto
   :system ai/agent-system-prompt
   :tools ai/agent-tools
   :stream t
   :temperature nil
+  :request-params '(:reasoning (:effort "max"))
   :use-context 'system
   :track-media t
   :include-reasoning t)
@@ -50,7 +53,8 @@
   :parents '(agent)
   :description "GPT-5.6 Sol project agent through OpenRouter."
   :backend (ai/llm-backend 'openrouter)
-  :model 'openai/gpt-5.6-sol)
+  :model 'openai/gpt-5.6-sol
+  :request-params nil)
 
 (with-eval-after-load 'org-ql
   (require 'todo nil t))

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -25,6 +25,7 @@
 (unless (string-match-p "Image and prompt-template rules:" ai/agent-system-prompt)
   (setq ai/agent-system-prompt
         (concat ai/agent-system-prompt ai/image-agent-instructions)))
+(setq ai/chat-system-prompt ai/agent-system-prompt)
 
 (gptel-make-preset 'gpt-5.6-sol-pro
   :description "GPT-5.6 Sol Pro through OpenRouter Exacto."

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -5,20 +5,38 @@
 (require 'ai-image)
 (require 'meme)
 (require 'ai-agent)
+(require 'ai-image-tools)
 (require 'ai-mcp)
 (require 'chat)
 
-;; Override values left bound by an older loaded copy of this configuration.
+(unless (assq 'openai/gpt-5.6-sol-pro:exacto ai/llm-openrouter-models)
+  (push '(openai/gpt-5.6-sol-pro:exacto
+          :description "GPT-5.6 Sol Pro through OpenRouter Exacto"
+          :capabilities (reasoning media tool-use json url)
+          :context-window 1050)
+        ai/llm-openrouter-models))
+
 (setq ai/llm-provider 'openrouter
-      ai/llm-model 'z-ai/glm-5.2)
+      ai/llm-model 'openai/gpt-5.6-sol-pro:exacto)
+(ai/llm-backend 'openrouter t)
 (ai/llm-apply-defaults)
 
-;; `agent.el' historically used direct provider backends.  Re-register the
-;; public presets after it loads so all normal agent traffic stays on OpenRouter.
-(gptel-make-preset 'agent
-  :description "GLM-5.2 project agent through OpenRouter."
+(ai/image-register-gptel-tools)
+(unless (string-match-p "Image and prompt-template rules:" ai/agent-system-prompt)
+  (setq ai/agent-system-prompt
+        (concat ai/agent-system-prompt ai/image-agent-instructions)))
+
+(gptel-make-preset 'gpt-5.6-sol-pro
+  :description "GPT-5.6 Sol Pro through OpenRouter Exacto."
   :backend (ai/llm-backend 'openrouter)
-  :model 'z-ai/glm-5.2
+  :model 'openai/gpt-5.6-sol-pro:exacto
+  :stream t
+  :include-reasoning 'ignore)
+
+(gptel-make-preset 'agent
+  :description "GPT-5.6 Sol Pro project agent through OpenRouter Exacto."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'openai/gpt-5.6-sol-pro:exacto
   :system ai/agent-system-prompt
   :tools ai/agent-tools
   :stream t

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -9,6 +9,15 @@
 (require 'ai-mcp)
 (require 'chat)
 
+(unless (assq 'openrouter/auto ai/llm-openrouter-models)
+  (push '(openrouter/auto
+          :description "OpenRouter Auto Router in pure-quality mode"
+          :capabilities (reasoning media tool-use json url)
+          :context-window 2000
+          :request-params (:plugins [(:id "auto-router"
+                                      :cost_quality_tradeoff 0)]))
+        ai/llm-openrouter-models))
+
 (unless (assq 'anthropic/claude-opus-5:exacto ai/llm-openrouter-models)
   (push '(anthropic/claude-opus-5:exacto
           :description "Claude Opus 5 through OpenRouter Exacto"
@@ -18,7 +27,7 @@
         ai/llm-openrouter-models))
 
 (setq ai/llm-provider 'openrouter
-      ai/llm-model 'anthropic/claude-opus-5:exacto)
+      ai/llm-model 'openrouter/auto)
 (ai/llm-backend 'openrouter t)
 (ai/llm-apply-defaults)
 
@@ -27,6 +36,15 @@
   (setq ai/agent-system-prompt
         (concat ai/agent-system-prompt ai/image-agent-instructions)))
 (setq ai/chat-system-prompt ai/agent-system-prompt)
+
+(gptel-make-preset 'best
+  :description "OpenRouter Auto Router with cost-quality tradeoff pinned to pure quality."
+  :backend (ai/llm-backend 'openrouter)
+  :model 'openrouter/auto
+  :stream t
+  :request-params '(:plugins [(:id "auto-router"
+                               :cost_quality_tradeoff 0)])
+  :include-reasoning 'ignore)
 
 (gptel-make-preset 'claude-opus-5
   :description "Claude Opus 5 through OpenRouter Exacto at max reasoning effort."
@@ -37,22 +55,28 @@
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'agent
-  :description "Claude Opus 5 project agent through OpenRouter Exacto."
+  :description "Pure-quality OpenRouter Auto Router project agent."
   :backend (ai/llm-backend 'openrouter)
-  :model 'anthropic/claude-opus-5:exacto
+  :model 'openrouter/auto
   :system ai/agent-system-prompt
   :tools ai/agent-tools
   :stream t
   :temperature nil
-  :request-params '(:reasoning (:effort "max"))
+  :request-params '(:plugins [(:id "auto-router"
+                               :cost_quality_tradeoff 0)])
   :use-context 'system
   :track-media t
   :include-reasoning t)
 
+(gptel-make-preset 'agent-claude-opus-5
+  :parents '(agent)
+  :description "Claude Opus 5 project agent through OpenRouter Exacto."
+  :model 'anthropic/claude-opus-5:exacto
+  :request-params '(:reasoning (:effort "max")))
+
 (gptel-make-preset 'agent-gpt-5.6-sol
   :parents '(agent)
   :description "GPT-5.6 Sol project agent through OpenRouter."
-  :backend (ai/llm-backend 'openrouter)
   :model 'openai/gpt-5.6-sol
   :request-params nil)
 

--- a/lisp/llm/chat.el
+++ b/lisp/llm/chat.el
@@ -145,12 +145,36 @@
       (set-visited-file-name (ai/chat--file "chat") t))
     (save-buffer)))
 
-(defun ai/chat--after-response (_start _end)
-  "Persist the response and optionally generate a title."
+(defun ai/chat--display-inline-images ()
+  "Render local Org image links in the current chat buffer."
   (when (derived-mode-p 'org-mode)
+    (condition-case nil
+        (org-display-inline-images)
+      (error nil))))
+
+(defun ai/chat--after-response (_start _end)
+  "Persist the response, render images, and optionally generate a title."
+  (when (derived-mode-p 'org-mode)
+    (ai/chat--display-inline-images)
     (ai/chat--save)
     (when (and ai/chat-auto-title (not ai/chat--titled))
       (ai/chat--title-async))))
+
+(defun ai/chat--configure-buffer ()
+  "Configure the current Org buffer as an image-capable gptel chat."
+  (org-mode)
+  (setq-local gptel-backend (ai/llm-backend))
+  (setq-local gptel-model (ai/llm-resolve-model))
+  (setq-local gptel-system-message ai/chat-system-prompt)
+  (setq-local gptel-tools (ai/chat--agent-tools))
+  (setq-local gptel-use-tools t)
+  (setq-local gptel-use-context 'system)
+  (setq-local gptel-track-media t)
+  (setq-local gptel-include-reasoning t)
+  (setq-local org-startup-with-inline-images t)
+  (gptel-mode 1)
+  (add-hook 'gptel-post-response-functions #'ai/chat--after-response nil t)
+  (ai/chat--display-inline-images))
 
 ;;;###autoload
 (defun ai/chat (&optional name)
@@ -158,29 +182,19 @@
 
 The file is created immediately under `ai/chat-directory' as
 YYYY-MM-DD_HH-MM-SS_slug.org.  The buffer enables the local Emacs agent
-tools together with any globally active MCP tools."
+tools together with any globally active MCP and image tools."
   (interactive)
   (let* ((input (or name (read-string "Chat name: " "chat")))
          (name (if (string-empty-p (string-trim input)) "chat" input))
          (buffer (generate-new-buffer (format "*LLM: %s*" name))))
     (with-current-buffer buffer
-      (org-mode)
       (setq-local ai/chat--session-id (format-time-string "%Y-%m-%d_%H-%M-%S"))
-      (setq-local gptel-backend (ai/llm-backend))
-      (setq-local gptel-model (ai/llm-resolve-model))
-      (setq-local gptel-system-message ai/chat-system-prompt)
-      (setq-local gptel-tools (ai/chat--agent-tools))
-      (setq-local gptel-use-tools t)
-      (setq-local gptel-use-context 'system)
-      (setq-local gptel-track-media t)
-      (setq-local gptel-include-reasoning t)
       (make-directory ai/chat-directory t)
       (set-visited-file-name (ai/chat--file name) t)
+      (ai/chat--configure-buffer)
       (ai/chat--ensure-header name)
       (goto-char (point-max))
       (insert "* User\n")
-      (add-hook 'gptel-post-response-functions #'ai/chat--after-response nil t)
-      (gptel-mode 1)
       (ai/chat--save))
     (switch-to-buffer buffer)
     (goto-char (point-max))))
@@ -201,17 +215,7 @@ tools together with any globally active MCP tools."
                            (or (file-directory-p path)
                                (string-match-p "\\.org\\'" path))))))
   (find-file file)
-  (org-mode)
-  (setq-local gptel-backend (ai/llm-backend))
-  (setq-local gptel-model (ai/llm-resolve-model))
-  (setq-local gptel-system-message ai/chat-system-prompt)
-  (setq-local gptel-tools (ai/chat--agent-tools))
-  (setq-local gptel-use-tools t)
-  (setq-local gptel-use-context 'system)
-  (setq-local gptel-track-media t)
-  (setq-local gptel-include-reasoning t)
-  (add-hook 'gptel-post-response-functions #'ai/chat--after-response nil t)
-  (gptel-mode 1))
+  (ai/chat--configure-buffer))
 
 (provide 'chat)
 ;;; chat.el ends here

--- a/lisp/llm/chat.el
+++ b/lisp/llm/chat.el
@@ -168,6 +168,7 @@
   (setq-local gptel-system-message ai/chat-system-prompt)
   (setq-local gptel-tools (ai/chat--agent-tools))
   (setq-local gptel-use-tools t)
+  (setq-local gptel-include-tool-results t)
   (setq-local gptel-use-context 'system)
   (setq-local gptel-track-media t)
   (setq-local gptel-include-reasoning t)

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -5,10 +5,11 @@
 
 * Defaults
 
-The local gptel stack defaults to Z.AI =glm-5.2=.  OpenAI
-=gpt-5.6-sol= and =gpt-5.6-luna= are available through the OpenAI Responses
-API.  =claude-fable-5= is available through Anthropic.  GPT-5.6 Sol is also
-available through gptel's OpenAI subscription OAuth backend.
+The local gptel stack defaults to Claude Opus 5 through OpenRouter Exacto with
+maximum reasoning effort.  OpenRouter is the authoritative provider for normal
+chat, agent, and image-generation traffic.  GPT-5.6 Sol remains available as
+an alternate agent model, and GPT-5.6 Sol is also available through gptel's
+OpenAI subscription OAuth backend.
 
 The configuration tracks current upstream gptel instead of Doom's older pin.
 Modern defaults enable streaming, curl transport, tool use, per-tool automatic
@@ -24,6 +25,9 @@ API keys are resolved from environment variables first and then
 - =OPENAI_API_KEY= or host =api.openai.com=
 - =ANTHROPIC_API_KEY= or host =api.anthropic.com=
 - =OPENROUTER_API_KEY= or host =openrouter.ai=
+
+Normal chat and image generation require only the OpenRouter credential.
+Direct-provider credentials remain available for explicit provider switching.
 
 A Coding Plan endpoint can be selected without changing Lisp:
 
@@ -71,15 +75,16 @@ The same switches are exposed as =M-x +llm/use-glm-5.2=,
 =M-x +llm/use-fable=, and =M-x +llm/use-openai-oauth=.  A prefix argument
 makes the selection buffer-local.
 
-Available presets:
+Available presets include:
 
+- =@claude-opus-5= — Claude Opus 5 through OpenRouter Exacto at max reasoning
 - =@glm-5.2=
 - =@gpt-5.6-sol=
 - =@gpt-5.6-luna=
 - =@gpt-5.6-sol-oauth=
 - =@claude-fable-5=
-- =@agent= — GLM-5.2 with the project agent tools
-- =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tools
+- =@agent= — Claude Opus 5 Exacto with project and image tools
+- =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tool suite
 
 * Reusable prompt templates
 
@@ -104,20 +109,17 @@ M-x ai/prompt-template-edit
 
 Doom binds =SPC y p= to the prompt/image Transient menu.
 
-* OpenAI image tools
+* OpenRouter image tools
 
-=image-generation= calls use the hosted OpenAI Responses API image tool instead
-of routing through OpenRouter.  They therefore require =OPENAI_API_KEY= or an
-=auth-source= entry for =api.openai.com=.  Image requests run asynchronously
-through Emacs =url.el=; the API key is sent as an HTTP header rather than being
-placed in a shell command line.
+Image generation uses OpenRouter's dedicated =/api/v1/images= endpoint with
+=openai/gpt-image-2= as the default image model.  Generation and editing use
+the same =OPENROUTER_API_KEY= / OpenRouter =auth-source= credential as normal
+chat.  Requests run asynchronously through Emacs =url.el=; API keys are sent in
+HTTP headers rather than placed on a shell command line.
 
-The defaults use =gpt-5.2= to invoke the hosted tool and =gpt-image-2= as the
-image model.  Both are customizable with =ai/image-responses-model= and
-=ai/image-model=.
-
-Generated files default to =~/Pictures/ai/= and open automatically when the
-request completes.
+Generated files default to =~/Pictures/ai/=.  In Org buffers the resulting
+=[[file:...]]= link is inserted and rendered inline.  Outside Org buffers the
+interactive command can open the generated file in another window.
 
 #+begin_src emacs-lisp
 M-x ai/image-generate
@@ -127,13 +129,38 @@ M-x ai/image-edit
 
 =ai/image-generate= uses the active region as the prompt when a region is
 selected.  =ai/image-generate-template= fills one of the reusable templates and
-sends the rendered prompt directly to the image tool.  =ai/image-edit= sends a
-local PNG, JPEG, or WebP as an image input and requests an edit with high input
-fidelity.
+sends the rendered prompt directly to GPT Image 2.  =ai/image-edit= sends a
+local PNG, JPEG, or WebP as an OpenRouter reference image.
 
 Doom binds =SPC y i= directly to image generation.  The =SPC y p= Transient
 also exposes generation from a raw prompt, generation from a template, and
 image editing.
+
+** Image generation inside chat
+
+The Org chat registers four gptel tools:
+
+- =GenerateImage= — generate an image from a complete prompt
+- =EditImage= — edit a local image from a complete instruction
+- =ListPromptTemplates= — enumerate reusable =.prompt= templates
+- =ReadPromptTemplate= — load a named template verbatim
+
+When a chat request asks for an image, the agent can call =GenerateImage= or
+=EditImage= directly.  Image tool results are always retained in the Org chat,
+contain a local =[[file:...]]= link, and are rendered inline after the response.
+The agent is instructed to repeat that exact link in its final answer as well.
+This makes image generation part of the normal =M-x +llm/chat= flow rather
+than a separate command-only workflow.
+
+A named design prompt can therefore be used conversationally, for example:
+
+#+begin_example
+Use starintel-visual and generate an infographic for the actor system.
+#+end_example
+
+The agent can read =starintel-visual.prompt=, compose the final image prompt,
+call GPT Image 2 through OpenRouter, and place the generated image directly in
+the chat transcript.
 
 * OpenAI subscription OAuth
 
@@ -193,6 +220,7 @@ The enabled agent surface is intentionally small and Claude Code-like:
 - =Mkdir=, =Move=, =Delete=
 - =Bash=, =GitStatus=, =GitDiff=, =DiffFiles=
 - buffer, Emacs introspection, web fetch, and project-context tools
+- image generation, image editing, and reusable prompt-template lookup
 
 Mutations are project-confined by default, writes are atomic, exact edits
 fail on ambiguous matches, command output is bounded, and unified patches
@@ -214,15 +242,17 @@ actual Org buffer is changed only after the patch succeeds.
 
 * Persistent chat
 
-=M-x +llm/chat= opens an Org-native gptel chat using the active backend,
-agent tool set, response autosave, and one-time automatic title generation.
-Chats are stored below =~/Documents/Notes/org/roam/llm/=.
+=M-x +llm/chat= opens an Org-native gptel chat using Claude Opus 5 Exacto by
+default, with the project agent tools, image tools, response autosave, inline
+image rendering, and one-time automatic title generation.  Chats are stored
+below =~/Documents/Notes/org/roam/llm/=.
 
 * Source files
 
 #+INCLUDE: "ai.el" src emacs-lisp
 #+INCLUDE: "ai-prompts.el" src emacs-lisp
 #+INCLUDE: "ai-image.el" src emacs-lisp
+#+INCLUDE: "ai-image-tools.el" src emacs-lisp
 #+INCLUDE: "ai-agent-core.el" src emacs-lisp
 #+INCLUDE: "agent-core.el" src emacs-lisp
 #+INCLUDE: "ai-agent.el" src emacs-lisp

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -5,11 +5,12 @@
 
 * Defaults
 
-The local gptel stack defaults to Claude Opus 5 through OpenRouter Exacto with
-maximum reasoning effort.  OpenRouter is the authoritative provider for normal
-chat, agent, and image-generation traffic.  GPT-5.6 Sol remains available as
-an alternate agent model, and GPT-5.6 Sol is also available through gptel's
-OpenAI subscription OAuth backend.
+The local gptel stack defaults to OpenRouter's =openrouter/auto= router with
+=cost_quality_tradeoff= pinned to =0=, its pure-quality setting.  OpenRouter
+selects the most capable model for each prompt without optimizing for cost.
+OpenRouter is the authoritative provider for normal chat, agent, and
+image-generation traffic.  Claude Opus 5 Exacto and GPT-5.6 Sol remain
+available as fixed-model agent presets.
 
 The configuration tracks current upstream gptel instead of Doom's older pin.
 Modern defaults enable streaming, curl transport, tool use, per-tool automatic
@@ -77,14 +78,16 @@ makes the selection buffer-local.
 
 Available presets include:
 
+- =@best= — OpenRouter Auto Router with pure-quality routing
 - =@claude-opus-5= — Claude Opus 5 through OpenRouter Exacto at max reasoning
 - =@glm-5.2=
 - =@gpt-5.6-sol=
 - =@gpt-5.6-luna=
 - =@gpt-5.6-sol-oauth=
 - =@claude-fable-5=
-- =@agent= — Claude Opus 5 Exacto with project and image tools
-- =@agent-gpt-5.6-sol= — GPT-5.6 Sol with the same tool suite
+- =@agent= — pure-quality OpenRouter routing with project and image tools
+- =@agent-claude-opus-5= — fixed Claude Opus 5 Exacto with the same tool suite
+- =@agent-gpt-5.6-sol= — fixed GPT-5.6 Sol with the same tool suite
 
 * Reusable prompt templates
 
@@ -242,10 +245,10 @@ actual Org buffer is changed only after the patch succeeds.
 
 * Persistent chat
 
-=M-x +llm/chat= opens an Org-native gptel chat using Claude Opus 5 Exacto by
-default, with the project agent tools, image tools, response autosave, inline
-image rendering, and one-time automatic title generation.  Chats are stored
-below =~/Documents/Notes/org/roam/llm/=.
+=M-x +llm/chat= opens an Org-native gptel chat using OpenRouter's pure-quality
+Auto Router by default, with the project agent tools, image tools, response
+autosave, inline image rendering, and one-time automatic title generation.
+Chats are stored below =~/Documents/Notes/org/roam/llm/=.
 
 * Source files
 


### PR DESCRIPTION
## What changed
- make OpenRouter the image-generation path, using `openai/gpt-image-2` through `/api/v1/images`
- register async gptel tools for image generation, image editing, and reusable prompt-template lookup
- always retain image tool results in the Org chat, return local `[[file:...]]` links, and render them inline
- teach the chat agent to call the image tools when the user asks for an image
- default chat/agent inference to `openrouter/auto` with `cost_quality_tradeoff: 0` — OpenRouter's pure-quality mode
- retain fixed Claude Opus 5 Exacto and GPT-5.6 Sol agent presets when deterministic model selection is wanted

## Routing
OpenRouter documents `openrouter/auto` as selecting the best model for each prompt. Setting `cost_quality_tradeoff` to `0` disables cost optimization and tells the router to choose purely for capability. Tool calling remains supported through the router.

## Auth
Both chat orchestration and image generation use the existing `OPENROUTER_API_KEY` / OpenRouter auth-source path. The generic image workflow no longer requires a direct OpenAI API key.