### PR TITLE
Add Prolog RLM gptel tool

### DIFF
--- a/.github/scripts/check-prolog-rlm-bridge.sh
+++ b/.github/scripts/check-prolog-rlm-bridge.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+request=$(printf '{"operation":"status","root":"%s"}' "$PWD/.ci/prolog-rlm")
+response=$(printf '%s' "$request" | swipl -q -s lisp/llm/prolog-rlm-bridge.pl)
+
+RESPONSE="$response" python3 - <<'PY'
+import json
+import os
+
+value = json.loads(os.environ["RESPONSE"])
+assert value["ok"] is True, value
+assert value["ready"] is True, value
+assert value["version"], value
+print("prolog-rlm bridge status:", value["version"])
+PY

--- a/.github/workflows/prolog-rlm-tool.yml
+++ b/.github/workflows/prolog-rlm-tool.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           nix shell \
-            github:NixOS/nixpkgs/nixos-26.05#swiProlog \
+            github:NixOS/nixpkgs/nixos-26.05#swi-prolog \
             --command bash -euo pipefail -c '
               request=$(printf "{\"operation\":\"status\",\"root\":\"%s\"}" "$PWD/.ci/prolog-rlm")
               response=$(printf "%s" "$request" | swipl -q -s lisp/llm/prolog-rlm-bridge.pl)
@@ -67,7 +67,7 @@ jobs:
           set -euo pipefail
           nix shell \
             github:NixOS/nixpkgs/nixos-26.05#emacs-nox \
-            github:NixOS/nixpkgs/nixos-26.05#swiProlog \
+            github:NixOS/nixpkgs/nixos-26.05#swi-prolog \
             --command emacs -Q --batch \
               -L .ci/gptel \
               -L lisp/llm \

--- a/.github/workflows/prolog-rlm-tool.yml
+++ b/.github/workflows/prolog-rlm-tool.yml
@@ -7,6 +7,7 @@ on:
       - "lisp/llm/prolog-rlm-bridge.pl"
       - "lisp/llm/ai-prolog-rlm-test.el"
       - "lisp/llm/ai-init.el"
+      - ".github/scripts/check-prolog-rlm-bridge.sh"
       - ".github/workflows/prolog-rlm-tool.yml"
   push:
     branches:
@@ -17,6 +18,7 @@ on:
       - "lisp/llm/prolog-rlm-bridge.pl"
       - "lisp/llm/ai-prolog-rlm-test.el"
       - "lisp/llm/ai-init.el"
+      - ".github/scripts/check-prolog-rlm-bridge.sh"
       - ".github/workflows/prolog-rlm-tool.yml"
 
 permissions:
@@ -49,18 +51,7 @@ jobs:
           set -euo pipefail
           nix shell \
             github:NixOS/nixpkgs/nixos-26.05#swi-prolog \
-            --command bash -euo pipefail -c '
-              request=$(printf "{\"operation\":\"status\",\"root\":\"%s\"}" "$PWD/.ci/prolog-rlm")
-              response=$(printf "%s" "$request" | swipl -q -s lisp/llm/prolog-rlm-bridge.pl)
-              RESPONSE="$response" python3 - <<"PY"
-          import json, os
-          value = json.loads(os.environ["RESPONSE"])
-          assert value["ok"] is True, value
-          assert value["ready"] is True, value
-          assert value["version"], value
-          print("prolog-rlm bridge status:", value["version"])
-          PY
-            '
+            --command bash .github/scripts/check-prolog-rlm-bridge.sh
 
       - name: Run Emacs 30 adapter ERT tests
         run: |

