### PR TITLE
Fix gptel tool-result JSON serialization

### DIFF
--- a/.github/workflows/gptel-tool-results.yml
+++ b/.github/workflows/gptel-tool-results.yml
@@ -1,0 +1,48 @@
+name: gptel tool results
+
+on:
+  pull_request:
+    paths:
+      - "lisp/llm/agent-core.el"
+      - "lisp/llm/ai-agent-core.el"
+      - "lisp/llm/agent.el"
+      - "lisp/llm/ai-agent-tool-result-test.el"
+      - ".github/workflows/gptel-tool-results.yml"
+  push:
+    branches:
+      - master
+      - "agent/**"
+    paths:
+      - "lisp/llm/agent-core.el"
+      - "lisp/llm/ai-agent-core.el"
+      - "lisp/llm/agent.el"
+      - "lisp/llm/ai-agent-tool-result-test.el"
+      - ".github/workflows/gptel-tool-results.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  tool-result-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out tested gptel revision
+        uses: actions/checkout@v4
+        with:
+          repository: karthink/gptel
+          ref: dc0280821c344ec10547e13179ea2095f6165f05
+          path: .ci/gptel
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Run Emacs 30 tool-result ERT tests
+        run: |
+          set -euo pipefail
+          nix shell github:NixOS/nixpkgs/nixos-26.05#emacs-nox --command \
+            emacs -Q --batch \
+              -L .ci/gptel \
+              -L lisp/llm \
+              -l lisp/llm/ai-agent-tool-result-test.el \
+              -f ert-run-tests-batch-and-exit

