### PR TITLE
Add local fren loader

### DIFF
--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -8,6 +8,7 @@
 (require 'ai-image-tools)
 (require 'ai-mcp)
 (require 'chat)
+(require 'fren-loader)
 
 (unless (assq 'openrouter/auto ai/llm-openrouter-models)
   (push '(openrouter/auto

--- a/lisp/llm/fren-loader.el
+++ b/lisp/llm/fren-loader.el
@@ -1,0 +1,19 @@
+;;; fren-loader.el --- Load the local fren runtime -*- lexical-binding: t; -*-
+
+(defconst fren-loader-root
+  (expand-file-name "~/Documents/mara/")
+  "Local fren runtime checkout.")
+
+(defun fren-loader-load ()
+  "Load the local fren runtime when its checkout is available."
+  (interactive)
+  (let* ((emacs-directory (expand-file-name "emacs/" fren-loader-root))
+         (entry (expand-file-name "mara.el" emacs-directory)))
+    (when (file-readable-p entry)
+      (add-to-list 'load-path emacs-directory)
+      (require 'mara nil t))))
+
+(fren-loader-load)
+
+(provide 'fren-loader)
+;;; fren-loader.el ends here


### PR DESCRIPTION
## What changed

- adds `lisp/llm/fren-loader.el`
- assumes Mara is checked out at `~/Documents/mara/`
- adds only `~/Documents/mara/emacs/` to `load-path`
- loads `mara.el` when the checkout is present
- leaves the existing gptel/OpenRouter configuration unchanged
- safely does nothing when the local checkout is absent

The loader is required from the existing LLM initialization path.