### PR TITLE
Use Seedream for OpenRouter image generation

### DIFF
--- a/lisp/llm/ai-image-tools.el
+++ b/lisp/llm/ai-image-tools.el
@@ -46,7 +46,7 @@ Image and prompt-template rules:
    :function #'ai/image-chat-generate
    :category "image"
    :description
-   "Generate a finished image from a complete prompt with GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."
+   "Generate a finished image from a complete prompt with the configured OpenRouter image model. Returns an Org file link that must be included verbatim in the final response."
    :args '((:name "prompt"
             :type string
             :description "Complete image-generation prompt"))
@@ -58,7 +58,7 @@ Image and prompt-template rules:
    :function #'ai/image-chat-edit
    :category "image"
    :description
-   "Edit a local PNG, JPEG, or WebP from a complete edit instruction using GPT Image 2 through OpenRouter. Returns an Org file link that must be included verbatim in the final response."
+   "Edit a local PNG, JPEG, or WebP from a complete edit instruction using the configured OpenRouter image model. Returns an Org file link that must be included verbatim in the final response."
    :args '((:name "file"
             :type string
             :description "Absolute or expanded local image path")
@@ -79,7 +79,7 @@ Image and prompt-template rules:
    :name "ReadPromptTemplate"
    :function #'ai/image-tool-read-template
    :category "image"
-   :description "Read one reusable .prompt template verbatim before composing an image prompt."
+   :description "Read one reusable prompt template verbatim before composing an image prompt."
    :args '((:name "name"
             :type string
             :description "Template name without the .prompt extension"))

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -10,6 +10,14 @@
 (require 'chat)
 (require 'fren-loader)
 
+(defconst ai/default-openrouter-image-model
+  (or (getenv "OPENROUTER_IMAGE_MODEL")
+      "bytedance-seed/seedream-4.5")
+  "OpenRouter image model used by image and meme generation.")
+
+(setq ai/image-model ai/default-openrouter-image-model
+      ai/meme-model ai/default-openrouter-image-model)
+
 (unless (assq 'openrouter/auto ai/llm-openrouter-models)
   (push '(openrouter/auto
           :description "OpenRouter Auto Router in pure-quality mode"


### PR DESCRIPTION
Switch the active Emacs image path away from OpenAI image models while keeping OpenRouter as the transport.

Changes:
- default image and meme generation to `bytedance-seed/seedream-4.5`
- allow `OPENROUTER_IMAGE_MODEL` to override the default without editing Lisp
- make gptel image tool descriptions model-agnostic instead of claiming GPT Image 2

OpenRouter's dedicated image API remains the endpoint; only the default model changes.

Note: unrelated Doom keymap boot fix is being handled separately.