### PR TITLE
Revert qtile .xinitrc fixes (#69, #70)

### DIFF
--- a/.config/qtile/scripts/autostart.sh
+++ b/.config/qtile/scripts/autostart.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function run {
-    if ! pgrep -x "$(basename "$1" | head -c 15)" 1>/dev/null; then
-        "$@" </dev/null >/dev/null 2>&1 &
+    if ! pgrep -x $(basename $1 | head -c 15) 1>/dev/null; then
+        $@ &
     fi
 }
 
@@ -32,15 +32,15 @@ fi
 #wallpaper for other Arch based systems
 #feh --bg-fill /usr/share/archlinux-tweak-tool/data/wallpaper/wallpaper.png &
 #start the conky to learn the shortcuts
-(conky -c $HOME/.config/qtile/scripts/system-overview) </dev/null >/dev/null 2>&1 &
-(conky -c $HOME/Documents/Scripts/weather.conf) </dev/null >/dev/null 2>&1 &
+(conky -c $HOME/.config/qtile/scripts/system-overview) &
+(conky -c $HOME/Documents/Scripts/weather.conf) &
 
 #starting utility applications at boot time
 run variety &
 run nm-applet &
 #run pamac-tray &
 run xfce4-power-manager &
-numlockx on </dev/null >/dev/null 2>&1 &
+numlockx on &
 run blueman-applet &
 run picom &
 run /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &

--- a/.xinitrc
+++ b/.xinitrc
@@ -31,16 +31,4 @@ fi
 
 "$HOME/.config/qtile/scripts/setup-monitors.sh"
 
-# Qtile talks to Xorg over the X socket, not the controlling tty. startx
-# keeps the foreground process group of tty1, so qtile and everything it
-# spawns (including Electron apps that re-open /dev/tty) would run as a
-# background pgrp and get stopped by SIGTTIN/SIGTSTP on any tty read,
-# freezing the whole WM.
-#
-# `setsid` puts qtile in a new session with no controlling terminal, so
-# /dev/tty is unopenable (ENXIO) by qtile or its children. Stdio is pointed
-# at /dev/null and a session log; VT switching still works because Xorg owns
-# the vt, not qtile.
-session_log="$HOME/.local/state/qtile/session.log"
-mkdir -p "$(dirname "$session_log")"
-exec setsid qtile start </dev/null >>"$session_log" 2>&1
+exec qtile start


### PR DESCRIPTION
Revert PR #69 and #70 — the stdio redirect and setsid broke startx. Restores .xinitrc to its pre-fix state: `exec qtile start`.