### PR TITLE
Set Qtile Xorg session environment

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export XDG_SESSION_TYPE=x11
+export XDG_CURRENT_DESKTOP=qtile
+export DESKTOP_SESSION=qtile
+
+systemctl --user import-environment \
+  DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DESKTOP_SESSION
+
+exec qtile start


### PR DESCRIPTION
## Summary

Track the X startup script in dotfiles and export the Qtile/Xorg session metadata before launching Qtile. Import the same values into the systemd user manager so user services receive the graphical session context.

## Why

Qtile is started from a TTY, leaving `XDG_SESSION_TYPE=tty` and the desktop identifiers unset even though Xorg is active. Fail-closed desktop-aware services therefore cannot safely classify the session.

## Validation

- `sh -n .xinitrc`
- `bash -n .xinitrc`
- live `~/.xinitrc` now symlinks to the tracked file
- previous live file preserved at `~/.xinitrc.pre-local-recall-20260811`