### PR TITLE
fix(qtile): inherit Home Manager session environment

### DIFF
--- a/nix/nixos/mods/desktop.nix
+++ b/nix/nixos/mods/desktop.nix
@@ -69,6 +69,14 @@
         windowManager.session = lib.singleton {
           name = "qtile";
           start = ''
+            hm_session_vars="$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+            if [ -r "$hm_session_vars" ]; then
+              . "$hm_session_vars"
+            fi
+
+            export XDG_DATA_DIRS="$HOME/.nix-profile/share:/etc/profiles/per-user/$USER/share:/run/current-system/sw/share:/nix/var/nix/profiles/default/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+            systemctl --user import-environment DISPLAY PATH XDG_DATA_DIRS
+
             ${config.desktop.qtile.package}/bin/qtile start -b ${config.desktop.sessionType} \
             --config /home/unseen/.config/qtile/config.py &
             waitPID=$!


### PR DESCRIPTION
## Summary

- source the standalone Home Manager session variables before LightDM starts Qtile
- prepend Home Manager, per-user Nix, and system profile data directories to `XDG_DATA_DIRS`
- import the resulting `PATH` and `XDG_DATA_DIRS` into the user systemd environment

## Root cause

After switching from `startx`/`.xinitrc` to LightDM, the Qtile session no longer inherited Home Manager's login-shell environment. `j4-dmenu-desktop` therefore could not discover `.desktop` files under the Home Manager profile even though packages such as Brave were installed.

## Impact

Application discovery works generically for Home Manager and Nix profile applications instead of special-casing Brave.