### PR TITLE
Add one-shot Termux bootstrap

### DIFF
--- a/.github/workflows/android-emacs.yml
+++ b/.github/workflows/android-emacs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "android/**"
+      - "bootstrap-termux.sh"
       - ".doom.d/android.org"
       - ".github/workflows/android-emacs.yml"
   push:
@@ -12,6 +13,7 @@ on:
       - "agent/**"
     paths:
       - "android/**"
+      - "bootstrap-termux.sh"
       - ".doom.d/android.org"
       - ".github/workflows/android-emacs.yml"
 
@@ -57,3 +59,9 @@ jobs:
           set -euo pipefail
           bash -n android/bin/sync-auto-research
           shellcheck --severity=warning android/bin/sync-auto-research
+
+      - name: Check Termux bootstrap
+        run: |
+          set -euo pipefail
+          bash -n bootstrap-termux.sh
+          shellcheck --severity=warning bootstrap-termux.sh

--- a/android/README.org
+++ b/android/README.org
@@ -22,8 +22,26 @@ android/
 
 * Termux tools
 
-Use the paired native Android Emacs and Termux builds that can access the same
-Android application data.  In Termux install the command-line side:
+For a fresh Termux install, bootstrap the dotfiles, Emacs, GitHub CLI, and
+OpenCode in one shot:
+
+#+begin_src sh
+curl -fsSL https://raw.githubusercontent.com/lost-rob0t/dotfiles/master/bootstrap-termux.sh | bash
+#+end_src
+
+The bootstrap installs the native Termux tools, clones this repository to
+=~/.dotfiles=, activates =android/= as the Emacs profile when no existing Emacs
+configuration is present, and installs OpenCode inside a Debian =proot-distro=.
+A native Termux =opencode= wrapper enters that Debian environment while sharing
+the Termux home directory, so projects under =~= remain directly usable.
+
+OpenCode currently ships Linux arm64 binaries that target glibc rather than the
+Android/Termux ABI, so the bootstrap intentionally does not install the binary
+as a native Android executable.
+
+For manual setup, use the paired native Android Emacs and Termux builds that can
+access the same Android application data.  In Termux install the command-line
+side:
 
 #+begin_src sh
 pkg update

