### PR TITLE
feat(qtile): show OpenRouter credits and token telemetry

### DIFF
--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -1,0 +1,52 @@
+"""OpenRouter status widget integration for the Qtile bar."""
+
+from libqtile import widget
+
+
+def _status_widget(home, colors):
+    return widget.GenPollCommand(
+        name="openrouter_status",
+        cmd=["python3", home + "/.config/qtile/scripts/openrouter_status.py"],
+        update_interval=15,
+        markup=True,
+        font="Hack Nerd Regular",
+        fontsize=12,
+        padding=4,
+        foreground=colors[5],
+        background=colors[1],
+    )
+
+
+def install_openrouter_widget(config_globals):
+    """Insert OpenRouter telemetry immediately after the existing Net widget."""
+    original_widgets = config_globals.get("widgets")
+    separator = config_globals.get("sep")
+    home = config_globals.get("home")
+    colors = config_globals.get("colors")
+
+    if not callable(original_widgets) or not home or not colors:
+        return
+    if getattr(original_widgets, "_openrouter_wrapped", False):
+        return
+
+    def widgets_with_openrouter():
+        items = original_widgets()
+        if any(getattr(item, "name", None) == "openrouter_status" for item in items):
+            return items
+
+        insert_at = next(
+            (
+                index + 1
+                for index, item in enumerate(items)
+                if item.__class__.__name__ == "Net"
+            ),
+            len(items),
+        )
+        additions = [_status_widget(home, colors)]
+        if callable(separator):
+            additions.insert(0, separator(5))
+        items[insert_at:insert_at] = additions
+        return items
+
+    widgets_with_openrouter._openrouter_wrapped = True
+    config_globals["widgets"] = widgets_with_openrouter

--- a/.config/qtile/qtile_telemetry.py
+++ b/.config/qtile/qtile_telemetry.py
@@ -159,6 +159,10 @@ def install_telemetry(config_globals):
     _config = config_globals
     _instrument_keys(config_globals.get("keys", ()))
 
