### PR TITLE
Add ChatGPT desktop to Home Manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,26 @@
         "type": "github"
       }
     },
+    "chatgpt-desktop": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786997787,
+        "narHash": "sha256-YZkMbqe09x8Ua0pydX0IZXiDVLY1fmSyjfxWNE36PS0=",
+        "owner": "lost-rob0t",
+        "repo": "chatgpt-desktop",
+        "rev": "d3567103749b03a5c73e617d56e2c97391101b29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lost-rob0t",
+        "repo": "chatgpt-desktop",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -253,6 +273,7 @@
     "root": {
       "inputs": {
         "bixby-studio": "bixby-studio",
+        "chatgpt-desktop": "chatgpt-desktop",
         "disko": "disko",
         "home-manager": "home-manager",
         "mousetrap": "mousetrap",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
       url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    chatgpt-desktop = {
+      url = "github:lost-rob0t/chatgpt-desktop";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     zara.url = "github:lost-rob0t/zara";
     org-vector.url = "github:lost-rob0t/org-vector";
     bixby-studio.url = "github:lost-rob0t/org-vector";

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
       nixpkgs,
       disko,
       home-manager,
+      chatgpt-desktop,
       zara,
       org-vector,
       bixby-studio,

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -22,7 +22,8 @@ in
       inputs.zara.packages.${stdenv.hostPlatform.system}.zara-prolog
       inputs.org-vector.packages.${stdenv.hostPlatform.system}.org-vector
 
-      # LLM Editors
+      # LLM Editors and desktop clients
+      inputs.chatgpt-desktop.packages.${stdenv.hostPlatform.system}.default
       opencode
       claude-code
 


### PR DESCRIPTION
## Summary
- add `lost-rob0t/chatgpt-desktop` as a flake input
- make the package input follow the dotfiles `nixpkgs` pin
- install ChatGPT desktop through the existing `llm` Home Manager module

## Validation
The existing Nix CI evaluates the flake and `unseen@desktop` Home Manager configuration. The first CI pass will also resolve the new flake input so its lock data can be committed rather than leaving Home Manager to mutate `flake.lock` locally.