### PR TITLE
fix(qtile): repair OpenRouter status widget rendering

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -4,26 +4,9 @@ if [[ -f "$HOME/.bashrc" ]]; then
     source "$HOME/.bashrc"
 fi
 
-# Synchronize a git checkout with its configured upstream without creating
-# merge commits or rewriting local history. Defaults to the current directory.
-git-sync() {
-    local repo="${1:-$PWD}"
-    local upstream
-
-    if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        printf 'git-sync: not a git repository: %s\n' "$repo" >&2
-        return 2
-    fi
-
-    upstream="$(git -C "$repo" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)" || {
-        printf 'git-sync: no upstream configured for %s\n' "$repo" >&2
-        return 3
-    }
-
-    git -C "$repo" fetch --prune || return
-    git -C "$repo" merge --ff-only "$upstream"
-}
-export -f git-sync
+if [[ -f "$HOME/.config/bash/git-sync.sh" ]]; then
+    source "$HOME/.config/bash/git-sync.sh"
+fi
 
 # Start the X11 Qtile session after logging in on the first virtual terminal.
 if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then

--- a/.bash_profile
+++ b/.bash_profile
@@ -4,6 +4,27 @@ if [[ -f "$HOME/.bashrc" ]]; then
     source "$HOME/.bashrc"
 fi
 
+# Synchronize a git checkout with its configured upstream without creating
+# merge commits or rewriting local history. Defaults to the current directory.
+git-sync() {
+    local repo="${1:-$PWD}"
+    local upstream
+
+    if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        printf 'git-sync: not a git repository: %s\n' "$repo" >&2
+        return 2
+    fi
+
+    upstream="$(git -C "$repo" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)" || {
+        printf 'git-sync: no upstream configured for %s\n' "$repo" >&2
+        return 3
+    }
+
+    git -C "$repo" fetch --prune || return
+    git -C "$repo" merge --ff-only "$upstream"
+}
+export -f git-sync
+
 # Start the X11 Qtile session after logging in on the first virtual terminal.
 if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
     case "$(tty)" in

--- a/.config/bash/git-sync.sh
+++ b/.config/bash/git-sync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Synchronize a git checkout with its configured upstream without creating
+# merge commits or rewriting local history. Defaults to the current directory.
+git-sync() {
+    local repo="${1:-$PWD}"
+    local upstream
+
+    if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        printf 'git-sync: not a git repository: %s\n' "$repo" >&2
+        return 2
+    fi
+
+    upstream="$(git -C "$repo" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)" || {
+        printf 'git-sync: no upstream configured for %s\n' "$repo" >&2
+        return 3
+    }
+
+    git -C "$repo" fetch --prune || return
+    git -C "$repo" merge --ff-only "$upstream"
+}
+export -f git-sync

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -1,6 +1,13 @@
-"""OpenRouter status widget integration for the Qtile bar."""
+"""OpenRouter status widget integration and small Qtile runtime helpers."""
 
 from libqtile import widget
+from libqtile.config import Key
+from libqtile.lazy import lazy
+
+SYNC_AND_RELOAD_COMMAND = (
+    'git-sync "$HOME/.dotfiles" && '
+    "qtile cmd-obj -o root -f reload_config"
+)
 
 
 def _status_widget(home, colors):
@@ -17,8 +24,34 @@ def _status_widget(home, colors):
     )
 
 
+def _install_sync_and_reload_key(config_globals):
+    keys = config_globals.get("keys")
+    mod = config_globals.get("mod", "mod4")
+    if not isinstance(keys, list):
+        return
+
+    modifiers = {mod, "control", "shift"}
+    if any(
+        getattr(binding, "key", None) == "r"
+        and set(getattr(binding, "modifiers", ())) == modifiers
+        for binding in keys
+    ):
+        return
+
+    keys.append(
+        Key(
+            [mod, "control", "shift"],
+            "r",
+            lazy.spawn(["bash", "-lc", SYNC_AND_RELOAD_COMMAND]),
+            desc="Sync dotfiles and reload Qtile",
+        )
+    )
+
+
 def install_openrouter_widget(config_globals):
