### PR TITLE
Isolate Steam from Nix shell paths

### DIFF
--- a/.local/bin/steam
+++ b/.local/bin/steam
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+unset LD_LIBRARY_PATH LD_PRELOAD NIX_LD NIX_LD_LIBRARY_PATH
+unset GTK_PATH GIO_EXTRA_MODULES GI_TYPELIB_PATH
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+
+exec /usr/bin/steam "$@"

--- a/.local/share/applications/steam.desktop
+++ b/.local/share/applications/steam.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Steam
+Comment=Application for managing and playing games on Steam
+Exec=/home/unseen/.local/bin/steam %U
+Icon=steam
+Terminal=false
+Type=Application
+Categories=Game;
+MimeType=x-scheme-handler/steam;
+StartupNotify=true
+StartupWMClass=Steam
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
## What changed

- add a tracked Steam launcher that clears conflicting loader variables and uses a system-only executable path
- add a user desktop entry so menu launches use the same isolated launcher

## Root cause

Launching native Arch Steam from a Nix development shell caused Steam to resolve `dirname` from `~/.nix-profile/bin` while its runtime loaded `/usr/lib/libc.so.6`. That mixed runtime failed with `__pointer_chk_guard, version GLIBC_PRIVATE` and prevented the UI from starting.

## Validation

- reproduced the symbol lookup failure with the live Steam runtime environment
- launched the wrapper from the same StarIntel Nix development shell
- confirmed the Steam UI and `steamwebhelper` started
- confirmed the new `console-linux.txt` segment contains no symbol lookup or `__pointer_chk_guard` errors
- `sh -n .local/bin/steam`
- ShellCheck 0.11.0
- `desktop-file-validate .local/share/applications/steam.desktop`
- `git diff --check`