--- a/.github/workflows/prolog-rlm-tool.yml
+++ b/.github/workflows/prolog-rlm-tool.yml
@@ -1,0 +1,75 @@
+name: Prolog RLM tool
+
+on:
+  pull_request:
+    paths:
+      - "lisp/llm/ai-prolog-rlm.el"
+      - "lisp/llm/prolog-rlm-bridge.pl"
+      - "lisp/llm/ai-prolog-rlm-test.el"
+      - "lisp/llm/ai-init.el"
+      - ".github/workflows/prolog-rlm-tool.yml"
+  push:
+    branches:
+      - master
+      - "agent/**"
+    paths:
+      - "lisp/llm/ai-prolog-rlm.el"
+      - "lisp/llm/prolog-rlm-bridge.pl"
+      - "lisp/llm/ai-prolog-rlm-test.el"
+      - "lisp/llm/ai-init.el"
+      - ".github/workflows/prolog-rlm-tool.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  prolog-rlm-tool:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out researched prolog-rlm runtime
+        uses: actions/checkout@v4
+        with:
+          repository: lost-rob0t/prolog-rlm
+          ref: 4cdc9854a510a2d07b559e9ae34491d43d81301a
+          path: .ci/prolog-rlm
+
+      - name: Check out tested gptel revision
+        uses: actions/checkout@v4
+        with:
+          repository: karthink/gptel
+          ref: dc0280821c344ec10547e13179ea2095f6165f05
+          path: .ci/gptel
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Verify trusted SWI bridge
+        run: |
+          set -euo pipefail
+          nix shell \
+            github:NixOS/nixpkgs/nixos-26.05#swiProlog \
+            --command bash -euo pipefail -c '
+              request=$(printf "{\"operation\":\"status\",\"root\":\"%s\"}" "$PWD/.ci/prolog-rlm")
+              response=$(printf "%s" "$request" | swipl -q -s lisp/llm/prolog-rlm-bridge.pl)
+              RESPONSE="$response" python3 - <<"PY"
+          import json, os
+          value = json.loads(os.environ["RESPONSE"])
+          assert value["ok"] is True, value
+          assert value["ready"] is True, value
+          assert value["version"], value
+          print("prolog-rlm bridge status:", value["version"])
+          PY
+            '
+
+      - name: Run Emacs 30 adapter ERT tests
+        run: |
+          set -euo pipefail
+          nix shell \
+            github:NixOS/nixpkgs/nixos-26.05#emacs-nox \
+            github:NixOS/nixpkgs/nixos-26.05#swiProlog \
+            --command emacs -Q --batch \
+              -L .ci/gptel \
+              -L lisp/llm \
+              -l lisp/llm/ai-prolog-rlm-test.el \
+              -f ert-run-tests-batch-and-exit

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -6,6 +6,7 @@
 (require 'meme)
 (require 'ai-agent)
 (require 'ai-image-tools)
+(require 'ai-prolog-rlm)
 (require 'ai-mcp)
 (require 'chat)
 (require 'fren-loader)
@@ -63,9 +64,13 @@
   (add-hook 'mara-mode-hook #'ai/llm-configure-mara-buffer))
 
 (ai/image-register-gptel-tools)
+(ai/prolog-rlm-register-gptel-tool)
 (unless (string-match-p "Image and prompt-template rules:" ai/agent-system-prompt)
   (setq ai/agent-system-prompt
         (concat ai/agent-system-prompt ai/image-agent-instructions)))
+(unless (string-match-p "Prolog RLM rules:" ai/agent-system-prompt)
+  (setq ai/agent-system-prompt
+        (concat ai/agent-system-prompt ai/prolog-rlm-agent-instructions)))
 (setq ai/chat-system-prompt ai/agent-system-prompt)
 
 (gptel-make-preset 'best

--- a/lisp/llm/ai-prolog-rlm-test.el
+++ b/lisp/llm/ai-prolog-rlm-test.el
@@ -1,0 +1,101 @@
+;;; ai-prolog-rlm-test.el --- Tests for PrologRLM gptel tool -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+(require 'ai-prolog-rlm)
+
+(defun ai/prolog-rlm-test--parse (text)
+  "Parse tool-result JSON TEXT."
+  (json-parse-string text
+                     :object-type 'alist
+                     :array-type 'list
+                     :null-object nil
+                     :false-object :json-false))
+
+(ert-deftest ai/prolog-rlm-context-requires-exactly-one-source ()
+  (should-error (ai/prolog-rlm--context nil nil))
+  (should-error (ai/prolog-rlm--context "README.md" "inline")))
+
+(ert-deftest ai/prolog-rlm-inline-context-preserves-unicode ()
+  (let ((text "RLM → λ 日本語 🚀\nsecond line"))
+    (should (equal (ai/prolog-rlm--context nil text) text))))
+
+(ert-deftest ai/prolog-rlm-file-context-is-bounded-and-lossless ()
+  (let* ((directory (make-temp-file "prolog-rlm-context-" t))
+         (file (expand-file-name "context.md" directory))
+         (body "# Context\n\n\"quotes\" \\slashes — λ\n"))
+    (unwind-protect
+        (progn
+          (with-temp-file file (insert body))
+          (let ((ai/agent-restrict-to-project nil)
+                (ai/prolog-rlm-max-context-bytes 4096))
+            (should (equal (ai/prolog-rlm--context file nil) body)))
+          (let ((ai/agent-restrict-to-project nil)
+                (ai/prolog-rlm-max-context-bytes 2))
+            (should-error (ai/prolog-rlm--context file nil))))
+      (delete-directory directory t))))
+
+(ert-deftest ai/prolog-rlm-budget-is-host-bounded ()
+  (let* ((ai/prolog-rlm-max-total-tokens 999999)
+         (ai/prolog-rlm-max-cost-usd 99.0)
+         (ai/prolog-rlm-time-limit 999.0)
+         (budget (ai/prolog-rlm--budget)))
+    (should (= (alist-get 'max_recursion_depth budget) 1))
+    (should (= (alist-get 'max_tool_calls budget) 0))
+    (should (= (alist-get 'max_total_tokens budget) 32768))
+    (should (= (alist-get 'max_cost_usd budget) 1.0))
+    (should (= (alist-get 'time_limit budget) 120.0))))
+
+(ert-deftest ai/prolog-rlm-request-serializes-as-gptel-safe-text ()
+  (let* ((root (make-temp-file "prolog-rlm-root-" t))
+         (entry-dir (expand-file-name "prolog" root))
+         (entry (expand-file-name "rlm.pl" entry-dir))
+         (ai/prolog-rlm-root root)
+         (ai/prolog-rlm-model "openrouter/auto"))
+    (unwind-protect
+        (progn
+          (make-directory entry-dir t)
+          (with-temp-file entry (insert "% fixture\n"))
+          (let* ((request (ai/prolog-rlm--request "Find → λ" "opaque 日本語"))
+                 (encoded (ai/agent--tool-result request))
+                 (parsed (ai/prolog-rlm-test--parse encoded)))
+            (should (multibyte-string-p encoded))
+            (should (equal (alist-get 'operation parsed) "completion"))
+            (should (equal (alist-get 'model parsed) "openrouter/auto"))
+            (should (equal (alist-get 'query parsed) "Find → λ"))
+            (should (equal (alist-get 'context parsed) "opaque 日本語"))))
+      (delete-directory root t))))
+
+(ert-deftest ai/prolog-rlm-bridge-output-normalizes-once ()
+  (let* ((raw "{\"ok\":true,\"kind\":\"rlm_result\",\"result\":{\"value\":\"λ — ok\"}}")
+         (result (ai/prolog-rlm--bridge-output raw))
+         (parsed (ai/prolog-rlm-test--parse result)))
+    (should (multibyte-string-p result))
+    (should (eq (alist-get 'ok parsed) t))
+    (should (equal (alist-get 'kind parsed) "rlm_result"))
+    (should-not (string-prefix-p "\"{" result))))
+
+(ert-deftest ai/prolog-rlm-configuration-failure-calls-back-once ()
+  (let ((calls 0)
+        result)
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_program) nil)))
+      (ai/prolog-rlm--start
+       (lambda (value)
+         (setq calls (1+ calls)
+               result value))
+       '((operation . "completion"))))
+    (should (= calls 1))
+    (should (eq (alist-get 'ok (ai/prolog-rlm-test--parse result))
+                :json-false))))
+
+(ert-deftest ai/prolog-rlm-registers-async-gptel-tool ()
+  (ai/prolog-rlm-register-gptel-tool)
+  (let ((tool (gptel-get-tool "PrologRLM")))
+    (should tool)
+    (should (gptel-tool-async tool))
+    (should (member "PrologRLM" ai/agent-tools))))
+
+(provide 'ai-prolog-rlm-test)
+;;; ai-prolog-rlm-test.el ends here

--- a/lisp/llm/ai-prolog-rlm.el
+++ b/lisp/llm/ai-prolog-rlm.el
@@ -1,0 +1,313 @@
+;;; ai-prolog-rlm.el --- Async Prolog RLM tool for gptel -*- lexical-binding: t; -*-
+
+(require 'ai)
+(require 'ai-agent-core)
+(require 'cl-lib)
+(require 'gptel)
+(require 'json)
+(require 'subr-x)
+
+(defgroup ai/prolog-rlm nil
+  "gptel integration for the local prolog-rlm runtime."
+  :group 'ai/agent
+  :prefix "ai/prolog-rlm-")
+
+(defcustom ai/prolog-rlm-root
+  (expand-file-name "~/Documents/Projects/prolog-rlm")
+  "Checkout containing prolog-rlm's public `prolog/rlm.pl' entrypoint."
+  :type 'directory
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-model "openrouter/auto"
+  "OpenRouter model used by the inner Prolog RLM runtime."
+  :type 'string
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-max-context-bytes (* 8 1024 1024)
+  "Maximum UTF-8 file payload accepted by one PrologRLM tool call."
+  :type 'integer
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-max-total-tokens 8192
+  "Requested aggregate token ceiling for one Prolog RLM completion.
+The trusted Prolog bridge applies its own hard upper bound as well."
+  :type 'integer
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-max-cost-usd 0.25
+  "Requested aggregate dollar ceiling for one Prolog RLM completion.
+The trusted Prolog bridge applies its own hard upper bound as well."
+  :type 'number
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-time-limit 60.0
+  "Requested wall-time ceiling in seconds for one Prolog RLM completion."
+  :type 'number
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-host-timeout-slack 15.0
+  "Seconds the Emacs host allows beyond the Prolog runtime time limit."
+  :type 'number
+  :group 'ai/prolog-rlm)
+
+(defcustom ai/prolog-rlm-max-result-bytes (* 512 1024)
+  "Maximum JSON response accepted from the Prolog bridge."
+  :type 'integer
+  :group 'ai/prolog-rlm)
+
+(defconst ai/prolog-rlm--module-directory
+  (file-name-directory (or load-file-name buffer-file-name))
+  "Directory containing the Prolog RLM Emacs integration files.")
+
+(defconst ai/prolog-rlm--bridge-file
+  (expand-file-name "prolog-rlm-bridge.pl" ai/prolog-rlm--module-directory)
+  "Trusted JSON/stdin bridge between Emacs and prolog-rlm.")
+
+(defconst ai/prolog-rlm-agent-instructions
+  "\n\nProlog RLM rules:\n- Use PrologRLM for large-context analysis or tasks where bounded search, slicing, decomposition, or recursive subcalls are useful.\n- Do not use PrologRLM for trivial questions that the current model can answer directly.\n- When the source is a local project file, pass its path directly to PrologRLM instead of calling Read first and copying the full file into the conversation.\n- Supply exactly one of path or context. Use context only when the relevant text is already available without another file read.\n- Treat PrologRLM failures as structured tool failures; do not invent a result when it reports an error."
+  "System-prompt fragment describing appropriate PrologRLM use.")
+
+(defun ai/prolog-rlm--error-result (kind message &optional details)
+  "Return a canonical gptel tool result for KIND, MESSAGE and DETAILS."
+  (ai/agent--tool-result
+   (ai/agent--object
+    "ok" :json-false
+    "kind" kind
+    "error" message
+    "details" details)))
+
+(defun ai/prolog-rlm--root ()
+  "Return the validated prolog-rlm checkout root."
+  (let* ((root (file-name-as-directory (expand-file-name ai/prolog-rlm-root)))
+         (entrypoint (expand-file-name "prolog/rlm.pl" root)))
+    (unless (file-readable-p entrypoint)
+      (error "prolog-rlm entrypoint is not readable: %s" entrypoint))
+    root))
+
+(defun ai/prolog-rlm--read-context-file (path)
+  "Read PATH as bounded text using the agent's filesystem policy."
+  (let* ((file (ai/agent--resolve-path path))
+         (attributes (file-attributes file 'string)))
+    (unless attributes
+      (error "Context file does not exist: %s" path))
+    (unless (file-regular-p file)
+      (error "Context path is not a regular file: %s" path))
+    (unless (file-readable-p file)
+      (error "Context file is not readable: %s" path))
+    (let ((bytes (file-attribute-size attributes)))
+      (when (> bytes ai/prolog-rlm-max-context-bytes)
+        (error "Context file is %d bytes; limit is %d"
+               bytes ai/prolog-rlm-max-context-bytes)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (when (string-match-p "\0" text)
+          (error "Context file appears to be binary: %s" path))
+        text))))
+
+(defun ai/prolog-rlm--context (path context)
+  "Resolve exactly one of PATH or inline CONTEXT to text."
+  (let ((has-path (and (stringp path) (not (string-empty-p path))))
+        (has-context (and (stringp context) (not (string-empty-p context)))))
+    (cond
+     ((and has-path has-context)
+      (error "PrologRLM accepts exactly one of path or context"))
+     (has-path (ai/prolog-rlm--read-context-file path))
+     (has-context
+      (when (> (string-bytes context) ai/prolog-rlm-max-context-bytes)
+        (error "Inline context exceeds %d bytes" ai/prolog-rlm-max-context-bytes))
+      context)
+     (t (error "PrologRLM requires exactly one of path or context")))))
+
+(defun ai/prolog-rlm--budget ()
+  "Return the host-requested RLM budget as JSON-compatible data."
+  (ai/agent--object
+   "max_iterations" 32
+   "max_recursion_depth" 1
+   "max_concurrent_subcalls" 2
+   "max_model_calls" 4
+   "max_tool_calls" 0
+   "max_context_ops" 8
+   "max_total_tokens" (max 256 (min 32768 ai/prolog-rlm-max-total-tokens))
+   "max_cost_usd" (max 0.0 (min 1.0 ai/prolog-rlm-max-cost-usd))
+   "max_output_bytes" 65536
+   "time_limit" (max 1.0 (min 120.0 ai/prolog-rlm-time-limit))))
+
+(defun ai/prolog-rlm--request (query context)
+  "Build the trusted bridge request for QUERY over CONTEXT."
+  (unless (and (stringp query) (not (string-empty-p (string-trim query))))
+    (error "PrologRLM query must be non-empty"))
+  (unless (and (stringp ai/prolog-rlm-model)
+               (not (string-empty-p ai/prolog-rlm-model)))
+    (error "ai/prolog-rlm-model must be non-empty"))
+  (ai/agent--object
+   "operation" "completion"
+   "root" (ai/prolog-rlm--root)
+   "query" query
+   "context" context
+   "model" ai/prolog-rlm-model
+   "budget" (ai/prolog-rlm--budget)))
+
+(defun ai/prolog-rlm--stderr-text (buffer)
+  "Return bounded stderr text from BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (car (ai/agent--truncate
+            (buffer-substring-no-properties (point-min) (point-max))
+            16384)))))
+
+(defun ai/prolog-rlm--bridge-output (raw)
+  "Validate RAW bridge JSON and return canonical gptel result text."
+  (when (> (string-bytes raw) ai/prolog-rlm-max-result-bytes)
+    (error "Prolog RLM response exceeded %d bytes"
+           ai/prolog-rlm-max-result-bytes))
+  (let ((parsed
+         (json-parse-string
+          (string-trim raw)
+          :object-type 'alist
+          :array-type 'array
+          :null-object nil
+          :false-object :json-false)))
+    (ai/agent--tool-result parsed)))
+
+(defun ai/prolog-rlm--start (callback request)
+  "Run REQUEST through the trusted SWI bridge and invoke CALLBACK once."
+  (unless (executable-find "swipl")
+    (funcall callback
+             (ai/prolog-rlm--error-result
+              "configuration_error" "swipl is not on exec-path"))
+    (cl-return-from ai/prolog-rlm--start nil))
+  (unless (file-readable-p ai/prolog-rlm--bridge-file)
+    (funcall callback
+             (ai/prolog-rlm--error-result
+              "configuration_error"
+              (format "Prolog RLM bridge is not readable: %s"
+                      ai/prolog-rlm--bridge-file)))
+    (cl-return-from ai/prolog-rlm--start nil))
+  (let ((key (ai/llm--api-key 'openrouter)))
+    (unless (and (stringp key) (not (string-empty-p key)))
+      (funcall callback
+               (ai/prolog-rlm--error-result
+                "configuration_error"
+                "No OpenRouter credential is available to PrologRLM"))
+      (cl-return-from ai/prolog-rlm--start nil))
+    (let* ((stdout (generate-new-buffer " *prolog-rlm-out*"))
+           (stderr (generate-new-buffer " *prolog-rlm-err*"))
+           (request-text (ai/agent--tool-result request))
+           (finished nil)
+           (timer nil)
+           (process nil)
+           (host-timeout (+ (max 1.0 (min 120.0 ai/prolog-rlm-time-limit))
+                            (max 0.0 ai/prolog-rlm-host-timeout-slack))))
+      (cl-labels
+          ((cleanup ()
+             (when (timerp timer)
+               (cancel-timer timer))
+             (when (buffer-live-p stdout)
+               (kill-buffer stdout))
+             (when (buffer-live-p stderr)
+               (kill-buffer stderr)))
+           (finish (result)
+             (unless finished
+               (setq finished t)
+               (unwind-protect
+                   (funcall callback result)
+                 (cleanup))))
+           (fail (kind message &optional details)
+             (finish (ai/prolog-rlm--error-result kind message details)))
+           (sentinel (proc _event)
+             (when (memq (process-status proc) '(exit signal))
+               (let ((status (process-exit-status proc))
+                     (errtext (ai/prolog-rlm--stderr-text stderr)))
+                 (if (not (zerop status))
+                     (fail "process_error"
+                           (format "Prolog RLM bridge exited with status %d" status)
+                           errtext)
+                   (condition-case err
+                       (let ((raw
+                              (when (buffer-live-p stdout)
+                                (with-current-buffer stdout
+                                  (buffer-substring-no-properties
+                                   (point-min) (point-max))))))
+                         (if (string-empty-p (or (string-trim (or raw "")) ""))
+                             (fail "protocol_error"
+                                   "Prolog RLM bridge returned no JSON"
+                                   errtext)
+                           (finish (ai/prolog-rlm--bridge-output raw))))
+                     (error
+                      (fail "protocol_error"
+                            (error-message-string err)
+                            errtext))))))))
+        (let ((process-environment (copy-sequence process-environment)))
+          (setenv "OPENROUTER_API_KEY" key)
+          (setq process
+                (make-process
+                 :name (generate-new-buffer-name "prolog-rlm")
+                 :buffer stdout
+                 :stderr stderr
+                 :command (list (executable-find "swipl")
+                                "-q" "-s" ai/prolog-rlm--bridge-file)
+                 :coding 'utf-8-unix
+                 :connection-type 'pipe
+                 :noquery t
+                 :sentinel #'sentinel)))
+        (setq timer
+              (run-at-time
+               host-timeout nil
+               (lambda ()
+                 (unless finished
+                   (setq finished t)
+                   (when (process-live-p process)
+                     (delete-process process))
+                   (unwind-protect
+                       (funcall callback
+                                (ai/prolog-rlm--error-result
+                                 "host_timeout"
+                                 (format "PrologRLM exceeded %.1f seconds"
+                                         host-timeout)))
+                     (cleanup))))))
+        (process-send-string process request-text)
+        (process-send-eof process)
+        process))))
+
+(defun ai/prolog-rlm-chat (callback query &optional path context)
+  "Run QUERY through prolog-rlm over PATH or inline CONTEXT.
+CALLBACK is supplied first by gptel because this is an asynchronous tool."
+  (condition-case err
+      (let* ((resolved-context (ai/prolog-rlm--context path context))
+             (request (ai/prolog-rlm--request query resolved-context)))
+        (ai/prolog-rlm--start callback request))
+    (error
+     (funcall callback
+              (ai/prolog-rlm--error-result
+               "input_error" (error-message-string err))))))
+
+(defun ai/prolog-rlm-register-gptel-tool ()
+  "Register the asynchronous PrologRLM tool and add it to agent presets."
+  (when (fboundp 'gptel-get-tool)
+    (ignore-errors (setf (gptel-get-tool "PrologRLM") nil)))
+  (gptel-make-tool
+   :name "PrologRLM"
+   :function #'ai/prolog-rlm-chat
+   :category "reasoning"
+   :description
+   "Run a bounded Recursive Language Model in SWI-Prolog over a large local file or inline text. The RLM can inspect/search/slice/partition opaque context and make bounded OpenRouter subcalls without exposing the full context to the outer model."
+   :args '((:name "query"
+            :type string
+            :description "Question or task the Prolog RLM should solve")
+           (:name "path"
+            :type string
+            :optional t
+            :description "Local context file. Prefer this for large project files; do not Read it first")
+           (:name "context"
+            :type string
+            :optional t
+            :description "Inline context text; mutually exclusive with path"))
+   :async t
+   :include t)
+  (when (boundp 'ai/agent-tools)
+    (cl-pushnew "PrologRLM" ai/agent-tools :test #'equal))
+  "PrologRLM")
+
+(provide 'ai-prolog-rlm)
+;;; ai-prolog-rlm.el ends here

--- a/lisp/llm/ai-prolog-rlm.el
+++ b/lisp/llm/ai-prolog-rlm.el
@@ -24,7 +24,7 @@
   :group 'ai/prolog-rlm)
 
 (defcustom ai/prolog-rlm-max-context-bytes (* 8 1024 1024)
-  "Maximum UTF-8 file payload accepted by one PrologRLM tool call."
+  "Maximum UTF-8 context payload accepted by one PrologRLM call."
   :type 'integer
   :group 'ai/prolog-rlm)
 
@@ -68,7 +68,7 @@ The trusted Prolog bridge applies its own hard upper bound as well."
   "System-prompt fragment describing appropriate PrologRLM use.")
 
 (defun ai/prolog-rlm--error-result (kind message &optional details)
-  "Return a canonical gptel tool result for KIND, MESSAGE and DETAILS."
+  "Return canonical gptel tool-result text for KIND, MESSAGE and DETAILS."
   (ai/agent--tool-result
    (ai/agent--object
     "ok" :json-false
@@ -85,7 +85,7 @@ The trusted Prolog bridge applies its own hard upper bound as well."
     root))
 
 (defun ai/prolog-rlm--read-context-file (path)
-  "Read PATH as bounded text using the agent's filesystem policy."
+  "Read PATH as bounded text using the agent filesystem policy."
   (let* ((file (ai/agent--resolve-path path))
          (attributes (file-attributes file 'string)))
     (unless attributes
@@ -112,12 +112,14 @@ The trusted Prolog bridge applies its own hard upper bound as well."
     (cond
      ((and has-path has-context)
       (error "PrologRLM accepts exactly one of path or context"))
-     (has-path (ai/prolog-rlm--read-context-file path))
+     (has-path
+      (ai/prolog-rlm--read-context-file path))
      (has-context
       (when (> (string-bytes context) ai/prolog-rlm-max-context-bytes)
         (error "Inline context exceeds %d bytes" ai/prolog-rlm-max-context-bytes))
       context)
-     (t (error "PrologRLM requires exactly one of path or context")))))
+     (t
+      (error "PrologRLM requires exactly one of path or context")))))
 
 (defun ai/prolog-rlm--budget ()
   "Return the host-requested RLM budget as JSON-compatible data."
@@ -161,6 +163,8 @@ The trusted Prolog bridge applies its own hard upper bound as well."
   (when (> (string-bytes raw) ai/prolog-rlm-max-result-bytes)
     (error "Prolog RLM response exceeded %d bytes"
            ai/prolog-rlm-max-result-bytes))
+  (when (string-empty-p (string-trim raw))
+    (error "Prolog RLM bridge returned no JSON"))
   (let ((parsed
          (json-parse-string
           (string-trim raw)
@@ -170,105 +174,107 @@ The trusted Prolog bridge applies its own hard upper bound as well."
           :false-object :json-false)))
     (ai/agent--tool-result parsed)))
 
+(defun ai/prolog-rlm--start-ready (callback request swipl key)
+  "Start SWIPL for REQUEST using KEY and invoke CALLBACK exactly once."
+  (let* ((stdout (generate-new-buffer " *prolog-rlm-out*"))
+         (stderr (generate-new-buffer " *prolog-rlm-err*"))
+         (request-text (ai/agent--tool-result request))
+         (finished nil)
+         (timer nil)
+         (process nil)
+         (host-timeout (+ (max 1.0 (min 120.0 ai/prolog-rlm-time-limit))
+                          (max 0.0 ai/prolog-rlm-host-timeout-slack))))
+    (cl-labels
+        ((cleanup ()
+           (when (timerp timer)
+             (cancel-timer timer))
+           (when (buffer-live-p stdout)
+             (kill-buffer stdout))
+           (when (buffer-live-p stderr)
+             (kill-buffer stderr)))
+         (finish (result)
+           (unless finished
+             (setq finished t)
+             (unwind-protect
+                 (funcall callback result)
+               (cleanup))))
+         (fail (kind message &optional details)
+           (finish (ai/prolog-rlm--error-result kind message details)))
+         (sentinel (proc _event)
+           (when (memq (process-status proc) '(exit signal))
+             (let ((status (process-exit-status proc))
+                   (errtext (ai/prolog-rlm--stderr-text stderr)))
+               (if (not (zerop status))
+                   (fail "process_error"
+                         (format "Prolog RLM bridge exited with status %d" status)
+                         errtext)
+                 (condition-case err
+                     (let ((raw
+                            (when (buffer-live-p stdout)
+                              (with-current-buffer stdout
+                                (buffer-substring-no-properties
+                                 (point-min) (point-max))))))
+                       (finish (ai/prolog-rlm--bridge-output (or raw ""))))
+                   (error
+                    (fail "protocol_error"
+                          (error-message-string err)
+                          errtext))))))))
+      (let ((process-environment (copy-sequence process-environment)))
+        (setenv "OPENROUTER_API_KEY" key)
+        (setq process
+              (make-process
+               :name (generate-new-buffer-name "prolog-rlm")
+               :buffer stdout
+               :stderr stderr
+               :command (list swipl "-q" "-s" ai/prolog-rlm--bridge-file)
+               :coding 'utf-8-unix
+               :connection-type 'pipe
+               :noquery t
+               :sentinel #'sentinel)))
+      (setq timer
+            (run-at-time
+             host-timeout nil
+             (lambda ()
+               (unless finished
+                 (setq finished t)
+                 (when (process-live-p process)
+                   (delete-process process))
+                 (unwind-protect
+                     (funcall callback
+                              (ai/prolog-rlm--error-result
+                               "host_timeout"
+                               (format "PrologRLM exceeded %.1f seconds"
+                                       host-timeout)))
+                   (cleanup))))))
+      (process-send-string process request-text)
+      (process-send-eof process)
+      process)))
+
 (defun ai/prolog-rlm--start (callback request)
-  "Run REQUEST through the trusted SWI bridge and invoke CALLBACK once."
-  (unless (executable-find "swipl")
-    (funcall callback
-             (ai/prolog-rlm--error-result
-              "configuration_error" "swipl is not on exec-path"))
-    (cl-return-from ai/prolog-rlm--start nil))
-  (unless (file-readable-p ai/prolog-rlm--bridge-file)
-    (funcall callback
-             (ai/prolog-rlm--error-result
-              "configuration_error"
-              (format "Prolog RLM bridge is not readable: %s"
-                      ai/prolog-rlm--bridge-file)))
-    (cl-return-from ai/prolog-rlm--start nil))
-  (let ((key (ai/llm--api-key 'openrouter)))
-    (unless (and (stringp key) (not (string-empty-p key)))
+  "Run REQUEST through the trusted SWI bridge and invoke CALLBACK."
+  (let ((swipl (executable-find "swipl"))
+        (key (ai/llm--api-key 'openrouter)))
+    (cond
+     ((not swipl)
+      (funcall callback
+               (ai/prolog-rlm--error-result
+                "configuration_error" "swipl is not on exec-path"))
+      nil)
+     ((not (file-readable-p ai/prolog-rlm--bridge-file))
+      (funcall callback
+               (ai/prolog-rlm--error-result
+                "configuration_error"
+                (format "Prolog RLM bridge is not readable: %s"
+                        ai/prolog-rlm--bridge-file)))
+      nil)
+     ((not (and (stringp key) (not (string-empty-p key))))
       (funcall callback
                (ai/prolog-rlm--error-result
                 "configuration_error"
                 "No OpenRouter credential is available to PrologRLM"))
-      (cl-return-from ai/prolog-rlm--start nil))
-    (let* ((stdout (generate-new-buffer " *prolog-rlm-out*"))
-           (stderr (generate-new-buffer " *prolog-rlm-err*"))
-           (request-text (ai/agent--tool-result request))
-           (finished nil)
-           (timer nil)
-           (process nil)
-           (host-timeout (+ (max 1.0 (min 120.0 ai/prolog-rlm-time-limit))
-                            (max 0.0 ai/prolog-rlm-host-timeout-slack))))
-      (cl-labels
-          ((cleanup ()
-             (when (timerp timer)
-               (cancel-timer timer))
-             (when (buffer-live-p stdout)
-               (kill-buffer stdout))
-             (when (buffer-live-p stderr)
-               (kill-buffer stderr)))
-           (finish (result)
-             (unless finished
-               (setq finished t)
-               (unwind-protect
-                   (funcall callback result)
-                 (cleanup))))
-           (fail (kind message &optional details)
-             (finish (ai/prolog-rlm--error-result kind message details)))
-           (sentinel (proc _event)
-             (when (memq (process-status proc) '(exit signal))
-               (let ((status (process-exit-status proc))
-                     (errtext (ai/prolog-rlm--stderr-text stderr)))
-                 (if (not (zerop status))
-                     (fail "process_error"
-                           (format "Prolog RLM bridge exited with status %d" status)
-                           errtext)
-                   (condition-case err
-                       (let ((raw
-                              (when (buffer-live-p stdout)
-                                (with-current-buffer stdout
-                                  (buffer-substring-no-properties
-                                   (point-min) (point-max))))))
-                         (if (string-empty-p (or (string-trim (or raw "")) ""))
-                             (fail "protocol_error"
-                                   "Prolog RLM bridge returned no JSON"
-                                   errtext)
-                           (finish (ai/prolog-rlm--bridge-output raw))))
-                     (error
-                      (fail "protocol_error"
-                            (error-message-string err)
-                            errtext))))))))
-        (let ((process-environment (copy-sequence process-environment)))
-          (setenv "OPENROUTER_API_KEY" key)
-          (setq process
-                (make-process
-                 :name (generate-new-buffer-name "prolog-rlm")
-                 :buffer stdout
-                 :stderr stderr
-                 :command (list (executable-find "swipl")
-                                "-q" "-s" ai/prolog-rlm--bridge-file)
-                 :coding 'utf-8-unix
-                 :connection-type 'pipe
-                 :noquery t
-                 :sentinel #'sentinel)))
-        (setq timer
-              (run-at-time
-               host-timeout nil
-               (lambda ()
-                 (unless finished
-                   (setq finished t)
-                   (when (process-live-p process)
-                     (delete-process process))
-                   (unwind-protect
-                       (funcall callback
-                                (ai/prolog-rlm--error-result
-                                 "host_timeout"
-                                 (format "PrologRLM exceeded %.1f seconds"
-                                         host-timeout)))
-                     (cleanup))))))
-        (process-send-string process request-text)
-        (process-send-eof process)
-        process))))
+      nil)
+     (t
+      (ai/prolog-rlm--start-ready callback request swipl key)))))
 
 (defun ai/prolog-rlm-chat (callback query &optional path context)
   "Run QUERY through prolog-rlm over PATH or inline CONTEXT.

--- a/lisp/llm/prolog-rlm-bridge.pl
+++ b/lisp/llm/prolog-rlm-bridge.pl
@@ -1,0 +1,238 @@
+:- module(prolog_rlm_bridge, [main/0]).
+
+:- use_module(library(http/json)).
+:- use_module(library(lists)).
+
+:- initialization(main, main).
+
+main :-
+    catch(run, Exception, write_bridge_exception(Exception)).
+
+run :-
+    json_read_dict(current_input, Request),
+    require_text(Request, operation, Operation),
+    dispatch(Operation, Request, Response),
+    write_json(Response).
+
+dispatch("status", Request, Response) :-
+    !,
+    load_rlm(Request),
+    rlm:rlm_version(Version),
+    (   rlm:rlm_ready
+    ->  Ready = true
+    ;   Ready = false
+    ),
+    text_value(Version, VersionText),
+    Response = _{ok:true,
+                 operation:"status",
+                 ready:Ready,
+                 version:VersionText}.
+dispatch("completion", Request, Response) :-
+    !,
+    load_rlm(Request),
+    require_text(Request, query, Query),
+    require_text(Request, context, Context),
+    request_model(Request, Model),
+    request_budget(Request, Budget),
+    rlm_chain:openrouter_provider(Model, Provider),
+    root_capabilities(Capabilities),
+    child_capabilities(ChildCapabilities),
+    planner_instruction(PlannerInstruction),
+    Options = [ provider(Provider),
+                provider_name(openrouter),
+                capabilities(Capabilities),
+                child_capabilities(ChildCapabilities),
+                planner_instruction(PlannerInstruction),
+                planner_attempts(2),
+                planner_max_tokens(1536),
+                context_options([max_results(64),
+                                 max_bytes(32768),
+                                 time_limit(1.0)]),
+                budget(Budget)
+              ],
+    rlm:rlm_completion(Query, text(Context), Options, Outcome),
+    outcome_response(Outcome, Response).
+dispatch(Operation, _, _) :-
+    throw(error(domain_error(prolog_rlm_bridge_operation, Operation), _)).
+
+load_rlm(Request) :-
+    require_text(Request, root, Root0),
+    (   absolute_file_name(Root0,
+                           Root,
+                           [ file_type(directory),
+                             access(read),
+                             file_errors(fail)
+                           ])
+    ->  true
+    ;   throw(error(existence_error(directory, Root0), _))
+    ),
+    directory_file_path(Root, 'prolog/rlm.pl', RlmFile),
+    (   exists_file(RlmFile)
+    ->  true
+    ;   throw(error(existence_error(source_sink, RlmFile), _))
+    ),
+    load_files(RlmFile, [silent(true)]).
+
+request_model(Request, Model) :-
+    (   get_dict(model, Request, Model0),
+        text_value(Model0, ModelText),
+        ModelText \== ""
+    ->  atom_string(Model, ModelText)
+    ;   Model = 'openrouter/free'
+    ).
+
+request_budget(Request, Budget) :-
+    (   get_dict(budget, Request, Requested),
+        is_dict(Requested)
+    ->  true
+    ;   Requested = _{}
+    ),
+    bounded_integer(Requested, max_iterations, 32, 1, 64, MaxIterations),
+    bounded_integer(Requested, max_recursion_depth, 1, 0, 1, MaxDepth),
+    bounded_integer(Requested, max_concurrent_subcalls, 2, 1, 4, MaxConcurrent),
+    bounded_integer(Requested, max_model_calls, 4, 1, 8, MaxModelCalls),
+    bounded_integer(Requested, max_tool_calls, 0, 0, 0, MaxToolCalls),
+    bounded_integer(Requested, max_context_ops, 8, 1, 32, MaxContextOps),
+    bounded_integer(Requested, max_total_tokens, 8192, 256, 32768, MaxTokens),
+    bounded_number(Requested, max_cost_usd, 0.25, 0.0, 1.0, MaxCost),
+    bounded_integer(Requested, max_output_bytes, 65536, 1024, 262144, MaxOutput),
+    bounded_number(Requested, time_limit, 60.0, 1.0, 120.0, TimeLimit),
+    Budget = completion_budget{
+                 max_iterations:MaxIterations,
+                 max_recursion_depth:MaxDepth,
+                 max_concurrent_subcalls:MaxConcurrent,
+                 max_model_calls:MaxModelCalls,
+                 max_tool_calls:MaxToolCalls,
+                 max_context_ops:MaxContextOps,
+                 max_total_tokens:MaxTokens,
+                 max_cost_usd:MaxCost,
+                 max_output_bytes:MaxOutput,
+                 time_limit:TimeLimit
+             }.
+
+bounded_integer(Dict, Key, Default, Min, Max, Value) :-
+    (   get_dict(Key, Dict, Candidate),
+        integer(Candidate)
+    ->  clamp(Candidate, Min, Max, Value)
+    ;   Value = Default
+    ).
+
+bounded_number(Dict, Key, Default, Min, Max, Value) :-
+    (   get_dict(Key, Dict, Candidate),
+        number(Candidate)
+    ->  clamp(Candidate, Min, Max, Value)
+    ;   Value = Default
+    ).
+
+clamp(Value, Min, _, Min) :- Value < Min, !.
+clamp(Value, _, Max, Max) :- Value > Max, !.
+clamp(Value, _, _, Value).
+
+root_capabilities([ rlm,
+                    model(openrouter),
+                    context(peek),
+                    context(slice),
+                    context(search),
+                    context(partition),
+                    context(map),
+                    context(reduce)
+                  ]).
+
+child_capabilities([model(openrouter)]).
+
+planner_instruction(
+"Use the opaque context whenever the answer depends on supplied context. Inspect it with bounded context operations rather than guessing from metadata. Prefer deterministic context search/slicing before model recursion. Recurse only when decomposition materially helps. Return a final answer grounded in inspected context.").
+
+outcome_response(ok(Result), Response) :-
+    !,
+    json_safe(Result, Safe),
+    Response = _{ok:true,
+                 kind:"rlm_result",
+                 result:Safe}.
+outcome_response(error(Error), Response) :-
+    !,
+    json_safe(Error, Safe),
+    Response = _{ok:false,
+                 kind:"rlm_error",
+                 error:Safe}.
+outcome_response(Other, Response) :-
+    json_safe(Other, Safe),
+    Response = _{ok:false,
+                 kind:"invalid_rlm_outcome",
+                 error:Safe}.
+
+json_safe(Value, Safe) :-
+    var(Value),
+    !,
+    term_string(Value, Text, [quoted(true), numbervars(true)]),
+    Safe = _{type:"prolog_variable", value:Text}.
+json_safe(Value, Safe) :-
+    is_dict(Value),
+    !,
+    dict_pairs(Value, Tag, Pairs0),
+    maplist(json_safe_pair, Pairs0, Pairs),
+    safe_tag(Tag, TagSafe),
+    (   TagSafe == null
+    ->  dict_pairs(Safe, json, Pairs)
+    ;   dict_pairs(Safe0, json, Pairs),
+        put_dict('_tag', Safe0, TagSafe, Safe)
+    ).
+json_safe(Value, Safe) :-
+    is_list(Value),
+    !,
+    maplist(json_safe, Value, Safe).
+json_safe(Value, Value) :-
+    string(Value),
+    !.
+json_safe(Value, Value) :-
+    number(Value),
+    !.
+json_safe(true, true) :- !.
+json_safe(false, false) :- !.
+json_safe(null, null) :- !.
+json_safe(Value, Safe) :-
+    atom(Value),
+    !,
+    atom_string(Value, Safe).
+json_safe(Value, Safe) :-
+    compound(Value),
+    !,
+    Value =.. [Functor|Args],
+    atom_string(Functor, FunctorText),
+    maplist(json_safe, Args, SafeArgs),
+    Safe = _{type:"prolog_term",
+             functor:FunctorText,
+             args:SafeArgs}.
+json_safe(Value, Safe) :-
+    term_string(Value, Safe, [quoted(true), numbervars(true)]).
+
+json_safe_pair(Key-Value0, Key-Value) :-
+    json_safe(Value0, Value).
+
+safe_tag(Tag, null) :- var(Tag), !.
+safe_tag(Tag, Safe) :- atom(Tag), !, atom_string(Tag, Safe).
+safe_tag(Tag, Safe) :- text_value(Tag, Safe).
+
+require_text(Dict, Key, Text) :-
+    (   get_dict(Key, Dict, Value),
+        text_value(Value, Text),
+        Text \== ""
+    ->  true
+    ;   throw(error(domain_error(nonempty_text_field, Key), _))
+    ).
+
+text_value(Value, Value) :- string(Value), !.
+text_value(Value, Text) :- atom(Value), !, atom_string(Value, Text).
+text_value(Value, _) :-
+    throw(error(type_error(text, Value), _)).
+
+write_bridge_exception(Exception) :-
+    json_safe(Exception, Safe),
+    write_json(_{ok:false,
+                 kind:"bridge_error",
+                 error:Safe}).
+
+write_json(Dict) :-
+    json_write_dict(current_output, Dict, [width(0)]),
+    nl,
+    flush_output(current_output).


### PR DESCRIPTION
## Summary

- add an async `PrologRLM` gptel tool for bounded large-context recursive analysis
- pass requests as JSON over stdin to a trusted SWI-Prolog bridge instead of constructing Prolog source or shell commands from model input
- call prolog-rlm's public `rlm_completion/4` API with host-controlled OpenRouter provider, capabilities, recursion depth, cost/token/time budgets, and no nested local tools
- let the outer model provide only the task plus either a local context path or inline context
- pass the OpenRouter credential only in the spawned SWI process environment
- normalize arbitrary structured Prolog outcomes into JSON-safe values and then through the shared gptel tool-result serialization adapter
- wire `PrologRLM` into agent presets and add usage guidance

## Research basis

The integration was designed against prolog-rlm main at `4cdc9854a510a2d07b559e9ae34491d43d81301a`. The runtime already exposes `rlm_completion/4`, real OpenRouter support, opaque context operations, bounded recursion, capabilities and structured outcomes. Its host-facing CLI/JSON surface is still tracked separately by prolog-rlm issue #19, so this PR keeps the adapter local to dotfiles rather than modifying prolog-rlm core.

## Security / execution boundary

- no model-generated `swipl -g` source
- no shell interpolation
- context path is resolved through the existing agent filesystem policy
- exactly one of `path` or `context` is accepted
- nested Prolog RLM tools are disabled in this first integration (`max_tool_calls = 0`)
- recursion is hard-capped at depth 1 by the bridge
- bridge clamps model-call, token, cost, output and wall-time budgets even if a caller sends larger values
- provider credentials are never placed in argv or bridge JSON

## Validation

- trusted SWI bridge loads prolog-rlm `0.1.0-dev` successfully from the pinned researched revision
- 8/8 focused ERT tests pass under Emacs 30.2
- gptel async registration, bounded/lossless file context, Unicode, one-shot configuration failure, budget clamps, and tool-result serialization are covered
- repository actionlint/ShellCheck and existing image-progress checks pass
- the dotfiles CI intentionally does not make a live OpenRouter request; prolog-rlm's provider integration remains covered in its own repository/live acceptance path