--- a/bootstrap-termux.sh
+++ b/bootstrap-termux.sh
@@ -1,0 +1,104 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+readonly DOTFILES_REPO="https://github.com/lost-rob0t/dotfiles.git"
+readonly DOTFILES_DIR="${STAR_DOTFILES_ROOT:-$HOME/.dotfiles}"
+readonly OPENCODE_INSTALL_URL="https://opencode.ai/install"
+readonly DISTRO="debian"
+
+fail() {
+  printf 'bootstrap-termux: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v pkg >/dev/null 2>&1 || fail "this script must run inside Termux"
+
+printf '==> Installing Termux packages\n'
+pkg update -y
+pkg install -y \
+  curl \
+  emacs \
+  fd \
+  gh \
+  git \
+  gnupg \
+  jq \
+  openssh \
+  proot-distro \
+  ripgrep \
+  sqlite
+
+printf '==> Bootstrapping dotfiles at %s\n' "$DOTFILES_DIR"
+if [[ -d "$DOTFILES_DIR/.git" ]]; then
+  git -C "$DOTFILES_DIR" fetch origin master
+  git -C "$DOTFILES_DIR" merge --ff-only origin/master
+elif [[ -e "$DOTFILES_DIR" ]]; then
+  fail "$DOTFILES_DIR exists but is not a Git checkout"
+else
+  git clone --branch master --single-branch "$DOTFILES_REPO" "$DOTFILES_DIR"
+fi
+
+if [[ ! -e "$HOME/.emacs" && ! -e "$HOME/.emacs.d" && ! -e "$HOME/.config/emacs" ]]; then
+  printf '==> Activating the Android Emacs profile\n'
+  ln -s "$DOTFILES_DIR/android" "$HOME/.emacs.d"
+else
+  printf '==> Existing Emacs configuration found; leaving it untouched\n'
+fi
+
+printf '==> Ensuring Debian proot is installed for OpenCode\n'
+if ! proot-distro login "$DISTRO" -- /bin/true >/dev/null 2>&1; then
+  proot-distro install "$DISTRO"
+fi
+
+printf '==> Installing OpenCode inside Debian\n'
+proot-distro login "$DISTRO" -- /bin/bash -lc '
+  set -euo pipefail
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y ca-certificates curl git
+  installer="$(mktemp)"
+  trap '\''rm -f "$installer"'\'' EXIT
+  curl -fsSL https://opencode.ai/install -o "$installer"
+  OPENCODE_INSTALL_DIR=/usr/local/bin bash "$installer"
+  /usr/local/bin/opencode --version
+'
+
+printf '==> Installing the Termux OpenCode wrapper\n'
+cat > "$PREFIX/bin/opencode" <<'EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+readonly DISTRO="debian"
+readonly TERMUX_HOME="${HOME:?}"
+readonly HOST_PWD="$(pwd -P)"
+
+case "$HOST_PWD" in
+  "$TERMUX_HOME")
+    guest_pwd="/root"
+    ;;
+  "$TERMUX_HOME"/*)
+    guest_pwd="/root/${HOST_PWD#"$TERMUX_HOME"/}"
+    ;;
+  *)
+    guest_pwd="/root"
+    ;;
+esac
+
+exec proot-distro login "$DISTRO" \
+  --shared-home \
+  --work-dir "$guest_pwd" \
+  -- /usr/local/bin/opencode "$@"
+EOF
+chmod 0755 "$PREFIX/bin/opencode"
+
+printf '\n==> Bootstrap complete\n'
+printf 'Emacs:   '
+emacs --version | head -n 1
+printf 'OpenCode: '
+opencode --version
+
+if gh auth status >/dev/null 2>&1; then
+  printf 'GitHub:   authenticated\n'
+else
+  printf 'GitHub:   run: gh auth login && gh auth setup-git\n'
+fi

--- a/bootstrap-termux.sh
+++ b/bootstrap-termux.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 readonly DOTFILES_REPO="https://github.com/lost-rob0t/dotfiles.git"
 readonly DOTFILES_DIR="${STAR_DOTFILES_ROOT:-$HOME/.dotfiles}"
-readonly OPENCODE_INSTALL_URL="https://opencode.ai/install"
 readonly DISTRO="debian"
 
 fail() {
@@ -55,11 +54,12 @@ proot-distro login "$DISTRO" -- /bin/bash -lc '
   set -euo pipefail
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
-  apt-get install -y ca-certificates curl git
+  apt-get install -y ca-certificates curl git tar
   installer="$(mktemp)"
   trap '\''rm -f "$installer"'\'' EXIT
   curl -fsSL https://opencode.ai/install -o "$installer"
-  OPENCODE_INSTALL_DIR=/usr/local/bin bash "$installer"
+  HOME=/root bash "$installer" --no-modify-path
+  install -m 0755 /root/.opencode/bin/opencode /usr/local/bin/opencode
   /usr/local/bin/opencode --version
 '
 
@@ -93,7 +93,7 @@ chmod 0755 "$PREFIX/bin/opencode"
 
 printf '\n==> Bootstrap complete\n'
 printf 'Emacs:   '
-emacs --version | head -n 1
+emacs --version | sed -n '1p'
 printf 'OpenCode: '
 opencode --version
 

--- a/bootstrap-termux.sh
+++ b/bootstrap-termux.sh
@@ -58,7 +58,7 @@ proot-distro login "$DISTRO" -- /bin/bash -lc '
   installer="$(mktemp)"
   trap '\''rm -f "$installer"'\'' EXIT
   curl -fsSL https://opencode.ai/install -o "$installer"
-  HOME=/root bash "$installer" --no-modify-path
+  HOME=/root PATH=/usr/bin:/bin bash "$installer" --no-modify-path
   install -m 0755 /root/.opencode/bin/opencode /usr/local/bin/opencode
   /usr/local/bin/opencode --version
 '


### PR DESCRIPTION
## Summary
- add `bootstrap-termux.sh` for a fresh Termux install
- install native Termux Emacs, GitHub CLI, Git, and supporting Android tools
- clone/update the dotfiles repo and activate the Android Emacs profile when safe
- install OpenCode inside Debian `proot-distro` and expose a native Termux wrapper
- document the one-liner and validate the bootstrap with `bash -n` + ShellCheck

## Rationale
OpenCode's current Linux arm64 binary targets glibc and is not directly compatible with native Termux/Android, so the bootstrap keeps OpenCode inside Debian while sharing the Termux home directory.

## Validation
CI: Android Emacs workflow (ERT + shell syntax + ShellCheck).