### PR TITLE
Fix Home Manager font fallbacks and trim Nix CI

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -1,9 +1,6 @@
 name: Publish Logos ISO
 
 on:
-  push:
-    tags:
-      - "logos-*"
   workflow_dispatch:
     inputs:
       release_tag:
@@ -40,11 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            release_tag="$GITHUB_REF_NAME"
-          else
-            release_tag="$MANUAL_TAG"
-          fi
+          release_tag="$MANUAL_TAG"
 
           if [[ ! "$release_tag" =~ ^logos-[A-Za-z0-9._-]+$ ]]; then
             echo "Release tag must start with logos- and contain only letters, numbers, dots, underscores, or dashes." >&2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -48,5 +48,7 @@ jobs:
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
-      - run: nix flake check --show-trace
-      - run: nix build --no-link --print-build-logs
+      - name: Evaluate flake checks without building system closures
+        run: nix flake check --no-build --show-trace
+      - name: Evaluate desktop Home Manager configuration
+        run: nix eval --raw '.#homeConfigurations."unseen@desktop".activationPackage.drvPath'

--- a/nix/home-manager/mods/fonts.nix
+++ b/nix/home-manager/mods/fonts.nix
@@ -1,4 +1,5 @@
-{ lib, pkgs, config, ... }: {
+{ lib, pkgs, config, ... }:
+{
   options = with lib; {
     desktop = {
       fonts = {
@@ -8,14 +9,27 @@
         };
         fontsList = mkOption {
           type = types.listOf types.package;
-          default = with pkgs; [ nerd-fonts.hack nerd-fonts.symbols-only];
+          default = with pkgs; [
+            nerd-fonts.hack
+            nerd-fonts.symbols-only
+            noto-fonts
+            noto-fonts-color-emoji
+          ];
         };
       };
     };
   };
 
   config = lib.mkIf config.desktop.fonts.enable {
-    home.packages = (config.desktop.fonts.fontsList or [  ]);
-    fonts.fontconfig.enable = true;
+    home.packages = config.desktop.fonts.fontsList or [ ];
+    fonts.fontconfig = {
+      enable = true;
+      defaultFonts = {
+        monospace = [ "Hack Nerd Font" ];
+        sansSerif = [ "Noto Sans" ];
+        serif = [ "Noto Serif" ];
+        emoji = [ "Noto Color Emoji" ];
+      };
+    };
   };
 }


### PR DESCRIPTION
## Summary

- install Noto text and color emoji fonts through the Home Manager font module
- define explicit fontconfig defaults while keeping Hack Nerd Font as the monospace default
- make normal Nix CI evaluation-only instead of realizing the full NixOS system closure
- explicitly evaluate the desktop Home Manager activation package in CI
- make Logos ISO publishing manual-only so tags no longer trigger an ISO build

## Why

The desktop already installed Nerd Fonts through Home Manager, but it did not install/configure a user-level emoji fallback. That leaves Chromium and other user applications able to render a tofu/missing-glyph box for emoji even when Nerd Font symbols are present.

The ISO path is rarely used and the normal CI did more realization work than needed for routine dotfile changes. The lightweight checks still parse workflows, lint shell scripts, evaluate flake checks, and evaluate the desktop Home Manager configuration without building the full system closure. The ISO remains available through an explicit workflow dispatch.

## Validation

- Home Manager `release-26.05` exposes `fonts.fontconfig.defaultFonts.{monospace,sansSerif,serif,emoji}`
- Nixpkgs `nixos-26.05` provides `noto-fonts`, `noto-fonts-color-emoji`, `nerd-fonts.hack`, and `nerd-fonts.symbols-only`
- branch is based directly on current `master`