-    """Insert OpenRouter telemetry immediately after the existing Net widget."""
+    """Install OpenRouter telemetry and related Qtile runtime helpers."""
+    _install_sync_and_reload_key(config_globals)
+
     original_widgets = config_globals.get("widgets")
     separator = config_globals.get("sep")
     home = config_globals.get("home")

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -17,12 +17,14 @@ from pathlib import Path
 from typing import Any
 
 API_BASE = "https://openrouter.ai/api/v1"
-AI_ICON = ""
+# Nerd Fonts v3+ Material Design "brain" (nf-md-brain).
+# The old U+F5DC Material Design range was removed in Nerd Fonts v3.
+AI_ICON = "\U000F09D1"
 
 RED = "#dd546e"
 YELLOW = "#fba922"
 GREEN = "#62FF00"
-TEXT = "#f3f4f5"
+IO = "#f6019d"
 ACCENT = "#2de2e6"
 
 CACHE_TTL_SECONDS = 12
@@ -67,11 +69,11 @@ def render(status: Status, *, stale: bool = False) -> str:
     return (
         f'<span foreground="{credit_color(status.credits_remaining)}">'
         f"{AI_ICON} ${status.credits_remaining:.2f}</span>"
-        f' <span foreground="{TEXT}">'
-        f"↓{compact_count(status.live_input_tokens)}/m "
-        f"↑{compact_count(status.live_output_tokens)}/m</span>"
+        f' <span foreground="{IO}">'
+        f"tok:{compact_count(status.live_input_tokens)}↓ "
+        f"{compact_count(status.live_output_tokens)}↑</span>"
         f' <span foreground="{ACCENT}">'
-        f"30d {compact_count(status.rolling_tokens)}{stale_marker}</span>"
+        f"30d:{compact_count(status.rolling_tokens)}{stale_marker}</span>"
     )
 
 

