### PR TITLE
fix(dotfiles): restore literate sources for git sync

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -16,6 +16,10 @@ if [ ! -d ~/.bashrc.d ]; then
 	done
 fi
 
+if [[ -f "$HOME/.config/bash/git-sync.sh" ]]; then
+    source "$HOME/.config/bash/git-sync.sh"
+fi
+
 export TERM="xterm-256color"                      # getting proper colors
 
 shopt -s histappend

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -1,0 +1,449 @@
+#+title: Qtile OpenRouter Telemetry
+#+property: header-args:python :tangle ./qtile_openrouter.py :mkdirp yes :results none
+
+* Runtime helper
+
+This file is the source of truth for the OpenRouter status widgets and the
+=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding.  Tangle this file whenever
+that runtime helper changes.
+
+#+begin_src python
+"""OpenRouter telemetry widgets and small Qtile runtime helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+
+from libqtile.config import Key
+from libqtile.lazy import lazy
+from libqtile.widget import base
+
+POLL_SECONDS = 1
+GRAPH_SAMPLES = 60
+GRAPH_WIDTH = 76
+CREDIT_FONTSIZE = 14
+IO_FONTSIZE = 12
+ROLLING_FONTSIZE = 13
+
+_poll_lock = threading.Lock()
+_last_poll_at = 0.0
+_last_payload = None
+_sync_lock = threading.Lock()
+_sync_in_progress = False
+
+
+def _color(colors, index):
+    value = colors[index]
+    if isinstance(value, (list, tuple)):
+        return value[0]
+    return value
+
+
+def _cache_path():
+    root = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+    return root / "qtile" / "openrouter-status.json"
+
+
+def _read_cached_status():
+    try:
+        cache = json.loads(_cache_path().read_text(encoding="utf-8"))
+        return cache.get("status")
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        return None
+
+
+def _compact_count(value):
+    value = float(value or 0)
+    for suffix, divisor in (("B", 1_000_000_000), ("M", 1_000_000), ("k", 1_000)):
+        if abs(value) >= divisor:
+            rendered = f"{value / divisor:.1f}".rstrip("0").rstrip(".")
+            return f"{rendered}{suffix}"
+    return str(int(round(value)))
+
+
+def _credit_color(value, colors):
+    if value < 5:
+        return _color(colors, 8)
+    if value < 10:
+        return _color(colors, 3)
+    return _color(colors, 7)
+
+
+def _fetch_payload(script):
+    global _last_payload, _last_poll_at
+
+    with _poll_lock:
+        now = time.monotonic()
+        if _last_payload is not None and now - _last_poll_at < 0.9:
+            return _last_payload
+
+        completed = subprocess.run(
+            ["python3", script, "--json", "--force"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=8,
+        )
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError:
+            payload = None
+
+        _last_poll_at = time.monotonic()
+        if isinstance(payload, dict) and "credits_remaining" in payload:
+            _last_payload = payload
+            return payload
+
+        cached = _read_cached_status()
+        if cached:
+            payload = dict(cached)
+            payload["stale"] = True
+            _last_payload = payload
+            return payload
+
+        return None
+
+
+def _notify(summary, body="", urgency="normal"):
+    notifier = shutil.which("dunstify") or shutil.which("notify-send")
+    if not notifier:
+        return
+
+    command = [notifier, "-a", "Qtile", "-u", urgency, summary]
+    if body:
+        command.append(body)
+    try:
+        subprocess.Popen(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        pass
+
+
+def _git_sync_command():
+    helper = Path.home() / ".config" / "bash" / "git-sync.sh"
+    repo = Path.home() / ".dotfiles"
+    return (
+        f'source "{helper}" && '
+        f'git-sync "{repo}"'
+    )
+
+
+def _run_dotfiles_sync():
+    return subprocess.run(
+        ["bash", "-lc", _git_sync_command()],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _sync_and_reload(qtile):
+    """Sync dotfiles off the event loop, then reload Qtile in-process."""
+    global _sync_in_progress
+
+    with _sync_lock:
+        if _sync_in_progress:
+            _notify("Dotfiles sync", "Already syncing.", "low")
+            return
+        _sync_in_progress = True
+
+    _notify("Dotfiles sync", "Fetching updates…")
+
+    def worker():
+        global _sync_in_progress
+        try:
+            completed = _run_dotfiles_sync()
+        except (OSError, subprocess.SubprocessError) as error:
+            _notify("Dotfiles sync failed", str(error), "critical")
+            with _sync_lock:
+                _sync_in_progress = False
+            return
+
+        with _sync_lock:
+            _sync_in_progress = False
+
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "git-sync failed").strip()
+            _notify("Dotfiles sync failed", detail[-800:], "critical")
+            return
+
+        detail = (completed.stdout or "Dotfiles are up to date.").strip()
+        _notify("Dotfiles synced", detail[-400:] + "\nReloading Qtile…")
+        qtile.call_soon_threadsafe(qtile.reload_config)
+
+    threading.Thread(
+        target=worker,
+        name="qtile-dotfiles-sync",
+        daemon=True,
+    ).start()
+
+
+class OpenRouterCredit(base.BackgroundPoll):
+    """Poll OpenRouter once per second across all monitor instances."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, script, colors, **config):
+        self.script = script
+        self.colors = colors
+        super().__init__(text="AI …", **config)
+
+    def poll(self):
+        payload = _fetch_payload(self.script)
+        if not payload:
+            return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
+
+        credits = float(payload["credits_remaining"])
+        stale = " ~" if payload.get("stale") else ""
+        color = _credit_color(credits, self.colors)
+        return (
+            f'<span foreground="{color}">'
+            f"\U000F09D1 ${credits:.2f}{stale}</span>"
+        )
+
+
+class OpenRouterCacheText(base.InLoopPollText):
+    """Read the shared OpenRouter cache without spawning more API requests."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, mode, colors, **config):
+        self.mode = mode
+        self.colors = colors
+        super().__init__(default_text="", **config)
+
+    def poll(self):
+        status = _read_cached_status()
+        if not status:
+            return ""
+
+        if self.mode == "io":
+            incoming = _compact_count(status.get("live_input_tokens", 0))
+            outgoing = _compact_count(status.get("live_output_tokens", 0))
+            return (
+                f'<span foreground="{_color(self.colors, 6)}">{incoming}↓</span>\n'
+                f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑</span>'
+            )
+
+        rolling = (
+            int(status.get("rolling_input_tokens", 0))
+            + int(status.get("rolling_output_tokens", 0))
+        )
+        return (
+            f'<span foreground="{_color(self.colors, 4)}">'
+            f"30d:{_compact_count(rolling)}</span>"
+        )
+
+
+class OpenRouterIOGraph(base._Widget):
+    """Mirrored one-minute token I/O sparkline fed from the shared cache."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    defaults = [
+        ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
+        ("samples", GRAPH_SAMPLES, "Number of one-second samples."),
+        ("input_color", "#f6019d", "Prompt-token graph color."),
+        ("output_color", "#2de2e6", "Completion-token graph color."),
+        ("midline_color", "#92406e", "Graph center-line color."),
+        ("line_width", 1.4, "Graph line width."),
+        ("margin_x", 2, "Horizontal graph margin."),
+        ("margin_y", 2, "Vertical graph margin."),
+    ]
+
+    def __init__(self, width=GRAPH_WIDTH, **config):
+        super().__init__(width, **config)
+        self.add_defaults(self.defaults)
+        self.input_values = deque([0.0] * self.samples, maxlen=self.samples)
+        self.output_values = deque([0.0] * self.samples, maxlen=self.samples)
+
+    def timer_setup(self):
+        self._update()
+        self.timeout_add(self.frequency, self.timer_setup)
+
+    def _update(self):
+        status = _read_cached_status() or {}
+        self.input_values.append(float(status.get("live_input_tokens", 0)))
+        self.output_values.append(float(status.get("live_output_tokens", 0)))
+        self.draw()
+
+    def _draw_series(self, values, color, center_y, half_height, direction):
+        if len(values) < 2:
+            return
+
+        # Each stream gets its own scale. Prompt traffic can be orders of
+        # magnitude larger than completion traffic and must not flatten it.
+        maximum = max(max(values, default=0), 1)
+        usable_width = max(self.width - 2 * self.margin_x, 1)
+        step = usable_width / max(len(values) - 1, 1)
+
+        self.drawer.set_source_rgb(color)
+        self.drawer.ctx.set_line_width(self.line_width)
+
+        for index, value in enumerate(values):
+            x = self.margin_x + index * step
+            distance = (float(value) / maximum) * half_height
+            y = center_y + direction * distance
+            if index == 0:
+                self.drawer.ctx.move_to(x, y)
+            else:
+                self.drawer.ctx.line_to(x, y)
+        self.drawer.ctx.stroke()
+
+    def draw(self):
+        self.drawer.clear(self.background or self.bar.background)
+
+        center_y = self.height / 2.0
+        half_height = max(center_y - self.margin_y - 1, 1)
+
+        self.drawer.set_source_rgb(self.midline_color)
+        self.drawer.ctx.set_line_width(0.6)
+        self.drawer.ctx.move_to(self.margin_x, center_y)
+        self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
+        self.drawer.ctx.stroke()
+
+        self._draw_series(
+            self.input_values,
+            self.input_color,
+            center_y,
+            half_height,
+            -1,
+        )
+        self._draw_series(
+            self.output_values,
+            self.output_color,
+            center_y,
+            half_height,
+            1,
+        )
+        self.draw_at_default_position()
+
+
+def _install_sync_and_reload_key(config_globals):
+    keys = config_globals.get("keys")
+    mod = config_globals.get("mod", "mod4")
+    if not isinstance(keys, list):
+        return
+
+    modifiers = {mod, "control", "shift"}
+    if any(
+        getattr(binding, "key", None) == "r"
+        and set(getattr(binding, "modifiers", ())) == modifiers
+        for binding in keys
+    ):
+        return
+
+    keys.append(
+        Key(
+            [mod, "control", "shift"],
+            "r",
+            lazy.function(_sync_and_reload),
+            desc="Sync dotfiles and reload Qtile",
+        )
+    )
+
+
+def _telemetry_widgets(home, colors):
+    script = home + "/.config/qtile/scripts/openrouter_status.py"
+    background = _color(colors, 1)
+
+    return [
+        OpenRouterCredit(
+            script,
+            colors,
+            name="openrouter_credit",
+            update_interval=POLL_SECONDS,
+            markup=True,
+            font="Hack Nerd Regular",
+            fontsize=CREDIT_FONTSIZE,
+            padding=4,
+            foreground=_color(colors, 5),
+            background=background,
+        ),
+        OpenRouterCacheText(
+            "io",
+            colors,
+            name="openrouter_io",
+            update_interval=POLL_SECONDS,
+            markup=True,
+            font="Hack Nerd Regular",
+            fontsize=IO_FONTSIZE,
+            padding=3,
+            foreground=_color(colors, 5),
+            background=background,
+        ),
+        OpenRouterIOGraph(
+            name="openrouter_io_graph",
+            frequency=POLL_SECONDS,
+            samples=GRAPH_SAMPLES,
+            input_color=_color(colors, 6),
+            output_color=_color(colors, 4),
+            midline_color=_color(colors, 2),
+            background=background,
+        ),
+        OpenRouterCacheText(
+            "rolling",
+            colors,
+            name="openrouter_rolling",
+            update_interval=POLL_SECONDS,
+            markup=True,
+            font="Hack Nerd Regular",
+            fontsize=ROLLING_FONTSIZE,
+            padding=4,
+            foreground=_color(colors, 4),
+            background=background,
+        ),
+    ]
+
+
+def install_openrouter_widget(config_globals):
+    """Install the OpenRouter telemetry cluster and Qtile runtime helpers."""
+
+    _install_sync_and_reload_key(config_globals)
+
+    original_widgets = config_globals.get("widgets")
+    separator = config_globals.get("sep")
+    home = config_globals.get("home")
+    colors = config_globals.get("colors")
+
+    if not callable(original_widgets) or not home or not colors:
+        return
+    if getattr(original_widgets, "_openrouter_wrapped", False):
+        return
+
+    def widgets_with_openrouter():
+        items = original_widgets()
+        if any(
+            str(getattr(item, "name", "")).startswith("openrouter_")
+            for item in items
+        ):
+            return items
+
+        insert_at = next(
+            (
+                index + 1
+                for index, item in enumerate(items)
+                if item.__class__.__name__ == "Net"
+            ),
+            len(items),
+        )
+        additions = _telemetry_widgets(home, colors)
+        if callable(separator):
+            additions.insert(0, separator(5))
+        items[insert_at:insert_at] = additions
+        return items
+
+    widgets_with_openrouter._openrouter_wrapped = True
+    config_globals["widgets"] = widgets_with_openrouter
+#+end_src

