### PR TITLE
fix(emacs): prevent ob-async unreadable process sentinel failures

### DIFF
--- a/.github/workflows/android-emacs.yml
+++ b/.github/workflows/android-emacs.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - "agent/**"
+      - "fix/**"
     paths:
       - "android/**"
       - ".doom.d/android.org"
@@ -34,19 +35,22 @@ jobs:
             (dolist (file (list "android/early-init.el"
                                 "android/init.el"
                                 "android/lisp/star-android-reader.el"
-                                "android/tests/star-android-reader-test.el"))
+                                "android/tests/star-android-reader-test.el"
+                                "android/tests/async-compat-test.el"))
               (with-temp-buffer
                 (insert-file-contents file)
                 (emacs-lisp-mode)
                 (check-parens)))'
 
-      - name: Run reader ERT tests
+      - name: Run reader and async compatibility ERT tests
         run: |
           set -euo pipefail
           emacs -Q --batch \
             -L android/lisp \
             -L android/tests \
+            -l android/early-init.el \
             -l android/tests/star-android-reader-test.el \
+            -l android/tests/async-compat-test.el \
             -f ert-run-tests-batch-and-exit
 
       - name: Check sync helper

--- a/.github/workflows/android-emacs.yml
+++ b/.github/workflows/android-emacs.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - master
       - "agent/**"
-      - "fix/**"
     paths:
       - "android/**"
       - ".doom.d/android.org"

--- a/android/early-init.el
+++ b/android/early-init.el
@@ -4,6 +4,9 @@
 ;; Keep startup cheap and expose the paired Termux toolchain to native Emacs.
 ;; Do not set LD_LIBRARY_PATH: Android Emacs and Termux manage their own native
 ;; library lookup and only executable discovery is shared here.
+;;
+;; The Temple Chemacs profile also enters through this directory.  Keep small
+;; compatibility shims that must run before Temple package loading here.
 
 ;;; Code:
 
@@ -13,6 +16,35 @@
       (featurep 'android)))
 
 (defconst star/android-termux-prefix "/data/data/com.termux/files/usr")
+
+(defun star/async-sanitize-readable-output (&optional buffer)
+  "Make printed opaque objects readable as Lisp in BUFFER.
+
+Older releases of `async' let representations such as `#<process ...>' reach
+`async-when-done', which then calls `read' and fails with invalid-read-syntax.
+Mirror the sanitization used by current emacs-async before its sentinel reads
+child output.  BUFFER defaults to the current buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (save-excursion
+      (save-restriction
+        (widen)
+        (goto-char (point-min))
+        (while (re-search-forward "#<\\([^>]*\\)>" nil t)
+          (replace-match (concat "(" (match-string 1) ")") t t))
+        (goto-char (point-min))
+        (while (re-search-forward "#(" nil t)
+          (replace-match "(" t t))))))
+
+(defun star/async-sanitize-process-output (proc &rest _ignored)
+  "Sanitize PROC output before an older `async-when-done' reads it."
+  (let ((buffer (and (processp proc) (process-buffer proc))))
+    (when (buffer-live-p buffer)
+      (star/async-sanitize-readable-output buffer))))
+
+(with-eval-after-load 'async
+  (unless (advice-member-p #'star/async-sanitize-process-output
+                           'async-when-done)
+    (advice-add 'async-when-done :before #'star/async-sanitize-process-output)))
 
 (when (android-p)
   (let ((bin (expand-file-name "bin" star/android-termux-prefix)))

--- a/android/tests/async-compat-test.el
+++ b/android/tests/async-compat-test.el
@@ -25,7 +25,8 @@
   "Sanitization covers the complete process buffer even when narrowed."
   (with-temp-buffer
     (insert "prefix\n#<buffer hidden>\nsuffix\n")
-    (narrow-to-region (point-min) (line-end-position))
+    (goto-char (point-min))
+    (narrow-to-region (line-beginning-position) (line-end-position))
     (star/async-sanitize-readable-output)
     (widen)
     (should-not (string-match-p "#<" (buffer-string)))

--- a/android/tests/async-compat-test.el
+++ b/android/tests/async-compat-test.el
@@ -1,0 +1,34 @@
+;;; async-compat-test.el --- Tests for async compatibility shim -*- lexical-binding: t; -*-
+
+(require 'ert)
+
+(ert-deftest star/async-sanitize-readable-output-process-object ()
+  "Opaque process output becomes readable before `async-when-done'."
+  (with-temp-buffer
+    (insert "#<process ob-async-shell>\n")
+    (star/async-sanitize-readable-output)
+    (should (equal (buffer-string) "(process ob-async-shell)\n"))
+    (goto-char (point-min))
+    (should (equal (read (current-buffer))
+                   '(process ob-async-shell)))))
+
+(ert-deftest star/async-sanitize-readable-output-hash-list ()
+  "Unreadable hash-list syntax is normalized like current emacs-async."
+  (with-temp-buffer
+    (insert "#(alpha beta)\n")
+    (star/async-sanitize-readable-output)
+    (should (equal (buffer-string) "(alpha beta)\n"))
+    (goto-char (point-min))
+    (should (equal (read (current-buffer)) '(alpha beta)))))
+
+(ert-deftest star/async-sanitize-readable-output-widens ()
+  "Sanitization covers the complete process buffer even when narrowed."
+  (with-temp-buffer
+    (insert "prefix\n#<buffer hidden>\nsuffix\n")
+    (narrow-to-region (point-min) (line-end-position))
+    (star/async-sanitize-readable-output)
+    (widen)
+    (should-not (string-match-p "#<" (buffer-string)))
+    (should (string-match-p "(buffer hidden)" (buffer-string)))))
+
+;;; async-compat-test.el ends here


### PR DESCRIPTION
## Summary

- backport current `emacs-async` output sanitization before `async-when-done` reads child output
- apply the shim from `android/early-init.el`, which is on the active Temple Chemacs startup path
- cover `#<process ...>`, `#(...)`, and narrowed process buffers with ERT regression tests
- include the compatibility tests in the existing Android Emacs CI job

## Why

Async Org Babel blocks were leaving placeholder hashes and failing in the process sentinel with:

```
async-when-done: Invalid read syntax: "#<"
```

Older `async` revisions can attempt to `read` printed opaque Emacs objects such as `#<process ...>`. Current upstream `emacs-async` sanitizes those representations before `read`; this config shim gives the active Temple profile the same behavior even when its Straight checkout is stale.

## Verification

CI: Android Emacs structure checks + reader/async ERT suite + shell helper checks.
