### PR TITLE
Add UDM Pro UniFi MCP integration

### DIFF
--- a/.doom.d/autoload/llm.el
+++ b/.doom.d/autoload/llm.el
@@ -77,6 +77,13 @@
   (ai/mcp-register-proxmox noerror))
 
 ;;;###autoload
+(defun +llm/unifi-register (&optional noerror)
+  "Register the UDM Pro / UniFi MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-register-unifi noerror))
+
+;;;###autoload
 (defun +llm/discord-register (&optional noerror)
   "Register the Discord MCP server."
   (interactive)
@@ -89,6 +96,13 @@
   (interactive)
   (require 'ai-mcp)
   (ai/mcp-connect-proxmox))
+
+;;;###autoload
+(defun +llm/unifi-connect ()
+  "Connect the UDM Pro / UniFi MCP server."
+  (interactive)
+  (require 'ai-mcp)
+  (ai/mcp-connect-unifi))
 
 ;;;###autoload
 (defun +llm/discord-connect ()

--- a/lisp/llm/ai-mcp.el
+++ b/lisp/llm/ai-mcp.el
@@ -26,6 +26,13 @@ When readable, it is exported to the launcher via PROXMOX_MCP_ENV."
   :type 'file
   :group 'ai/mcp)
 
+(defcustom ai/mcp-unifi-env-file
+  (expand-file-name "~/.config/unifi-mcp/unifi-mcp.env")
+  "Shell env file sourced by the UniFi MCP launcher before uvx.
+The real UDM Pro host and API key stay outside the dotfiles repository."
+  :type 'file
+  :group 'ai/mcp)
+
 (defcustom ai/mcp-discord-auth-host "discord"
   "auth-source host used to look up the Discord bot token."
   :type 'string
@@ -66,6 +73,23 @@ With NOERROR, return nil instead of signaling when unavailable."
                   (assoc-delete-all "proxmox" mcp-hub-servers)))
       t))))
 