--- a/lisp/llm/ai-agent-core.el
+++ b/lisp/llm/ai-agent-core.el
@@ -26,17 +26,18 @@ escape an allowed root."
     (nreverse result)))
 
 (defun ai/agent--tool-result (value)
-  "Return VALUE as JSON text suitable for a gptel tool result.
+  "Return VALUE as canonical multibyte JSON text for a gptel tool result.
 
 `json-serialize' returns UTF-8 bytes in a unibyte string on Emacs 30 and
 newer.  A gptel tool result is message text, not final wire JSON, so decode
-those bytes back into an Emacs Unicode string before gptel serializes the
-provider request."
-  (decode-coding-string
-   (json-serialize value
-                   :null-object nil
-                   :false-object :json-false)
-   'utf-8 t))
+those bytes before gptel serializes the provider request.  Canonicalize even
+ASCII-only results as multibyte text so the adapter has one representation."
+  (string-to-multibyte
+   (decode-coding-string
+    (json-serialize value
+                    :null-object nil
+                    :false-object :json-false)
+    'utf-8 t)))
 
 (defun ai/agent--json (&rest pairs)
   "Return alternating key/value PAIRS as gptel-safe JSON text."

--- a/lisp/llm/ai-agent-core.el
+++ b/lisp/llm/ai-agent-core.el
@@ -25,6 +25,23 @@ escape an allowed root."
         (push (cons (if (symbolp key) key (intern key)) value) result)))
     (nreverse result)))
 
+(defun ai/agent--tool-result (value)
+  "Return VALUE as JSON text suitable for a gptel tool result.
+
+`json-serialize' returns UTF-8 bytes in a unibyte string on Emacs 30 and
+newer.  A gptel tool result is message text, not final wire JSON, so decode
+those bytes back into an Emacs Unicode string before gptel serializes the
+provider request."
+  (decode-coding-string
+   (json-serialize value
+                   :null-object nil
+                   :false-object :json-false)
+   'utf-8 t))
+
+(defun ai/agent--json (&rest pairs)
+  "Return alternating key/value PAIRS as gptel-safe JSON text."
+  (ai/agent--tool-result (apply #'ai/agent--object pairs)))
+
 (defun ai/agent--path-allowed-p (path project-root)
   "Return non-nil when PATH is inside PROJECT-ROOT or an allowed root."
   (or (ai/agent--inside-p path project-root)

--- a/lisp/llm/ai-agent-tool-result-test.el
+++ b/lisp/llm/ai-agent-tool-result-test.el
@@ -1,0 +1,222 @@
+;;; ai-agent-tool-result-test.el --- Tool-result serialization tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'json)
+(require 'cl-lib)
+(require 'gptel-request)
+(require 'gptel-openai)
+
+;; The agent core only needs these features to exist while its functions are
+;; defined.  The tests exercise gptel-request and gptel-openai directly so they
+;; do not need the full interactive gptel UI or the normal ai backend setup.
+(unless (featurep 'gptel)
+  (provide 'gptel))
+(unless (featurep 'ai)
+  (provide 'ai))
+
+(require 'ai-agent-core)
+
+(defun ai/agent-tool-result-test--parse (text)
+  "Parse JSON TEXT using the same false/null conventions as the agent tools."
+  (json-parse-string text
+                     :object-type 'alist
+                     :array-type 'list
+                     :null-object nil
+                     :false-object :json-false))
+
+(defun ai/agent-tool-result-test--backend ()
+  "Return an OpenRouter-shaped gptel OpenAI-compatible backend without I/O."
+  (gptel-make-openai "Tool Result Test"
+    :host "openrouter.invalid"
+    :endpoint "/api/v1/chat/completions"
+    :protocol "https"
+    :header nil
+    :key nil
+    :models '(tool-result-test-model)
+    :stream nil))
+
+(defun ai/agent-tool-result-test--provider-cycle (result)
+  "Feed tool RESULT through gptel's OpenAI request path and parse a reply.
+
+Return a plist containing the provider DATA, encoded wire request, decoded tool
+CONTENT and the parsed simulated continuation response."
+  (let* ((backend (ai/agent-tool-result-test--backend))
+         (gptel-backend backend)
+         (gptel-model 'tool-result-test-model)
+         (gptel-stream nil)
+         (gptel-system-prompt nil)
+         (gptel-use-tools nil)
+         (gptel--request-params nil)
+         (data (gptel--request-data
+                backend
+                (list (list :role "user" :content "Read README.md"))))
+         (tool-call
+          (list :id "call_read_1"
+                :name "Read"
+                :args '(:path "README.md")
+                :result result)))
+    (gptel--inject-prompt
+     backend data
+     '(:role "assistant"
+       :content :null
+       :tool_calls
+       [(:id "call_read_1"
+         :type "function"
+         :function (:name "Read"
+                    :arguments "{\"path\":\"README.md\"}"))]))
+    (gptel--inject-prompt
+     backend data
+     (gptel--parse-tool-results backend (list tool-call)))
+    (let* ((info (list :backend backend
+                       :model 'tool-result-test-model
+                       :stream nil
+                       :data data))
+           ;; This is the exact function named in the original crash.  It must
+           ;; be able to serialize the second request without json-value-p.
+           (curl-config (gptel-curl--get-config info "tool-result-test-uuid"))
+           (wire-json
+            (decode-coding-string (gptel--json-encode data) 'utf-8 t))
+           (wire-value
+            (json-parse-string wire-json
+                               :object-type 'plist
+                               :array-type 'array
+                               :null-object :null
+                               :false-object :json-false))
+           (messages (plist-get wire-value :messages))
+           (tool-message (aref messages (1- (length messages))))
+           (content (plist-get tool-message :content))
+           (continued
+            (gptel--parse-response
+             backend
+             '(:choices [(:message (:content "continuation ok"))]
+               :usage (:prompt_tokens 3 :completion_tokens 2))
+             info)))
+      (list :data data
+            :curl-config curl-config
+            :wire-json wire-json
+            :content content
+            :continued continued))))
+
+(ert-deftest ai/agent-tool-result-reproduces-emacs30-unibyte-json-failure ()
+  "Document the old double-serialization boundary that triggered the crash."
+  (skip-unless (>= emacs-major-version 30))
+  (let* ((legacy
+          (json-serialize
+           (ai/agent--object "ok" t "value" "Unicode — λ")
+           :null-object nil
+           :false-object :json-false))
+         (outer (list :role "tool" :content legacy)))
+    (should (stringp legacy))
+    (should-not (multibyte-string-p legacy))
+    (should-error
+     (json-serialize outer :null-object :null :false-object :json-false)
+     :type 'wrong-type-argument)))
+
+(ert-deftest ai/agent-tool-result-simple ()
+  (let* ((result (ai/agent--json "ok" t "value" "hello"))
+         (parsed (ai/agent-tool-result-test--parse result)))
+    (should (stringp result))
+    (should (multibyte-string-p result))
+    (should (eq (alist-get 'ok parsed) t))
+    (should (equal (alist-get 'value parsed) "hello"))))
+
+(ert-deftest ai/agent-tool-result-file-read-preserves-text ()
+  (let* ((directory (make-temp-file "ai-agent-tool-result-" t))
+         (file (expand-file-name "README.md" directory))
+         (body (concat
+                "# Markdown\n\n"
+                "A \"quoted\" value and \\backslashes.\n"
+                "```elisp\n(message \"hello\")\n```\n"
+                "multiple\nlines\n"
+                "Unicode: λ 日本語 — ready.\n")))
+    (unwind-protect
+        (progn
+          (with-temp-file file (insert body))
+          (let* ((default-directory directory)
+                 (ai/agent-restrict-to-project nil)
+                 (result (ai/agent-read-file file 1 300))
+                 (parsed (ai/agent-tool-result-test--parse result)))
+            (should (multibyte-string-p result))
+            (should (eq (alist-get 'ok parsed) t))
+            (should (equal (alist-get 'content parsed) body))))
+      (delete-directory directory t))))
+
+(ert-deftest ai/agent-tool-result-nested-structured-value ()
+  (let* ((result
+          (ai/agent--json
+           "ok" t
+           "meta" (ai/agent--object "start_line" 1 "end_line" 220)
+           "items" ["a" "b" "c"]
+           "empty" nil))
+         (parsed (ai/agent-tool-result-test--parse result))
+         (meta (alist-get 'meta parsed)))
+    (should (eq (alist-get 'ok parsed) t))
+    (should (= (alist-get 'start_line meta) 1))
+    (should (= (alist-get 'end_line meta) 220))
+    (should (equal (alist-get 'items parsed) '("a" "b" "c")))
+    (should (null (alist-get 'empty parsed)))))
+
+(ert-deftest ai/agent-tool-result-unicode ()
+  (let* ((text "Zażółć gęślą jaźń — λ 日本語 🚀")
+         (result (ai/agent--json "ok" t "value" text))
+         (parsed (ai/agent-tool-result-test--parse result)))
+    (should (multibyte-string-p result))
+    (should (equal (alist-get 'value parsed) text))))
+
+(ert-deftest ai/agent-tool-result-error-survives-provider-path ()
+  (let* ((result (ai/agent--json-error "boom" "file not found — nope"))
+         (cycle (ai/agent-tool-result-test--provider-cycle result))
+         (content (plist-get cycle :content))
+         (parsed (ai/agent-tool-result-test--parse content)))
+    (should (stringp (plist-get cycle :curl-config)))
+    (should (eq (alist-get 'ok parsed) :json-false))
+    (should (equal (alist-get 'error parsed) "boom"))
+    (should (equal (plist-get cycle :continued) "continuation ok"))))
+
+(ert-deftest ai/agent-tool-result-no-double-encoding ()
+  (let* ((result
+          (ai/agent--json
+           "ok" t
+           "meta" (ai/agent--object "start_line" 1 "end_line" 220)
+           "items" ["a" "b" "c"]
+           "value" "Unicode — λ"))
+         (cycle (ai/agent-tool-result-test--provider-cycle result))
+         (content (plist-get cycle :content))
+         (parsed (ai/agent-tool-result-test--parse content)))
+    ;; OpenAI-compatible chat completions defines tool result `content' as text.
+    ;; The outer request therefore quotes it exactly once.  Parsing the outer
+    ;; request must recover the original JSON text, not a quoted JSON string.
+    (should (equal content result))
+    (should (string-prefix-p "{" content))
+    (should-not (string-prefix-p "\"{" content))
+    (should (eq (alist-get 'ok parsed) t))
+    (should (equal (alist-get 'items parsed) '("a" "b" "c")))))
+
+(ert-deftest ai/agent-tool-result-model-continuation-end-to-end ()
+  (let* ((directory (make-temp-file "ai-agent-tool-continuation-" t))
+         (file (expand-file-name "README.md" directory)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "# prolog-rlm\n\nModel → tool → model — continue.\n"))
+          (let* ((default-directory directory)
+                 (ai/agent-restrict-to-project nil)
+                 ;; Execute the real Read implementation, then drive its result
+                 ;; through gptel's tool-result/provider continuation path.
+                 (result (ai/agent-read-file file 1 300))
+                 (cycle (ai/agent-tool-result-test--provider-cycle result)))
+            (should (stringp (plist-get cycle :curl-config)))
+            (should (equal (plist-get cycle :content) result))
+            (should (equal (plist-get cycle :continued) "continuation ok"))))
+      (delete-directory directory t))))
+
+(ert-deftest ai/agent-tool-result-large-content ()
+  (let* ((body (concat (make-string 100000 ?x) "\nUnicode tail — λ 日本語\n"))
+         (result (ai/agent--json "ok" t "content" body))
+         (cycle (ai/agent-tool-result-test--provider-cycle result))
+         (parsed (ai/agent-tool-result-test--parse (plist-get cycle :content))))
+    (should (equal (alist-get 'content parsed) body))
+    (should (equal (plist-get cycle :continued) "continuation ok"))))
+
+(provide 'ai-agent-tool-result-test)
+;;; ai-agent-tool-result-test.el ends here


### PR DESCRIPTION
## What changed

- normalize structured agent tool results at the canonical `ai-agent-core.el` adapter boundary
- decode `json-serialize` UTF-8 bytes back to Emacs Unicode text before handing results to gptel, then canonicalize results as multibyte strings
- add focused ERT coverage for simple, file-read, nested, Unicode, error, large-content, no-double-encoding, legacy-failure reproduction, and model-continuation paths
- test against gptel revision `dc0280821c344ec10547e13179ea2095f6165f05` using an OpenRouter-shaped OpenAI-compatible backend

## Root cause

On Emacs 30+, `json-serialize` returns a unibyte UTF-8 string. The custom tools returned that already-serialized byte string directly to gptel. gptel treats tool results as message text and later serializes the complete provider request. When the tool JSON contained non-ASCII UTF-8 bytes, the outer serialization rejected the nested unibyte string with `Wrong type argument: json-value-p`.

The fix preserves the textual JSON tool-result contract used by gptel/OpenAI-compatible chat completions while converting the intermediate serialized bytes back to normal Emacs Unicode text. Final provider JSON remains serialized by gptel; the tool result is not manually escaped or double encoded.

## Validation

- Emacs 30.2
- gptel `dc0280821c344ec10547e13179ea2095f6165f05`
- 9/9 ERT tests passed
- regression suite calls the real `ai/agent-read-file`, then drives the result through `gptel--parse-tool-results`, request injection, `gptel-curl--get-config`, outer request JSON serialization, and simulated assistant-response parsing
- legacy Emacs-30 unibyte failure is reproduced explicitly
- Unicode, Markdown, quotes, backslashes, newlines, nested objects/arrays, structured tool errors, and a 100 KB result are covered

## Version note

The dotfiles recipe currently uses `(unpin! gptel)`, so the repository itself does not identify the exact gptel commit installed in a particular local Doom checkout. The regression suite pins the inspected/tested upstream revision above so this bug stays reproducible.