### PR TITLE
Configure Mara from ai/llm defaults

### DIFF
--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -33,17 +33,34 @@
 (ai/llm-apply-defaults)
 
 (defun ai/llm-configure-mara ()
-  "Bind Mara's gptel provider to the active `ai/llm' defaults."
-  (when (boundp 'mara-gptel-backend)
-    (setq mara-gptel-backend (ai/llm-backend ai/llm-provider)))
-  (when (boundp 'mara-gptel-model)
-    (setq mara-gptel-model (ai/llm-resolve-model))))
+  "Bind Mara's provider settings to the active `ai/llm' defaults."
+  (let ((backend (ai/llm-backend ai/llm-provider))
+        (model (ai/llm-resolve-model)))
+    ;; Keep gptel's defaults usable outside dedicated ai/chat buffers too.
+    (set-default-toplevel-value 'gptel-backend backend)
+    (set-default-toplevel-value 'gptel-model model)
+    (when (boundp 'mara-gptel-backend)
+      (setq mara-gptel-backend backend))
+    (when (boundp 'mara-gptel-model)
+      (setq mara-gptel-model model))))
+
+(defun ai/llm-configure-mara-buffer ()
+  "Give the current Mara buffer the active `ai/llm' backend and model."
+  (setq-local gptel-backend (ai/llm-backend ai/llm-provider)
+              gptel-model (ai/llm-resolve-model)))
 
 (with-eval-after-load 'mara-provider-gptel
   (ai/llm-configure-mara))
 
+(with-eval-after-load 'mara-ui
+  (add-hook 'mara-mode-hook #'ai/llm-configure-mara-buffer))
+
 (when (featurep 'mara-provider-gptel)
   (ai/llm-configure-mara))
+
+(when (and (featurep 'mara-ui)
+           (boundp 'mara-mode-hook))
+  (add-hook 'mara-mode-hook #'ai/llm-configure-mara-buffer))
 
 (ai/image-register-gptel-tools)
 (unless (string-match-p "Image and prompt-template rules:" ai/agent-system-prompt)

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -32,6 +32,19 @@
 (ai/llm-backend 'openrouter t)
 (ai/llm-apply-defaults)
 
+(defun ai/llm-configure-mara ()
+  "Bind Mara's gptel provider to the active `ai/llm' defaults."
+  (when (boundp 'mara-gptel-backend)
+    (setq mara-gptel-backend (ai/llm-backend ai/llm-provider)))
+  (when (boundp 'mara-gptel-model)
+    (setq mara-gptel-model (ai/llm-resolve-model))))
+
+(with-eval-after-load 'mara-provider-gptel
+  (ai/llm-configure-mara))
+
+(when (featurep 'mara-provider-gptel)
+  (ai/llm-configure-mara))
+
 (ai/image-register-gptel-tools)
 (unless (string-match-p "Image and prompt-template rules:" ai/agent-system-prompt)
   (setq ai/agent-system-prompt


### PR DESCRIPTION
## What changed

- set gptel's default backend/model from the active `ai/llm` configuration
- bind `mara-gptel-backend` and `mara-gptel-model` to the same values
- set backend/model buffer-locally on every current `mara-mode` buffer
- handle both load orders: Mara already loaded and Mara loaded after `ai-init.el`

## Why

`M-x mara-doctor` showed `gptel backend: unset` and `gptel model: unset`. The current Mara provider checks `gptel-backend` in the calling Mara buffer before dispatching a request, so configuring only Mara's provider override is insufficient. The Mara buffer itself must inherit the shared `ai/llm` backend/model.

## Expected result

With the current dotfiles defaults, Mara resolves to the same OpenRouter backend and `openrouter/auto` model as `ai/chat`, while retaining streaming via gptel/curl.

## Validation

- actionlint / shell checks: green
- latest Nix flake/build workflow must be green before merge