+(defun ai/mcp-register-unifi (&optional noerror)
+  "Register the local UDM Pro / UniFi MCP launcher.
+With NOERROR, return nil instead of signaling when unavailable."
+  (cond
+   ((not (file-readable-p ai/mcp-unifi-env-file))
+    (unless noerror
+      (user-error "Missing UniFi MCP config: %s" ai/mcp-unifi-env-file)))
+   ((not (executable-find "unifi-mcp-launcher"))
+    (unless noerror
+      (user-error "unifi-mcp-launcher is not on exec-path")))
+   (t
+    (setq mcp-hub-servers
+          (cons `("unifi-udmp" . (:command "unifi-mcp-launcher"
+                                  :env (:UNIFI_MCP_ENV ,ai/mcp-unifi-env-file)))
+                (assoc-delete-all "unifi-udmp" mcp-hub-servers)))
+    t)))
+
 (defun ai/mcp-register-discord (&optional noerror)
   "Register the local Discord MCP launcher.
 With NOERROR, return nil instead of signaling when unavailable."
@@ -95,6 +119,7 @@ With NOERROR, report failures without aborting Emacs startup."
         (require 'mcp-hub)
         (ai/mcp-register-discord 'noerror)
         (ai/mcp-register-proxmox 'noerror)
+        (ai/mcp-register-unifi 'noerror)
         (gptel-mcp-connect)
         t)
     (error
@@ -111,6 +136,14 @@ With NOERROR, report failures without aborting Emacs startup."
   (require 'mcp-hub)
   (ai/mcp-register-proxmox)
   (gptel-mcp-connect '("proxmox")))
+
+(defun ai/mcp-connect-unifi ()
+  "Register and connect the UDM Pro / UniFi MCP server."
+  (interactive)
+  (require 'gptel-integrations)
+  (require 'mcp-hub)
+  (ai/mcp-register-unifi)
+  (gptel-mcp-connect '("unifi-udmp")))
 
 (defun ai/mcp-connect-discord ()
   "Register and connect the Discord MCP server."

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -15,5 +15,6 @@
     ./llm.nix
     ./proxmox-mcp.nix
     ./discord-mcp.nix
+    ./unifi-mcp.nix
   ];
 }

--- a/nix/home-manager/mods/unifi-mcp.nix
+++ b/nix/home-manager/mods/unifi-mcp.nix
@@ -25,7 +25,7 @@ let
       set +a
 
       case "''${UNIFI_HOST:-}" in
-        "" | "192.168.1.1")
+        "" | "your-udmp-host")
           echo "unifi-mcp-launcher: set UNIFI_HOST in $env_file" >&2
           exit 1
           ;;

--- a/nix/home-manager/mods/unifi-mcp.nix
+++ b/nix/home-manager/mods/unifi-mcp.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.unifiMcp;
+  exampleEnv = ../../../scripts/unifi-mcp.env.example;
+
+  unifiMcpLauncher = pkgs.writeShellApplication {
+    name = "unifi-mcp-launcher";
+    runtimeInputs = with pkgs; [
+      coreutils
+      uv
+    ];
+    text = ''
+      env_file="''${UNIFI_MCP_ENV:-${cfg.envFile}}"
+
+      if [ ! -r "$env_file" ]; then
+        echo "unifi-mcp-launcher: no readable config at $env_file" >&2
+        echo "Run unifi-mcp-init, then configure the UDM Pro host and API key." >&2
+        exit 1
+      fi
+
+      set -a
+      # shellcheck disable=SC1090
+      . "$env_file"
+      set +a
+
+      case "''${UNIFI_HOST:-}" in
+        "" | "192.168.1.1")
+          echo "unifi-mcp-launcher: set UNIFI_HOST in $env_file" >&2
+          exit 1
+          ;;
+      esac
+
+      case "''${UNIFI_API_KEY:-}" in
+        "" | "replace-me")
+          echo "unifi-mcp-launcher: set UNIFI_API_KEY in $env_file" >&2
+          exit 1
+          ;;
+      esac
+
+      export STUB_MODE=false
+      export MCP_TRANSPORT=stdio
+      export MCP_UNIFI_READONLY="''${MCP_UNIFI_READONLY:-${if cfg.readOnly then "true" else "false"}}"
+      export MCP_UNIFI_MODULES_ENABLED="''${MCP_UNIFI_MODULES_ENABLED:-${cfg.modules}}"
+      export MCP_UNIFI_AUDIT_PATH="''${MCP_UNIFI_AUDIT_PATH:-${cfg.auditPath}}"
+
+      mkdir -p "$(dirname "$MCP_UNIFI_AUDIT_PATH")"
+
+      exec uvx --from "git+https://github.com/pete-builds/mcp-unifi@${cfg.version}" mcp-unifi
+    '';
+  };
+
+  unifiMcpInit = pkgs.writeShellApplication {
+    name = "unifi-mcp-init";
+    runtimeInputs = with pkgs; [ coreutils ];
+    text = ''
+      env_file="${cfg.envFile}"
+      env_dir="$(dirname "$env_file")"
+
+      if [ -e "$env_file" ]; then
+        echo "unifi-mcp-init: refusing to overwrite $env_file" >&2
+        exit 1
+      fi
+
+      install -d -m 0700 "$env_dir"
+      install -m 0600 "${exampleEnv}" "$env_file"
+      echo "Created $env_file"
+      echo "Set UNIFI_HOST and UNIFI_API_KEY before connecting."
+    '';
+  };
+in
+{
+  options.unifiMcp = {
+    enable = lib.mkEnableOption "UDM Pro / UniFi MCP integration";
+
+    version = lib.mkOption {
+      type = lib.types.str;
+      default = "v0.21.1";
+      description = "Pinned pete-builds/mcp-unifi release executed by uvx.";
+    };
+
+    envFile = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.config/unifi-mcp/unifi-mcp.env";
+      description = "Secret UniFi MCP environment file kept outside the dotfiles repository.";
+    };
+
+    readOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Default MCP_UNIFI_READONLY policy when the env file does not override it.";
+    };
+
+    modules = lib.mkOption {
+      type = lib.types.str;
+      default = "network";
+      description = "Default comma-separated UniFi MCP modules to enable.";
+    };
+
+    auditPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.stateHome}/unifi-mcp/audit.jsonl";
+      description = "Default JSONL audit log path for UniFi MCP calls.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      unifiMcpInit
+      unifiMcpLauncher
+    ];
+
+    home.file.".config/unifi-mcp/unifi-mcp.env.example".source = exampleEnv;
+  };
+}

--- a/nix/home-manager/mods/unifi-mcp.nix
+++ b/nix/home-manager/mods/unifi-mcp.nix
@@ -8,6 +8,7 @@ let
     name = "unifi-mcp-launcher";
     runtimeInputs = with pkgs; [
       coreutils
+      python313
       uv
     ];
     text = ''
@@ -43,6 +44,8 @@ let
       export MCP_UNIFI_READONLY="''${MCP_UNIFI_READONLY:-${if cfg.readOnly then "true" else "false"}}"
       export MCP_UNIFI_MODULES_ENABLED="''${MCP_UNIFI_MODULES_ENABLED:-${cfg.modules}}"
       export MCP_UNIFI_AUDIT_PATH="''${MCP_UNIFI_AUDIT_PATH:-${cfg.auditPath}}"
+      export UV_PYTHON="${pkgs.python313}/bin/python3.13"
+      export UV_PYTHON_DOWNLOADS=never
 
       mkdir -p "$(dirname "$MCP_UNIFI_AUDIT_PATH")"
 
@@ -76,7 +79,7 @@ in
     version = lib.mkOption {
       type = lib.types.str;
       default = "v0.21.1";
-      description = "Pinned pete-builds/mcp-unifi release executed by uvx.";
+      description = "Pinned pete-builds/mcp-unifi version executed by uvx.";
     };
 
     envFile = lib.mkOption {

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -28,6 +28,10 @@
     enable = true;
   };
 
+  unifiMcp = {
+    enable = true;
+  };
+
   emacs = {
     enable = true;
     # I mostly use magit hence configured in the ./nixos/mods/emacs.nix module
@@ -59,11 +63,9 @@
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
-  # incompatible changes.
-  #
-  # You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version
-  # changes in each release.
+  # incompatible changes. You can update Home Manager without
+  # changing this value. See the Home Manager release notes for
+  # a list of state version changes in each release.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -63,9 +63,8 @@
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
-  # incompatible changes. You can update Home Manager without
-  # changing this value. See the Home Manager release notes for
-  # a list of state version changes in each release.
+  # incompatible changes. You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version changes in each release.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -63,8 +63,11 @@
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
-  # incompatible changes. You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version changes in each release.
+  # incompatible changes.
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/scripts/unifi-mcp.env.example
+++ b/scripts/unifi-mcp.env.example
@@ -2,7 +2,7 @@
 # Copy with `unifi-mcp-init`, then keep the real file out of Git.
 
 # UDM Pro / UniFi OS gateway IP or hostname, without https://.
-UNIFI_HOST=192.168.1.1
+UNIFI_HOST=your-udmp-host
 
 # Local API key from:
 # Settings -> Control Plane -> Integrations -> Create API Key

--- a/scripts/unifi-mcp.env.example
+++ b/scripts/unifi-mcp.env.example
@@ -1,0 +1,27 @@
+# UniFi MCP local controller configuration.
+# Copy with `unifi-mcp-init`, then keep the real file out of Git.
+
+# UDM Pro / UniFi OS gateway IP or hostname, without https://.
+UNIFI_HOST=192.168.1.1
+
+# Local API key from:
+# Settings -> Control Plane -> Integrations -> Create API Key
+UNIFI_API_KEY=replace-me
+
+# Normal UniFi OS defaults.
+UNIFI_PORT=443
+UNIFI_SITE=default
+
+# Most local UniFi gateways use a self-signed certificate. Set true only
+# after the gateway has a certificate trusted by this machine.
+UNIFI_VERIFY_SSL=false
+
+# Keep LLM access structurally read-only until you intentionally opt into
+# mutations. The MCP server also supports dry-run previews for writes.
+MCP_UNIFI_READONLY=true
+
+# UDM Pro administration starts with Network only. Protect and Access can be
+# enabled later with: network,protect,access
+MCP_UNIFI_MODULES_ENABLED=network
+
+LOG_LEVEL=INFO


### PR DESCRIPTION
## What changed

- package `pete-builds/mcp-unifi` behind a Home Manager `unifi-mcp-launcher`
- pin the MCP server to `v0.21.1` and Python 3.13
- keep the real UDM Pro API key in `~/.config/unifi-mcp/unifi-mcp.env`, outside the repository
- default the server to stdio, Network-only tools, read-only mode, and a local JSONL audit log
- add `unifi-mcp-init` and a non-secret example environment file
- register `unifi-udmp` with the existing gptel/mcp.el stack
- expose `+llm/unifi-register` and `+llm/unifi-connect`
- enable the Home Manager module on the desktop profile

## Safety

The launcher refuses placeholder credentials. Read-only mode is enabled by default; mutation tools remain disabled until explicitly opted into. The API key is not stored in Doom or OpenCode configuration.

## Validation

The branch was checked structurally against the existing Proxmox MCP packaging pattern and the upstream mcp-unifi configuration/entrypoint. Full Nix/Emacs execution checks were not available in the connector environment, so this PR remains draft until those are run on the target machine/CI.