### PR TITLE
fix: restore unseen Logos user

### DIFF
--- a/docs/logos-home-manager-bootstrap.md
+++ b/docs/logos-home-manager-bootstrap.md
@@ -1,6 +1,6 @@
 # Logos Home Manager bootstrap
 
-This repository exposes `logos` as a NixOS host and `useen@logos` as the standalone Home Manager configuration.
+This repository exposes `logos` as a NixOS host and `unseen@logos` as the standalone Home Manager configuration.
 
 ## Existing Nix install
 
@@ -9,28 +9,28 @@ If Nix is already installed on a non-NixOS machine, clone the repository and act
 ```bash
 git clone git@github.com:lost-rob0t/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
-nix run github:nix-community/home-manager/release-26.05 -- switch --flake .#useen@logos
+nix run github:nix-community/home-manager/release-26.05 -- switch --flake '.#unseen@logos'
 ```
 
 A global `home-manager` command is not required for the first activation.
 
-## Important username assumption
+## Username
 
-`nix/home-manager/systems/logos/home.nix` currently forces:
+The Logos configuration targets the normal `unseen` account:
 
 ```nix
-home.username = "useen";
-home.homeDirectory = "/home/useen";
+home.username = "unseen";
+home.homeDirectory = "/home/unseen";
 ```
 
-Before activating `useen@logos`, verify the laptop account is actually `useen`:
+Confirm the local account before activation:
 
 ```bash
 whoami
 printf '%s\n' "$HOME"
 ```
 
-If the laptop account is `unseen`, use an `unseen@...` profile or change the Logos Home Manager module rather than activating a configuration pointed at `/home/useen`.
+Expected output is `unseen` and `/home/unseen`.
 
 ## Inspect available outputs
 