+    from qtile_openrouter import install_openrouter_widget
+
+    install_openrouter_widget(config_globals)
+
 
 @hook.subscribe.startup_complete
 def _startup_complete():

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Render OpenRouter credits and token telemetry for the Qtile bar."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+API_BASE = "https://openrouter.ai/api/v1"
+AI_ICON = ""
+
+RED = "#dd546e"
+YELLOW = "#fba922"
+GREEN = "#62FF00"
+TEXT = "#f3f4f5"
+ACCENT = "#2de2e6"
+
+CACHE_TTL_SECONDS = 12
+ROLLING_TTL_SECONDS = 300
+LIVE_WINDOW_SECONDS = 60
+ROLLING_DAYS = 30
+REQUEST_TIMEOUT_SECONDS = 5
+
+
+@dataclass(frozen=True)
+class Status:
+    credits_remaining: float
+    live_input_tokens: int
+    live_output_tokens: int
+    rolling_input_tokens: int
+    rolling_output_tokens: int
+
+    @property
+    def rolling_tokens(self) -> int:
+        return self.rolling_input_tokens + self.rolling_output_tokens
+
+
+def compact_count(value: int | float) -> str:
+    value = float(value)
+    for suffix, divisor in (("B", 1_000_000_000), ("M", 1_000_000), ("k", 1_000)):
+        if abs(value) >= divisor:
+            rendered = f"{value / divisor:.1f}".rstrip("0").rstrip(".")
+            return f"{rendered}{suffix}"
+    return str(int(round(value)))
+
+
+def credit_color(credits_remaining: float) -> str:
+    if credits_remaining < 5:
+        return RED
+    if credits_remaining < 10:
+        return YELLOW
+    return GREEN
+
+
+def render(status: Status, *, stale: bool = False) -> str:
+    stale_marker = " ~" if stale else ""
+    return (
+        f'<span foreground="{credit_color(status.credits_remaining)}">'
+        f"{AI_ICON} ${status.credits_remaining:.2f}</span>"
+        f' <span foreground="{TEXT}">'
+        f"↓{compact_count(status.live_input_tokens)}/m "
+        f"↑{compact_count(status.live_output_tokens)}/m</span>"
+        f' <span foreground="{ACCENT}">'
+        f"30d {compact_count(status.rolling_tokens)}{stale_marker}</span>"
+    )
+
+
+def render_error(message: str) -> str:
+    return f'<span foreground="{RED}">{AI_ICON} {message}</span>'
+
+
+def _management_key_file() -> Path:
+    configured = os.environ.get("OPENROUTER_MANAGEMENT_KEY_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    return Path("~/.config/openrouter/management-key").expanduser()
+
+
+def load_management_key() -> str:
+    for env_name in ("OPENROUTER_MANAGEMENT_KEY", "OPENROUTER_API_KEY"):
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+
+    key_file = _management_key_file()
+    try:
+        return key_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise RuntimeError("management key missing") from exc
+
+
+def _request_json(
+    method: str,
+    path: str,
+    key: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = None
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {key}",
+        "User-Agent": "qtile-openrouter-status/1",
+    }
+    if payload is not None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(
+        f"{API_BASE}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(
+            request,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        ) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            raise RuntimeError("management key rejected") from exc
+        if exc.code == 429:
+            raise RuntimeError("OpenRouter rate limited") from exc
+        raise RuntimeError(f"OpenRouter HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise RuntimeError("OpenRouter unavailable") from exc
+
+
+def parse_credits(payload: dict[str, Any]) -> float:
+    data = payload["data"]
+    return max(0.0, float(data["total_credits"]) - float(data["total_usage"]))
+
+
+def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
+    rows = payload.get("data", {}).get("data", [])
+    prompt = sum(float(row.get("tokens_prompt") or 0) for row in rows)
+    completion = sum(float(row.get("tokens_completion") or 0) for row in rows)
+    return int(round(prompt)), int(round(completion))
+
+
+def fetch_credits(key: str) -> float:
+    return parse_credits(_request_json("GET", "/credits", key))
+
+
+def fetch_tokens(
+    key: str,
+    start: datetime,
+    end: datetime,
+) -> tuple[int, int]:
+    payload = {
+        "metrics": ["tokens_prompt", "tokens_completion"],
+        "time_range": {
+            "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "end": end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "limit": 10,
+    }
+    return parse_token_totals(
+        _request_json("POST", "/analytics/query", key, payload),
+    )
+
+
+def _cache_path() -> Path:
+    root = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+    return root / "qtile" / "openrouter-status.json"
+
+
+def _read_cache(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        return None
+
+
+def _status_from_cache(cache: dict[str, Any] | None) -> Status | None:
+    if not cache:
+        return None
+    try:
+        return Status(**cache["status"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _write_cache(
+    path: Path,
+    status: Status,
+    *,
+    fetched_at: float,
+    rolling_updated_at: float,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(
+            {
+                "fetched_at": fetched_at,
+                "rolling_updated_at": rolling_updated_at,
+                "status": asdict(status),
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def fetch_status(key: str, cache: dict[str, Any] | None = None) -> tuple[Status, float]:
+    now = datetime.now(timezone.utc)
+    cached_status = _status_from_cache(cache)
+    rolling_updated_at = float((cache or {}).get("rolling_updated_at", 0))
+    rolling_is_fresh = time.time() - rolling_updated_at < ROLLING_TTL_SECONDS
+
+    credits = fetch_credits(key)
+    live_input, live_output = fetch_tokens(
+        key,
+        now - timedelta(seconds=LIVE_WINDOW_SECONDS),
+        now,
+    )
+
+    if cached_status and rolling_is_fresh:
+        rolling_input = cached_status.rolling_input_tokens
+        rolling_output = cached_status.rolling_output_tokens
+    else:
+        rolling_input, rolling_output = fetch_tokens(
+            key,
+            now - timedelta(days=ROLLING_DAYS),
+            now,
+        )
+        rolling_updated_at = time.time()
+
+    return (
+        Status(
+            credits_remaining=credits,
+            live_input_tokens=live_input,
+            live_output_tokens=live_output,
+            rolling_input_tokens=rolling_input,
+            rolling_output_tokens=rolling_output,
+        ),
+        rolling_updated_at,
+    )
+
+
+def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
+    path = _cache_path()
+    lock_path = path.with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+
+        cache = _read_cache(path)
+        cached_status = _status_from_cache(cache)
+        fetched_at = float((cache or {}).get("fetched_at", 0))
+        if not force and cached_status and time.time() - fetched_at < CACHE_TTL_SECONDS:
+            return cached_status, False
+
+        try:
+            status, rolling_updated_at = fetch_status(key, cache)
+        except RuntimeError:
+            if cached_status:
+                return cached_status, True
+            raise
+
+        _write_cache(
+            path,
+            status,
+            fetched_at=time.time(),
+            rolling_updated_at=rolling_updated_at,
+        )
+        return status, False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print machine-readable status")
+    parser.add_argument("--force", action="store_true", help="ignore the short poll cache")
+    args = parser.parse_args(argv)
+
+    try:
+        key = load_management_key()
+        if not key:
+            raise RuntimeError("management key missing")
+        status, stale = status_with_cache(key, force=args.force)
+    except RuntimeError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}))
+        else:
+            short = "key?" if "key" in str(exc).lower() else "offline"
+            print(render_error(short))
+        return 1
+
+    if args.json:
+        payload = asdict(status)
+        payload["rolling_tokens"] = status.rolling_tokens
+        payload["stale"] = stale
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(render(status, stale=stale))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for the Qtile OpenRouter status helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "openrouter_status.py"
+SPEC = importlib.util.spec_from_file_location("openrouter_status", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenRouterStatusTests(unittest.TestCase):
+    def test_credit_color_thresholds(self):
+        self.assertEqual(MODULE.credit_color(4.99), MODULE.RED)
+        self.assertEqual(MODULE.credit_color(5.0), MODULE.YELLOW)
+        self.assertEqual(MODULE.credit_color(9.99), MODULE.YELLOW)
+        self.assertEqual(MODULE.credit_color(10.0), MODULE.GREEN)
+
+    def test_compact_count(self):
+        self.assertEqual(MODULE.compact_count(999), "999")
+        self.assertEqual(MODULE.compact_count(1_200), "1.2k")
+        self.assertEqual(MODULE.compact_count(12_000_000), "12M")
+        self.assertEqual(MODULE.compact_count(2_500_000_000), "2.5B")
+
+    def test_parse_credits_subtracts_usage(self):
+        payload = {"data": {"total_credits": 25.0, "total_usage": 17.25}}
+        self.assertEqual(MODULE.parse_credits(payload), 7.75)
+
+    def test_parse_credits_never_goes_negative(self):
+        payload = {"data": {"total_credits": 5.0, "total_usage": 8.0}}
+        self.assertEqual(MODULE.parse_credits(payload), 0.0)
+
+    def test_parse_token_totals_sums_rows(self):
+        payload = {
+            "data": {
+                "data": [
+                    {"tokens_prompt": 100, "tokens_completion": 10},
+                    {"tokens_prompt": 250, "tokens_completion": 25},
+                ]
+            }
+        }
+        self.assertEqual(MODULE.parse_token_totals(payload), (350, 35))
+
+    def test_render_contains_credit_live_io_and_rolling_total(self):
+        status = MODULE.Status(
+            credits_remaining=7.5,
+            live_input_tokens=12_300,
+            live_output_tokens=4_500,
+            rolling_input_tokens=40_000_000,
+            rolling_output_tokens=10_000_000,
+        )
+        rendered = MODULE.render(status)
+        self.assertIn(MODULE.AI_ICON, rendered)
+        self.assertIn(MODULE.YELLOW, rendered)
+        self.assertIn("$7.50", rendered)
+        self.assertIn("↓12.3k/m", rendered)
+        self.assertIn("↑4.5k/m", rendered)
+        self.assertIn("30d 50M", rendered)
+
+    def test_management_key_prefers_dedicated_environment_variable(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "OPENROUTER_MANAGEMENT_KEY": "management",
+                "OPENROUTER_API_KEY": "regular",
+            },
+            clear=True,
+        ):
+            self.assertEqual(MODULE.load_management_key(), "management")
+
+    def test_management_key_falls_back_to_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            key_file = Path(directory) / "management-key"
+            key_file.write_text("file-key\n", encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {"OPENROUTER_MANAGEMENT_KEY_FILE": str(key_file)},
+                clear=True,
+            ):
+                self.assertEqual(MODULE.load_management_key(), "file-key")
+
+    def test_fetch_status_reuses_fresh_rolling_total(self):
+        cached = MODULE.Status(
+            credits_remaining=12.0,
+            live_input_tokens=1,
+            live_output_tokens=2,
+            rolling_input_tokens=1_000,
+            rolling_output_tokens=500,
+        )
+        cache = {
+            "rolling_updated_at": MODULE.time.time(),
+            "status": MODULE.asdict(cached),
+        }
+        with (
+            mock.patch.object(MODULE, "fetch_credits", return_value=11.0),
+            mock.patch.object(MODULE, "fetch_tokens", return_value=(10, 20)) as fetch_tokens,
+        ):
+            status, _ = MODULE.fetch_status("key", cache)
+
+        self.assertEqual(fetch_tokens.call_count, 1)
+        self.assertEqual(status.live_input_tokens, 10)
+        self.assertEqual(status.live_output_tokens, 20)
+        self.assertEqual(status.rolling_tokens, 1_500)
+
+    def test_fetch_status_refreshes_stale_rolling_total(self):
+        cached = MODULE.Status(
+            credits_remaining=12.0,
+            live_input_tokens=1,
+            live_output_tokens=2,
+            rolling_input_tokens=1_000,
+            rolling_output_tokens=500,
+        )
+        cache = {
+            "rolling_updated_at": 0,
+            "status": MODULE.asdict(cached),
+        }
+        with (
+            mock.patch.object(MODULE, "fetch_credits", return_value=11.0),
+            mock.patch.object(
+                MODULE,
+                "fetch_tokens",
+                side_effect=[(10, 20), (2_000, 1_000)],
+            ) as fetch_tokens,
+        ):
+            status, rolling_updated_at = MODULE.fetch_status("key", cache)
+
+        self.assertEqual(fetch_tokens.call_count, 2)
+        self.assertGreater(rolling_updated_at, 0)
+        self.assertEqual(status.rolling_tokens, 3_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an OpenRouter Qtile status widget beside the existing network widget
- show account credits with thresholds: `<$5` red, `$5–<$10` yellow, `$10+` green
- show rolling 60-second prompt/completion token I/O as `↓in/m` and `↑out/m`
- show rolling 30-day total token usage
- use a Nerd Font AI/brain icon
- coalesce polling across the three monitor bars with a file lock/cache
- preserve stale values during transient OpenRouter failures instead of blanking the bar

## Authentication
The credits and analytics endpoints require an OpenRouter management key. The helper checks, in order:
1. `OPENROUTER_MANAGEMENT_KEY`
2. `OPENROUTER_API_KEY`
3. `~/.config/openrouter/management-key`

No secret is committed to the repo.

## Polling
- bar refresh: 15s
- shared short cache: 12s
- live token window: 60s
- rolling 30d total refresh: 5m

## Tests
- threshold boundaries
- compact token formatting
- credit calculation
- token aggregation
- rendered I/O/30d output
- key lookup precedence
- rolling-total cache behavior
