### PR TITLE
Fix Doom LLM leader prefix collision

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -28,7 +28,8 @@
 (defun +llm/bind-keys ()
   "Bind the local LLM entrypoints after Doom finishes loading."
   (define-key doom-leader-map (kbd "y i") #'+llm/image-generate)
-  (define-key doom-leader-map (kbd "y m") #'ai/meme-generate)
+  ;; Keep `y m' available as an MCP prefix in the main Doom config.
+  (define-key doom-leader-map (kbd "y m g") #'ai/meme-generate)
   (define-key doom-leader-map (kbd "y p") #'+llm/prompt-menu)
   (define-key doom-leader-map (kbd "y v") #'+llm/youtube-context)
   (define-key doom-leader-map (kbd "y y") #'ai/chat))


### PR DESCRIPTION
## Root cause

`SPC y m` was bound directly to `ai/meme-generate`, while the main Doom config also uses `SPC y m` as a prefix for MCP test bindings (`y m f`, `y m m`). Emacs rejects a longer key sequence when an earlier component is already a non-prefix command, causing Doom startup to abort with `Key sequence y m f starts with non-prefix key y m`.

## Fix

- keep `SPC y m` free as the MCP prefix
- move meme generation to `SPC y m g`
- leave the existing MCP test bindings unchanged

This is intentionally minimal and only touches the LLM autoload keybinding layer.

## Validation

Merge only if repository checks are green.