### PR TITLE
fix(qtile): setsid to drop controlling terminal entirely

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -31,9 +31,16 @@ fi
 
 "$HOME/.config/qtile/scripts/setup-monitors.sh"
 
-# Qtile talks to Xorg over the X socket, not the controlling tty. Keep stdio
-# off /dev/tty1: startx retains the foreground process group, so any read of
-# tty1 by qtile or its children (SIGTTIN) would stop the whole WM.
+# Qtile talks to Xorg over the X socket, not the controlling tty. startx
+# keeps the foreground process group of tty1, so qtile and everything it
+# spawns (including Electron apps that re-open /dev/tty) would run as a
+# background pgrp and get stopped by SIGTTIN/SIGTSTP on any tty read,
+# freezing the whole WM.
+#
+# `setsid` puts qtile in a new session with no controlling terminal, so
+# /dev/tty is unopenable (ENXIO) by qtile or its children. Stdio is pointed
+# at /dev/null and a session log; VT switching still works because Xorg owns
+# the vt, not qtile.
 session_log="$HOME/.local/state/qtile/session.log"
 mkdir -p "$(dirname "$session_log")"
-exec qtile start </dev/null >>"$session_log" 2>&1
+exec setsid qtile start </dev/null >>"$session_log" 2>&1


### PR DESCRIPTION
## Problem

PR #69 redirected qtile's stdio off tty1 but did **not** remove the controlling terminal. Electron apps (Chromium) explicitly open `/dev/tty` for logging (e.g. ChatGPT had fds 37, 39 → /dev/tty1), which still resolves to tty1 and delivers SIGTTIN to qtile's background pgrp, freezing the WM.

Confirmed: even after PR #69, launching ChatGPT froze qtile (state `T`, wchan `do_signal_stop`).

## Fix

```sh
exec setsid qtile start </dev/null >>"$session_log" 2>&1
```

`setsid` makes qtile a session leader with **no controlling terminal**, so `/dev/tty` returns `ENXIO` for qtile and all descendants — SIGTTIN/SIGTSTP can never fire regardless of what spawned apps do.

VT switching is unaffected: Xorg owns the vt (started with `-keeptty vt1`), not qtile.

## Validation

```
bash -n .xinitrc          # OK
command -v setsid         # /usr/bin/setsid
```

## To verify after merge

1. `startx` from tty1.
2. `cat /proc/$(pgrep -n qtile)/stat | awk '{print $6,$7}'` — sid should differ from parent, tty (field 7) should be `0`.
3. Launch ChatGPT; qtile state stays `R`/`S`.
4. VT switches still work.