--- a/.config/qtile/tests/test_literate_config_parity.py
+++ b/.config/qtile/tests/test_literate_config_parity.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Regression tests for literate configuration source/generated parity."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+QTILE_ORG = ROOT / ".config" / "qtile" / "qtile-openrouter.org"
+QTILE_PY = ROOT / ".config" / "qtile" / "qtile_openrouter.py"
+BASH_ORG = ROOT / "bash.org"
+BASHRC = ROOT / ".bashrc"
+GIT_SYNC_SOURCE = 'source "$HOME/.config/bash/git-sync.sh"'
+
+
+def _single_python_block(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = lines.index("#+begin_src python") + 1
+    end = lines.index("#+end_src", start)
+    return "\n".join(lines[start:end]) + "\n"
+
+
+class LiterateConfigParityTests(unittest.TestCase):
+    def test_qtile_openrouter_org_matches_runtime_exactly(self):
+        self.assertEqual(
+            _single_python_block(QTILE_ORG),
+            QTILE_PY.read_text(encoding="utf-8"),
+        )
+
+    def test_bash_org_and_bashrc_both_load_git_sync(self):
+        self.assertIn(GIT_SYNC_SOURCE, BASH_ORG.read_text(encoding="utf-8"))
+        self.assertIn(GIT_SYNC_SOURCE, BASHRC.read_text(encoding="utf-8"))
+
+    def test_tangled_bashrc_is_valid_bash(self):
+        completed = subprocess.run(
+            ["bash", "-n", str(BASHRC)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Source of truth
+
+This repository uses literate Org configuration. Treat the Org files as source code and tangled files as generated artifacts.
+
+- `bash.org` is the source of truth for `.bashrc`.
+- `.config/qtile/qtile-ai.org` is the main source of truth for `.config/qtile/config.py`.
+- `.config/qtile/qtile-openrouter.org` is the source of truth for `.config/qtile/qtile_openrouter.py`.
+- Do not make a lasting change only in a generated/tangled file.
+
+When a change touches a literate configuration:
+
+1. Edit the relevant Org source first.
+2. Tangle it and commit the generated output in the same change.
+3. Verify the generated output is in sync with its Org source.
+4. Run syntax checks and the relevant tests before merging.
+
+If an existing generated file has no literate source but belongs to a literate subsystem, add or identify the source before extending it. Do not create parallel sources of truth.
+
+## Qtile
+
+Keep keybindings documented in their literate source. The OpenRouter telemetry helper owns the dynamic `Super+Ctrl+Shift+R` sync-and-reload binding and must stay synchronized with `qtile-openrouter.org`.
+
+Qtile sync/reload behavior must:
+
+- use the shared `git-sync` implementation;
+- never block Qtile's event loop while running Git;
+- reload only after a successful sync;
+- surface start, success, and failure through desktop notifications;
+- retain the existing 1 Hz OpenRouter telemetry behavior unless intentionally changed.
+
+## Bash
+
+Interactive Bash must expose `git-sync` through the `.bashrc` generated from `bash.org`. The implementation lives in `.config/bash/git-sync.sh`; source that helper rather than duplicating its function body.
+
+## Testing
+
+Follow TDD for behavior changes. Add or update regression tests before implementation when practical, then run the real suite. Tests must validate literate/generated parity for files touched by a change rather than merely checking that both files exist.

--- a/bash.org
+++ b/bash.org
@@ -34,6 +34,14 @@ fi
 
 #+end_src
 
+Load shared git helpers in interactive Bash.  Qtile sources the same helper directly,
+so both entry points use one implementation.
+#+begin_src sh :tangle .bashrc
+if [[ -f "$HOME/.config/bash/git-sync.sh" ]]; then
+    source "$HOME/.config/bash/git-sync.sh"
+fi
+#+end_src
+
 Setting up colors
 #+begin_src sh :tangle .bashrc
 export TERM="xterm-256color"                      # getting proper colors
@@ -604,5 +612,4 @@ esac
 
 [fn:2] https://taingram.org/blog/emacs-client.html
 [fn:1] https://github.com/labbots/bash-oneliners#terminal
-
 


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` declaring Org files as source of truth and requiring source/generated parity
- update `bash.org` and tangled `.bashrc` together so interactive Bash sources `.config/bash/git-sync.sh`
- add `.config/qtile/qtile-openrouter.org` as the literate source of `qtile_openrouter.py`, including the `Super+Ctrl+Shift+R` sync/reload binding
- add regression tests that require exact Qtile Org/Python parity, require the git-sync source hook in both Bash source/output, and run `bash -n` on `.bashrc`

## Result
After pulling and sourcing `.bashrc`, `git-sync ~/.dotfiles` is available in ordinary interactive Bash. The Qtile helper and binding now have a literate source and CI-enforced parity.

## Process note
An earlier scratch branch was abandoned before PR creation after a transcription error was caught; this PR is rebuilt cleanly from current `master`.