### PR TITLE
fix(lightdm): load Home Manager environment in X session

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+hm_session_vars="$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+if [ -r "$hm_session_vars" ]; then
+    . "$hm_session_vars"
+fi
+
+export XDG_DATA_DIRS="$HOME/.nix-profile/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
+systemctl --user import-environment DISPLAY XAUTHORITY PATH XDG_DATA_DIRS

--- a/nix/nixos/mods/desktop.nix
+++ b/nix/nixos/mods/desktop.nix
@@ -69,14 +69,6 @@
         windowManager.session = lib.singleton {
           name = "qtile";
           start = ''
-            hm_session_vars="$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
-            if [ -r "$hm_session_vars" ]; then
-              . "$hm_session_vars"
-            fi
-
-            export XDG_DATA_DIRS="$HOME/.nix-profile/share:/etc/profiles/per-user/$USER/share:/run/current-system/sw/share:/nix/var/nix/profiles/default/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-            systemctl --user import-environment DISPLAY PATH XDG_DATA_DIRS
-
             ${config.desktop.qtile.package}/bin/qtile start -b ${config.desktop.sessionType} \
             --config /home/unseen/.config/qtile/config.py &
             waitPID=$!


### PR DESCRIPTION
## Summary

- add `~/.xprofile` so Arch LightDM loads the standalone Home Manager session environment before Qtile starts
- prepend the Home Manager profile to `XDG_DATA_DIRS` so `j4-dmenu-desktop` discovers Home Manager `.desktop` files
- import the graphical session environment into the user systemd manager
- revert the NixOS-only Qtile startup change from #81 because this workstation is using Arch LightDM

## Root cause

Arch LightDM starts Qtile through `/etc/lightdm/Xsession`, not `~/.xinitrc`. The wrapper sources `~/.xprofile`, so the Home Manager environment needs to be established there. Without the Home Manager profile in `XDG_DATA_DIRS`, applications such as Brave remain installed but are invisible to `j4-dmenu-desktop`.

## Deployment

The repository uses GNU Stow, so after pulling the merge, `stow .` will link `.xprofile` into the home directory. A new LightDM login is required for the session environment to be rebuilt.