@@ -39,10 +39,10 @@ cd ~/.dotfiles
 nix flake show
 ```
 
-Relevant outputs currently include:
+Relevant outputs include:
 
 - `nixosConfigurations.logos`
-- `homeConfigurations."useen@logos"`
+- `homeConfigurations."unseen@logos"`
 - `homeConfigurations."unseen@desktop"`
 - `homeConfigurations."unseen@hunter02"`
 

--- a/docs/logos-home-manager-bootstrap.md
+++ b/docs/logos-home-manager-bootstrap.md
@@ -1,0 +1,49 @@
+# Logos Home Manager bootstrap
+
+This repository exposes `logos` as a NixOS host and `useen@logos` as the standalone Home Manager configuration.
+
+## Existing Nix install
+
+If Nix is already installed on a non-NixOS machine, clone the repository and activate the Home Manager profile directly through the flake:
+
+```bash
+git clone git@github.com:lost-rob0t/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+nix run github:nix-community/home-manager/release-26.05 -- switch --flake .#useen@logos
+```
+
+A global `home-manager` command is not required for the first activation.
+
+## Important username assumption
+
+`nix/home-manager/systems/logos/home.nix` currently forces:
+
+```nix
+home.username = "useen";
+home.homeDirectory = "/home/useen";
+```
+
+Before activating `useen@logos`, verify the laptop account is actually `useen`:
+
+```bash
+whoami
+printf '%s\n' "$HOME"
+```
+
+If the laptop account is `unseen`, use an `unseen@...` profile or change the Logos Home Manager module rather than activating a configuration pointed at `/home/useen`.
+
+## Inspect available outputs
+
+```bash
+cd ~/.dotfiles
+nix flake show
+```
+
+Relevant outputs currently include:
+
+- `nixosConfigurations.logos`
+- `homeConfigurations."useen@logos"`
+- `homeConfigurations."unseen@desktop"`
+- `homeConfigurations."unseen@hunter02"`
+
+For a normal Ubuntu laptop with Nix already installed, prefer the standalone Home Manager output rather than the NixOS installer.

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
           export LOGOS_DEFAULT_FLAKE='${self.outPath}#logos'
           export LOGOS_SOURCE='${self.outPath}'
           export DISKO_INSTALL='${disko.packages.${system}.disko-install}/bin/disko-install'
-          exec '${pkgs.bash}/bin/bash' '${./scripts/install-logos-useen.sh}' "$@"
+          exec '${pkgs.bash}/bin/bash' '${./scripts/install-logos.sh}' "$@"
         '';
       };
 
@@ -87,7 +87,7 @@
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.extraSpecialArgs = homeArgs;
-            home-manager.users.useen = import ./nix/home-manager/systems/logos/home.nix;
+            home-manager.users.unseen = import ./nix/home-manager/systems/logos/home.nix;
           }
           ./nix/nixos/hosts/logos
         ];
@@ -100,7 +100,7 @@
       };
 
       homeConfigurations = {
-        "useen@logos" = home-manager.lib.homeManagerConfiguration {
+        "unseen@logos" = home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = homeArgs;
           modules = [
@@ -156,7 +156,7 @@
         install-logos = installLogos;
         install-logos-gui = installLogosGui;
         inherit flash-logos;
-        useen-home = homeConfigurations."useen@logos".activationPackage;
+        unseen-home = homeConfigurations."unseen@logos".activationPackage;
       };
 
       apps.${system} = {
@@ -173,7 +173,7 @@
       checks.${system} = {
         logos = logos.config.system.build.toplevel;
         install-logos = installLogos;
-        useen-home = homeConfigurations."useen@logos".activationPackage;
+        unseen-home = homeConfigurations."unseen@logos".activationPackage;
       };
 
       formatter.${system} = pkgs.nixfmt-rfc-style;

--- a/nix/home-manager/systems/logos/home.nix
+++ b/nix/home-manager/systems/logos/home.nix
@@ -3,6 +3,6 @@
 {
   imports = [ ../desktop/home.nix ];
 
-  home.username = lib.mkForce "useen";
-  home.homeDirectory = lib.mkForce "/home/useen";
+  home.username = lib.mkForce "unseen";
+  home.homeDirectory = lib.mkForce "/home/unseen";
 }

--- a/nix/nixos/hosts/logos/default.nix
+++ b/nix/nixos/hosts/logos/default.nix
@@ -102,9 +102,9 @@
     autoPrune.enable = true;
   };
 
-  users.users.useen = {
+  users.users.unseen = {
     isNormalUser = true;
-    description = "useen";
+    description = "unseen";
     extraGroups = [
       "wheel"
       "networkmanager"
@@ -127,7 +127,7 @@
     };
   };
 
-  fileSystems."/home/useen/share" = {
+  fileSystems."/home/unseen/share" = {
     device = "//storage.lost.system/unseen";
     fsType = "cifs";
     options = [
@@ -137,7 +137,7 @@
       "x-systemd.device-timeout=5s"
       "x-systemd.mount-timeout=5s"
       "uid=1000"
-      "credentials=/home/useen/.config/smb-creds"
+      "credentials=/home/unseen/.config/smb-creds"
     ];
   };
 

--- a/scripts/install-logos-gui.sh
+++ b/scripts/install-logos-gui.sh
@@ -54,10 +54,10 @@ flake="$(
 
 [[ "$flake" == *#* ]] || fail_dialog "The flake must include a configuration fragment, such as /etc/logos#logos."
 
-password="$(zenity --password --title="Logos User Password" --text="Password for the useen user:")" || exit 0
+password="$(zenity --password --title="Logos User Password" --text="Password for the unseen user:")" || exit 0
 [[ -n "$password" ]] || fail_dialog "The password cannot be empty."
 
-password_confirmation="$(zenity --password --title="Confirm Password" --text="Enter the useen user password again:")" || exit 0
+password_confirmation="$(zenity --password --title="Confirm Password" --text="Enter the unseen user password again:")" || exit 0
 [[ "$password" == "$password_confirmation" ]] || fail_dialog "The passwords do not match."
 unset password_confirmation
 

--- a/scripts/install-logos-useen.sh
+++ b/scripts/install-logos-useen.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -Eeuo pipefail
-
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-temporary_script="$(mktemp)"
-trap 'rm -f -- "$temporary_script"' EXIT
-
-sed 's/\bunseen\b/useen/g' "$script_dir/install-logos.sh" > "$temporary_script"
-bash "$temporary_script" "$@"


### PR DESCRIPTION
Restores the canonical `unseen` user throughout Logos and removes the temporary `install-logos-useen.sh` rewrite wrapper.

Changes:
- Home Manager profile is now `unseen@logos`
- Logos NixOS user and home paths are `/home/unseen`
- installer calls `scripts/install-logos.sh` directly
- GUI installer prompts refer to `unseen`
- package/check output renamed to `unseen-home`
- bootstrap documentation covers Home Manager activation on an existing Nix install

This fixes laptop bootstrap for an existing `unseen` account without introducing a second user.