--- a/.config/qtile/tests/test_git_sync.py
+++ b/.config/qtile/tests/test_git_sync.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for the Bash git-sync helper used by the Qtile reload chord."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "bash" / "git-sync.sh"
+
+
+def run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+class GitSyncTests(unittest.TestCase):
+    def test_fast_forwards_to_configured_upstream(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote = root / "remote.git"
+            first = root / "first"
+            second = root / "second"
+
+            self.assertEqual(run("git", "init", "--bare", str(remote)).returncode, 0)
+            self.assertEqual(run("git", "clone", str(remote), str(first)).returncode, 0)
+            for repo in (first,):
+                self.assertEqual(run("git", "config", "user.name", "test", cwd=repo).returncode, 0)
+                self.assertEqual(run("git", "config", "user.email", "test@example.com", cwd=repo).returncode, 0)
+
+            (first / "value").write_text("one\n", encoding="utf-8")
+            self.assertEqual(run("git", "add", "value", cwd=first).returncode, 0)
+            self.assertEqual(run("git", "commit", "-m", "one", cwd=first).returncode, 0)
+            self.assertEqual(run("git", "push", "-u", "origin", "HEAD", cwd=first).returncode, 0)
+
+            self.assertEqual(run("git", "clone", str(remote), str(second)).returncode, 0)
+            self.assertEqual(run("git", "config", "user.name", "test", cwd=second).returncode, 0)
+            self.assertEqual(run("git", "config", "user.email", "test@example.com", cwd=second).returncode, 0)
+            with (second / "value").open("a", encoding="utf-8") as stream:
+                stream.write("two\n")
+            self.assertEqual(run("git", "add", "value", cwd=second).returncode, 0)
+            self.assertEqual(run("git", "commit", "-m", "two", cwd=second).returncode, 0)
+            self.assertEqual(run("git", "push", cwd=second).returncode, 0)
+
+            command = f'source "{SCRIPT}"; git-sync "{first}"'
+            synced = run("bash", "--noprofile", "--norc", "-c", command)
+            self.assertEqual(synced.returncode, 0, synced.stderr)
+            self.assertEqual((first / "value").read_text(encoding="utf-8"), "one\ntwo\n")
+
+    def test_rejects_non_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            command = f'source "{SCRIPT}"; git-sync "{directory}"'
+            result = run("bash", "--noprofile", "--norc", "-c", command)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not a git repository", result.stderr)
+
+    def test_rejects_repository_without_upstream(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            self.assertEqual(run("git", "init", str(repo)).returncode, 0)
+            command = f'source "{SCRIPT}"; git-sync "{repo}"'
+            result = run("bash", "--noprofile", "--norc", "-c", command)
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("no upstream configured", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -32,6 +32,10 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(MODULE.compact_count(12_000_000), "12M")
         self.assertEqual(MODULE.compact_count(2_500_000_000), "2.5B")
 
+    def test_uses_current_nerd_font_brain_codepoint(self):
+        self.assertEqual(ord(MODULE.AI_ICON), 0xF09D1)
+        self.assertFalse(0xF500 <= ord(MODULE.AI_ICON) <= 0xFD46)
+
     def test_parse_credits_subtracts_usage(self):
         payload = {"data": {"total_credits": 25.0, "total_usage": 17.25}}
         self.assertEqual(MODULE.parse_credits(payload), 7.75)
@@ -51,7 +55,7 @@ class OpenRouterStatusTests(unittest.TestCase):
         }
         self.assertEqual(MODULE.parse_token_totals(payload), (350, 35))
 
-    def test_render_contains_credit_live_io_and_rolling_total(self):
+    def test_render_matches_net_direction_style(self):
         status = MODULE.Status(
             credits_remaining=7.5,
             live_input_tokens=12_300,
@@ -62,10 +66,11 @@ class OpenRouterStatusTests(unittest.TestCase):
         rendered = MODULE.render(status)
         self.assertIn(MODULE.AI_ICON, rendered)
         self.assertIn(MODULE.YELLOW, rendered)
+        self.assertIn(MODULE.IO, rendered)
         self.assertIn("$7.50", rendered)
-        self.assertIn("↓12.3k/m", rendered)
-        self.assertIn("↑4.5k/m", rendered)
-        self.assertIn("30d 50M", rendered)
+        self.assertIn("tok:12.3k↓ 4.5k↑", rendered)
+        self.assertIn("30d:50M", rendered)
+        self.assertNotIn("/m", rendered)
 
     def test_management_key_prefers_dedicated_environment_variable(self):
         with mock.patch.dict(

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,15 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n scripts/*.sh
-          shellcheck --severity=warning scripts/*.sh
+          bash -n scripts/*.sh .bash_profile .config/bash/git-sync.sh
+          shellcheck --severity=warning scripts/*.sh .bash_profile .config/bash/git-sync.sh
+      - name: Check Qtile Python helpers
+        run: >-
+          python3 -m py_compile
+          .config/qtile/qtile_openrouter.py
+          .config/qtile/scripts/openrouter_status.py
+      - name: Run Qtile helper tests
+        run: python3 -m unittest discover -s .config/qtile/tests -p 'test_*.py'
 
   image-progress-tests:
     needs: workflows


### PR DESCRIPTION
## Fix
- replace the removed legacy Nerd Fonts Material Design codepoint with current `nf-md-brain` (`U+F09D1`)
- render token I/O in the same visual direction style as Qtile's Net widget: count first, arrow suffix
- use the existing magenta network-style accent for live token I/O
- keep rolling 30-day total in cyan and credit threshold colors unchanged

## Git sync + reload
- add exported Bash function `git-sync [repo]`
- `git-sync` fetches/prunes and performs a fast-forward-only merge from the configured upstream
- add `Super+Ctrl+Shift+R` to run `git-sync "$HOME/.dotfiles"`
- Qtile reload runs only after the git sync exits successfully
- external reload uses Qtile's root `reload_config` command

## Regression coverage
- assert the AI glyph is the current Nerd Fonts brain codepoint
- explicitly reject the removed legacy `F500-FD46` range
- assert the rendered token format is `tok:12.3k↓ 4.5k↑` and no longer uses `/m`

## Verification
- OpenRouter helper unit suite passes
- Python syntax compile passes
- GitHub Nix workflow must pass before merge