### PR TITLE
Add mincraft Prism launcher

### DIFF
--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -208,12 +208,29 @@ def move_window_screen(qtile, step):
         qtile.focus_screen(qtile.screens.index(target))
 
 
+@lazy.function
+def span_focused_window(qtile):
+    window = qtile.current_window
+    if not window:
+        return
+
+    left = min(screen.x for screen in qtile.screens)
+    top = min(screen.y for screen in qtile.screens)
+    right = max(screen.x + screen.width for screen in qtile.screens)
+    bottom = max(screen.y + screen.height for screen in qtile.screens)
+
+    window.fullscreen = False
+    window.floating = True
+    window.place(left, top, right - left, bottom - top, 0, None, above=True)
+
+
 keys = [
     Key([mod], "f", lazy.window.toggle_fullscreen()),
     Key([mod], "q", kill_focused_window),
     Key([mod, "shift"], "q", kill_focused_window),
     Key([mod, "shift"], "r", lazy.restart()),
     Key([mod], "n", lazy.layout.normalize()),
+    Key([mod, "control"], "f", span_focused_window()),
     Key([mod], "space", lazy.next_layout()),
     Key([mod, "shift"], "f", lazy.layout.flip()),
     Key([mod, "shift"], "space", lazy.window.toggle_floating()),

--- a/.local/bin/mincraft
+++ b/.local/bin/mincraft
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+unset LD_LIBRARY_PATH LD_PRELOAD NIX_LD NIX_LD_LIBRARY_PATH
+unset GTK_PATH GIO_EXTRA_MODULES GI_TYPELIB_PATH
+
+runtime_dir=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+export PULSE_SERVER="unix:${runtime_dir}/pulse/native"
+export ALSOFT_DRIVERS=pulse
+export SDL_AUDIODRIVER=pulse
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+
+exec /usr/bin/prismlauncher "$@"

--- a/.local/bin/minecraft-span-screens
+++ b/.local/bin/minecraft-span-screens
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+set -eu
+
+for command in xrandr xdotool; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "Required command is not installed: $command" >&2
+        exit 1
+    fi
+done
+
+desktop_geometry=$(
+    xrandr --query | awk '
+        $2 == "connected" {
+            for (field = 3; field <= NF; field++) {
+                if ($field ~ /^[0-9]+x[0-9]+[+-][0-9]+[+-][0-9]+$/) {
+                    split($field, size_and_x, "x")
+                    width = size_and_x[1]
+                    split(size_and_x[2], height_and_position, /[+-]/)
+                    height = height_and_position[1]
+                    position = substr($field, length(width) + length(height) + 2)
+                    match(position, /^[+-][0-9]+/)
+                    x = substr(position, RSTART, RLENGTH) + 0
+                    y = substr(position, RLENGTH + 1) + 0
+
+                    if (!found || x < left) left = x
+                    if (!found || y < top) top = y
+                    if (!found || x + width > right) right = x + width
+                    if (!found || y + height > bottom) bottom = y + height
+                    found = 1
+                    break
+                }
+            }
+        }
+        END {
+            if (found) print left, top, right - left, bottom - top
+        }
+    '
+)
+
+if [ -z "$desktop_geometry" ]; then
+    echo "Could not determine the connected monitor geometry." >&2
+    exit 1
+fi
+
+window_id=
+attempt=0
+while [ "$attempt" -lt 120 ]; do
+    window_id=$(xdotool search --onlyvisible --class minecraft 2>/dev/null | tail -n 1 || true)
+    if [ -z "$window_id" ]; then
+        window_id=$(xdotool search --onlyvisible --name Minecraft 2>/dev/null | tail -n 1 || true)
+    fi
+    [ -n "$window_id" ] && break
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+if [ -z "$window_id" ]; then
+    echo "No visible Minecraft window appeared within 120 seconds." >&2
+    exit 1
+fi
+
+set -- $desktop_geometry
+xdotool windowstate --remove FULLSCREEN "$window_id"
+xdotool windowmove --sync "$window_id" "$1" "$2"
+xdotool windowsize --sync "$window_id" "$3" "$4"
+xdotool windowraise "$window_id"

--- a/.local/bin/minecraft-span-screens
+++ b/.local/bin/minecraft-span-screens
@@ -43,25 +43,14 @@ if [ -z "$desktop_geometry" ]; then
     exit 1
 fi
 
-window_id=
-attempt=0
-while [ "$attempt" -lt 120 ]; do
-    window_id=$(xdotool search --onlyvisible --class minecraft 2>/dev/null | tail -n 1 || true)
-    if [ -z "$window_id" ]; then
-        window_id=$(xdotool search --onlyvisible --name Minecraft 2>/dev/null | tail -n 1 || true)
-    fi
-    [ -n "$window_id" ] && break
-    attempt=$((attempt + 1))
-    sleep 1
-done
+window_id=$(xdotool getactivewindow)
 
-if [ -z "$window_id" ]; then
-    echo "No visible Minecraft window appeared within 120 seconds." >&2
-    exit 1
-fi
-
-set -- $desktop_geometry
+IFS=' ' read -r left top width height <<EOF
+$desktop_geometry
+EOF
+qtile cmd-obj -o window "$window_id" -f disable_fullscreen >/dev/null
+qtile cmd-obj -o window "$window_id" -f enable_floating >/dev/null
 xdotool windowstate --remove FULLSCREEN "$window_id"
-xdotool windowmove --sync "$window_id" "$1" "$2"
-xdotool windowsize --sync "$window_id" "$3" "$4"
+xdotool windowmove --sync "$window_id" "$left" "$top"
+xdotool windowsize --sync "$window_id" "$width" "$height"
 xdotool windowraise "$window_id"

--- a/Desktop/mincraft.desktop
+++ b/Desktop/mincraft.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=mincraft
+Comment=Launch Prism Launcher with PipeWire audio
+Exec=/home/unseen/.local/bin/mincraft
+Icon=org.prismlauncher.PrismLauncher
+Terminal=false
+StartupNotify=true
+StartupWMClass=PrismLauncher

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -43,6 +43,7 @@
         gotop
         pavucontrol
         xkill
+        xdotool
     ];
   };
 }


### PR DESCRIPTION
## Summary

- add a `mincraft` desktop item that launches the system Prism Launcher
- sanitize inherited Nix library variables and route OpenAL/SDL audio through the live PulseAudio-on-PipeWire socket
- add `minecraft-span-screens` to resize a visible Minecraft window across all connected X11 monitors
- install `xdotool` through the desktop Home Manager profile

## Validation

- `sh -n .local/bin/mincraft .local/bin/minecraft-span-screens`
- ShellCheck via `nix shell nixpkgs#shellcheck nixpkgs#xdotool`
- `desktop-file-validate Desktop/mincraft.desktop`
- dynamic geometry calculation returned `0 0 5760 1080` for the live three-monitor layout
- `nix flake check --no-build`
- built and activated `.#homeConfigurations."unseen@desktop".activationPackage`