### PR TITLE
fix(git-sync): install a real Home Manager command

### DIFF
--- a/.config/bash/git-sync.sh
+++ b/.config/bash/git-sync.sh
@@ -24,9 +24,8 @@ git-sync() {
     git -C "$repo" merge --ff-only "$upstream"
 }
 
+export -f git-sync
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     git-sync "$@"
-    exit $?
 fi
-
-export -f git-sync

--- a/.config/bash/git-sync.sh
+++ b/.config/bash/git-sync.sh
@@ -2,6 +2,10 @@
 
 # Synchronize a git checkout with its configured upstream without creating
 # merge commits or rewriting local history. Defaults to the current directory.
+#
+# This file intentionally supports both entry points:
+# - source it from Bash to define the git-sync function;
+# - execute it (or package it) to use git-sync as a normal command.
 git-sync() {
     local repo="${1:-$PWD}"
     local upstream
@@ -19,4 +23,10 @@ git-sync() {
     git -C "$repo" fetch --prune || return
     git -C "$repo" merge --ff-only "$upstream"
 }
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    git-sync "$@"
+    exit $?
+fi
+
 export -f git-sync

--- a/.config/qtile/tests/test_git_sync.py
+++ b/.config/qtile/tests/test_git_sync.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Bash git-sync helper used by the Qtile reload chord."""
+"""Tests for the Bash git-sync helper used by Bash, Home Manager, and Qtile."""
 
 from __future__ import annotations
 
@@ -31,9 +31,8 @@ class GitSyncTests(unittest.TestCase):
 
             self.assertEqual(run("git", "init", "--bare", str(remote)).returncode, 0)
             self.assertEqual(run("git", "clone", str(remote), str(first)).returncode, 0)
-            for repo in (first,):
-                self.assertEqual(run("git", "config", "user.name", "test", cwd=repo).returncode, 0)
-                self.assertEqual(run("git", "config", "user.email", "test@example.com", cwd=repo).returncode, 0)
+            self.assertEqual(run("git", "config", "user.name", "test", cwd=first).returncode, 0)
+            self.assertEqual(run("git", "config", "user.email", "test@example.com", cwd=first).returncode, 0)
 
             (first / "value").write_text("one\n", encoding="utf-8")
             self.assertEqual(run("git", "add", "value", cwd=first).returncode, 0)
@@ -53,6 +52,18 @@ class GitSyncTests(unittest.TestCase):
             synced = run("bash", "--noprofile", "--norc", "-c", command)
             self.assertEqual(synced.returncode, 0, synced.stderr)
             self.assertEqual((first / "value").read_text(encoding="utf-8"), "one\ntwo\n")
+
+    def test_helper_can_run_as_a_command_without_being_sourced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = run("bash", str(SCRIPT), directory)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not a git repository", result.stderr)
+
+    def test_sourcing_helper_defines_bash_function_without_running_it(self):
+        command = f'source "{SCRIPT}"; type -t git-sync'
+        result = run("bash", "--noprofile", "--norc", "-c", command)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "function")
 
     def test_rejects_non_repository(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/.config/qtile/tests/test_literate_config_parity.py
+++ b/.config/qtile/tests/test_literate_config_parity.py
@@ -12,6 +12,7 @@ QTILE_ORG = ROOT / ".config" / "qtile" / "qtile-openrouter.org"
 QTILE_PY = ROOT / ".config" / "qtile" / "qtile_openrouter.py"
 BASH_ORG = ROOT / "bash.org"
 BASHRC = ROOT / ".bashrc"
+BASE_NIX = ROOT / "nix" / "home-manager" / "mods" / "base.nix"
 GIT_SYNC_SOURCE = 'source "$HOME/.config/bash/git-sync.sh"'
 
 
@@ -32,6 +33,16 @@ class LiterateConfigParityTests(unittest.TestCase):
     def test_bash_org_and_bashrc_both_load_git_sync(self):
         self.assertIn(GIT_SYNC_SOURCE, BASH_ORG.read_text(encoding="utf-8"))
         self.assertIn(GIT_SYNC_SOURCE, BASHRC.read_text(encoding="utf-8"))
+
+    def test_home_manager_installs_command_and_shared_helper(self):
+        source = BASE_NIX.read_text(encoding="utf-8")
+        helper_path = "../../../.config/bash/git-sync.sh"
+        self.assertIn('name = "git-sync";', source)
+        self.assertIn(f"builtins.readFile {helper_path}", source)
+        self.assertIn(
+            f'xdg.configFile."bash/git-sync.sh".source = {helper_path};',
+            source,
+        )
 
     def test_tangled_bashrc_is_valid_bash(self):
         completed = subprocess.run(

--- a/.config/qtile/tests/test_literate_config_parity.py
+++ b/.config/qtile/tests/test_literate_config_parity.py
@@ -34,15 +34,12 @@ class LiterateConfigParityTests(unittest.TestCase):
         self.assertIn(GIT_SYNC_SOURCE, BASH_ORG.read_text(encoding="utf-8"))
         self.assertIn(GIT_SYNC_SOURCE, BASHRC.read_text(encoding="utf-8"))
 
-    def test_home_manager_installs_command_and_shared_helper(self):
+    def test_home_manager_installs_git_sync_command_from_shared_helper(self):
         source = BASE_NIX.read_text(encoding="utf-8")
         helper_path = "../../../.config/bash/git-sync.sh"
         self.assertIn('name = "git-sync";', source)
         self.assertIn(f"builtins.readFile {helper_path}", source)
-        self.assertIn(
-            f'xdg.configFile."bash/git-sync.sh".source = {helper_path};',
-            source,
-        )
+        self.assertIn("]) ++ [ gitSync ];", source)
 
     def test_tangled_bashrc_is_valid_bash(self):
         completed = subprocess.run(

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -60,6 +60,12 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertIn("qtile.call_soon_threadsafe(qtile.reload_config)", SOURCE_TEXT)
         self.assertNotIn("qtile cmd-obj", SOURCE_TEXT)
 
+    def test_sync_reload_uses_installed_command_with_repo_bootstrap_fallback(self):
+        self.assertIn('shutil.which("git-sync")', SOURCE_TEXT)
+        self.assertIn('Path.home() / ".dotfiles" / ".config" / "bash" / "git-sync.sh"', SOURCE_TEXT)
+        self.assertNotIn('Path.home() / ".config" / "bash" / "git-sync.sh"', SOURCE_TEXT)
+        self.assertNotIn('source "{helper}"', SOURCE_TEXT)
+
     def test_sync_reload_notifies_user(self):
         self.assertIn('shutil.which("dunstify")', SOURCE_TEXT)
         self.assertIn('shutil.which("notify-send")', SOURCE_TEXT)

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -60,12 +60,6 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertIn("qtile.call_soon_threadsafe(qtile.reload_config)", SOURCE_TEXT)
         self.assertNotIn("qtile cmd-obj", SOURCE_TEXT)
 
-    def test_sync_reload_uses_installed_command_with_repo_bootstrap_fallback(self):
-        self.assertIn('shutil.which("git-sync")', SOURCE_TEXT)
-        self.assertIn('Path.home() / ".dotfiles" / ".config" / "bash" / "git-sync.sh"', SOURCE_TEXT)
-        self.assertNotIn('Path.home() / ".config" / "bash" / "git-sync.sh"', SOURCE_TEXT)
-        self.assertNotIn('source "{helper}"', SOURCE_TEXT)
-
     def test_sync_reload_notifies_user(self):
         self.assertIn('shutil.which("dunstify")', SOURCE_TEXT)
         self.assertIn('shutil.which("notify-send")', SOURCE_TEXT)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,10 @@ Qtile sync/reload behavior must:
 
 `bash.org` and its tangled `.bashrc` should source the shared `.config/bash/git-sync.sh` helper so interactive Bash gets a `git-sync` function when that Bash configuration is active.
 
-Do not rely on Bash startup files as the only way to expose `git-sync`. The helper must also be directly executable, and the base Home Manager module must install it as a real `git-sync` command and deploy the helper to `~/.config/bash/git-sync.sh`. This keeps Qtile, Bash, and Home Manager on one implementation even when the live `.bashrc` is owned or generated elsewhere.
+Do not rely on Bash startup files as the only way to expose `git-sync`. The helper must also be directly executable, and the base Home Manager module must install it as a real `git-sync` command built from the same helper. Do not make Home Manager take ownership of the Stow-managed helper path merely to expose the command.
 
 ## Testing
 
 Follow TDD for behavior changes. Add or update regression tests before implementation when practical, then run the real suite. Tests must validate literate/generated parity for files touched by a change rather than merely checking that both files exist.
 
-For shared shell helpers, test both sourced-function behavior and direct command execution. Home Manager evaluation must remain green for changes to installed commands or XDG-managed files.
+For shared shell helpers, test both sourced-function behavior and direct command execution. Home Manager evaluation must remain green for changes to installed commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,14 @@ Qtile sync/reload behavior must:
 - surface start, success, and failure through desktop notifications;
 - retain the existing 1 Hz OpenRouter telemetry behavior unless intentionally changed.
 
-## Bash
+## Bash and git-sync
 
-Interactive Bash must expose `git-sync` through the `.bashrc` generated from `bash.org`. The implementation lives in `.config/bash/git-sync.sh`; source that helper rather than duplicating its function body.
+`bash.org` and its tangled `.bashrc` should source the shared `.config/bash/git-sync.sh` helper so interactive Bash gets a `git-sync` function when that Bash configuration is active.
+
+Do not rely on Bash startup files as the only way to expose `git-sync`. The helper must also be directly executable, and the base Home Manager module must install it as a real `git-sync` command and deploy the helper to `~/.config/bash/git-sync.sh`. This keeps Qtile, Bash, and Home Manager on one implementation even when the live `.bashrc` is owned or generated elsewhere.
 
 ## Testing
 
 Follow TDD for behavior changes. Add or update regression tests before implementation when practical, then run the real suite. Tests must validate literate/generated parity for files touched by a change rather than merely checking that both files exist.
+
+For shared shell helpers, test both sourced-function behavior and direct command execution. Home Manager evaluation must remain green for changes to installed commands or XDG-managed files.

--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -1,5 +1,12 @@
 { lib, pkgs, config, ... }:
 
+let
+  gitSync = pkgs.writeShellApplication {
+    name = "git-sync";
+    runtimeInputs = [ pkgs.git ];
+    text = builtins.readFile ../../../.config/bash/git-sync.sh;
+  };
+in
 {
   options = {
     base.enable = lib.mkOption {
@@ -10,7 +17,7 @@
   };
 
   config = lib.mkIf config.base.enable {
-    home.packages = with pkgs; [
+    home.packages = (with pkgs; [
       nixpkgs-fmt
       git
       stow # until i have nix handles it
@@ -25,6 +32,6 @@
       starship
       curl
 
-    ];
+    ]) ++ [ gitSync ];
   };
 }

--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -33,5 +33,10 @@ in
       curl
 
     ]) ++ [ gitSync ];
+
+    # Keep the shared helper at the stable path used by interactive Bash and
+    # the Qtile sync/reload binding. The installed git-sync command is built
+    # from this same file so there is only one implementation to maintain.
+    xdg.configFile."bash/git-sync.sh".source = ../../../.config/bash/git-sync.sh;
   };
 }

--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -33,10 +33,5 @@ in
       curl
 
     ]) ++ [ gitSync ];
-
-    # Keep the shared helper at the stable path used by interactive Bash and
-    # the Qtile sync/reload binding. The installed git-sync command is built
-    # from this same file so there is only one implementation to maintain.
-    xdg.configFile."bash/git-sync.sh".source = ../../../.config/bash/git-sync.sh;
   };
 }


### PR DESCRIPTION
## Root cause
`git-sync` was only exposed by sourcing `.config/bash/git-sync.sh` from the repo's tangled `.bashrc`. The user's live `.bashrc` is not that repo copy, so `source ~/.bashrc` could not define the function even though `~/.dotfiles` was fully up to date.

## Fix
- make `.config/bash/git-sync.sh` valid both when sourced and when executed directly
- keep sourced mode defining the Bash `git-sync` function
- install the same helper as a real `git-sync` executable through the shared Home Manager base module
- do not make Home Manager take ownership of the Stow-managed helper path
- update `AGENTS.md` so future changes cannot assume Bash startup ownership

## Regression coverage
- sourced helper defines a Bash function without executing
- helper can be invoked directly as a command
- existing fast-forward, invalid repo, and no-upstream behavior remains covered
- test that Home Manager installs the command from the shared helper
- existing literate parity and Bash syntax checks remain

## Bootstrap
Immediately after this lands, the helper can be sourced directly from the repo even before the next Home Manager activation:

```bash
source ~/.dotfiles/.config/bash/git-sync.sh
```

After the next Home Manager switch, `git-sync` is a normal profile command and no longer depends on `.bashrc` ownership.