### PR TITLE
Own gpt-todos sync runtime in literate dotfiles

### DIFF
--- a/.doom.d/autoload/gpt-todos.el
+++ b/.doom.d/autoload/gpt-todos.el
@@ -1,0 +1,23 @@
+;;; gpt-todos.el -*- lexical-binding: t; -*-
+
+(defcustom gpt-todos-sync-script
+  (expand-file-name "~/.local/share/gpt-todos/bin/sync")
+  "Path to the gpt-todos sync script."
+  :type 'file)
+
+;;;###autoload
+(defun gpt-todos-sync ()
+  "Run gpt-todos sync asynchronously in a hidden buffer."
+  (interactive)
+  (let* ((buffer (get-buffer-create " *gpt-todos-sync*"))
+         (proc (start-process "gpt-todos-sync" buffer
+                              "/usr/bin/env" "bash" gpt-todos-sync-script)))
+    (set-process-sentinel
+     proc
+     (lambda (p _event)
+       (when (memq (process-status p) '(exit signal))
+         (if (= 0 (process-exit-status p))
+             (message "gpt-todos sync complete")
+           (message "gpt-todos sync failed; see %s"
+                    (buffer-name (process-buffer p)))))))
+    (message "gpt-todos sync started")))

--- a/.doom.d/autoload/gpt-todos.el
+++ b/.doom.d/autoload/gpt-todos.el
@@ -1,8 +1,9 @@
 ;;; gpt-todos.el -*- lexical-binding: t; -*-
 
 (defcustom gpt-todos-sync-script
-  (expand-file-name "~/.local/share/gpt-todos/bin/sync")
-  "Path to the gpt-todos sync script."
+  (or (getenv "GPT_TODOS_SYNC")
+      (expand-file-name "~/.dotfiles/scripts/gpt-todos-sync"))
+  "Path to the dotfiles-owned gpt-todos sync script."
   :type 'file)
 
 ;;;###autoload

--- a/.doom.d/autoload/gpt-todos.org
+++ b/.doom.d/autoload/gpt-todos.org
@@ -1,0 +1,28 @@
+#+title: GPT TODO sync autoload
+#+property: header-args :emacs-lisp :tangle ./gpt-todos.el :results none
+
+#+begin_src emacs-lisp
+;;; gpt-todos.el -*- lexical-binding: t; -*-
+
+(defcustom gpt-todos-sync-script
+  (expand-file-name "~/.local/share/gpt-todos/bin/sync")
+  "Path to the gpt-todos sync script."
+  :type 'file)
+
+;;;###autoload
+(defun gpt-todos-sync ()
+  "Run gpt-todos sync asynchronously in a hidden buffer."
+  (interactive)
+  (let* ((buffer (get-buffer-create " *gpt-todos-sync*"))
+         (proc (start-process "gpt-todos-sync" buffer
+                              "/usr/bin/env" "bash" gpt-todos-sync-script)))
+    (set-process-sentinel
+     proc
+     (lambda (p _event)
+       (when (memq (process-status p) '(exit signal))
+         (if (= 0 (process-exit-status p))
+             (message "gpt-todos sync complete")
+           (message "gpt-todos sync failed; see %s"
+                    (buffer-name (process-buffer p)))))))
+    (message "gpt-todos sync started")))
+#+end_src

--- a/.doom.d/autoload/gpt-todos.org
+++ b/.doom.d/autoload/gpt-todos.org
@@ -5,8 +5,9 @@
 ;;; gpt-todos.el -*- lexical-binding: t; -*-
 
 (defcustom gpt-todos-sync-script
-  (expand-file-name "~/.local/share/gpt-todos/bin/sync")
-  "Path to the gpt-todos sync script."
+  (or (getenv "GPT_TODOS_SYNC")
+      (expand-file-name "~/.dotfiles/scripts/gpt-todos-sync"))
+  "Path to the dotfiles-owned gpt-todos sync script."
   :type 'file)
 
 ;;;###autoload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ This repository uses literate Org configuration. Treat the Org files as source c
 - `bash.org` is the source of truth for `.bashrc`.
 - `.config/qtile/qtile-ai.org` is the main source of truth for `.config/qtile/config.py`.
 - `.config/qtile/qtile-openrouter.org` is the source of truth for `.config/qtile/qtile_openrouter.py`.
+- `.doom.d/autoload/gpt-todos.org` is the source of truth for `.doom.d/autoload/gpt-todos.el`.
+- `scripts/gpt-todos-sync.org` is the source of truth for `scripts/gpt-todos-sync` and `scripts/install-gpt-todos-cron`.
 - Do not make a lasting change only in a generated/tangled file.
 
 When a change touches a literate configuration:
@@ -35,6 +37,14 @@ Qtile sync/reload behavior must:
 `bash.org` and its tangled `.bashrc` should source the shared `.config/bash/git-sync.sh` helper so interactive Bash gets a `git-sync` function when that Bash configuration is active.
 
 Do not rely on Bash startup files as the only way to expose `git-sync`. The helper must also be directly executable, and the base Home Manager module must install it as a real `git-sync` command built from the same helper. Do not make Home Manager take ownership of the Stow-managed helper path merely to expose the command.
+
+## GPT TODO sync
+
+`lost-rob0t/gpt-todos` owns durable Org task state. Dotfiles owns the local sync/runtime integration used to move that state into the user's live Org agenda.
+
+Do not put the canonical sync executable or Emacs integration in `gpt-todos`. Keep them in this repository and keep their Org sources synchronized with their generated counterparts.
+
+`gpt-todos-sync` may enforce known literate/generated pairs before task synchronization. Treat detected generated-only drift as a blocking error rather than silently syncing task state on top of inconsistent configuration.
 
 ## Testing
 

--- a/README.org
+++ b/README.org
@@ -27,6 +27,23 @@ Otherwise
 ** Install dotfiles
 clone repo  to ~/.dotfiles and run gnu stow .
 
+** GPT TODO sync
+The durable task-state checkout defaults to =~/Documents/gpt-todos= and only its
+=agenda/*.org= files are mirrored into =~/Documents/Notes/org/agenda=.
+
+After the dotfiles checkout exists, this one-liner updates dotfiles, performs an
+initial sync, and installs the five-minute cron entry:
+
+#+begin_src sh
+git -C ~/.dotfiles pull --ff-only && bash ~/.dotfiles/scripts/gpt-todos-sync --deploy 5
+#+end_src
+
+The dotfiles-owned deployment command by itself is:
+
+#+begin_src sh
+bash ~/.dotfiles/scripts/gpt-todos-sync --deploy 5
+#+end_src
+
 ** nix
 *** Setup nix
 Install nix: https://nixos.org/download

--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/.local/share/gpt-todos}"
+TASK_DIR="$REPO_DIR/agenda"
+ORG_DIR="${GPT_TODOS_ORG_DIR:-$HOME/Documents/Notes/org/agenda}"
+REMOTE="${GPT_TODOS_REMOTE:-git@github.com:lost-rob0t/gpt-todos.git}"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+LOCK="${XDG_RUNTIME_DIR:-/tmp}/gpt-todos-sync-${UID}.lock"
+
+mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
+exec 9>"$LOCK"
+flock -n 9 || exit 0
+
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  git clone "$REMOTE" "$REPO_DIR"
+fi
+mkdir -p "$TASK_DIR"
+
+sync_literate_pair() {
+  local src="$1"; shift
+  local relsrc="${src#"$DOTFILES_DIR/"}"
+  [[ -f "$src" ]] || return 0
+
+  local src_dirty=0 out_dirty=0 out
+  git -C "$DOTFILES_DIR" diff --quiet -- "$relsrc" || src_dirty=1
+  git -C "$DOTFILES_DIR" diff --cached --quiet -- "$relsrc" || src_dirty=1
+
+  for out in "$@"; do
+    [[ -e "$DOTFILES_DIR/$out" ]] || continue
+    git -C "$DOTFILES_DIR" diff --quiet -- "$out" || out_dirty=1
+    git -C "$DOTFILES_DIR" diff --cached --quiet -- "$out" || out_dirty=1
+  done
+
+  if (( out_dirty && ! src_dirty )); then
+    printf 'gpt-todos-sync: tangled output changed without literate source: %s\n' "$relsrc" >&2
+    printf 'Edit the Org source too, then rerun sync.\n' >&2
+    return 3
+  fi
+
+  if (( src_dirty )); then
+    command -v emacs >/dev/null || {
+      printf 'gpt-todos-sync: emacs required to tangle %s\n' "$relsrc" >&2
+      return 4
+    }
+    emacs --batch --quick \
+      --eval '(require (quote org))' \
+      --eval '(require (quote ob-tangle))' \
+      --eval "(org-babel-tangle-file \"$src\")" >/dev/null
+  fi
+}
+
+sync_dotfiles_literate() {
+  [[ -d "$DOTFILES_DIR/.git" ]] || return 0
+  sync_literate_pair "$DOTFILES_DIR/bash.org" ".bashrc"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/config.org" ".doom.d/config.el" ".doom.d/init.el"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/packages.org" ".doom.d/packages.el"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/autoload/gpt-todos.org" ".doom.d/autoload/gpt-todos.el"
+  sync_literate_pair "$DOTFILES_DIR/.config/qtile/qtile-ai.org" ".config/qtile/config.py"
+  sync_literate_pair "$DOTFILES_DIR/.config/qtile/qtile-openrouter.org" ".config/qtile/qtile_openrouter.py"
+  sync_literate_pair "$DOTFILES_DIR/scripts/gpt-todos-sync.org" \
+    "scripts/gpt-todos-sync" "scripts/install-gpt-todos-cron"
+}
+
+sync_dotfiles_literate
+
+# Only repo agenda/ is mirrored into ~/Documents/Notes/org/agenda.
+# Docs/README Org files never enter the live agenda.
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$ORG_DIR/" "$TASK_DIR/"
+
+git -C "$REPO_DIR" pull --rebase --autostash
+
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$TASK_DIR/" "$ORG_DIR/"
+
+mapfile -t org_paths < <(find "$TASK_DIR" -type f -name '*.org' -printf 'agenda/%P\n' | sort -u)
+if ((${#org_paths[@]})); then
+  git -C "$REPO_DIR" add -- "${org_paths[@]}"
+fi
+
+if ! git -C "$REPO_DIR" diff --cached --quiet; then
+  git -C "$REPO_DIR" commit -m "Sync Org task state"
+  git -C "$REPO_DIR" push
+fi
+
+git -C "$REPO_DIR" pull --rebase --autostash
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$TASK_DIR/" "$ORG_DIR/"

--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/.local/share/gpt-todos}"
+REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/Documents/gpt-todos}"
 TASK_DIR="$REPO_DIR/agenda"
 ORG_DIR="${GPT_TODOS_ORG_DIR:-$HOME/Documents/Notes/org/agenda}"
 REMOTE="${GPT_TODOS_REMOTE:-git@github.com:lost-rob0t/gpt-todos.git}"
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
 LOCK="${XDG_RUNTIME_DIR:-/tmp}/gpt-todos-sync-${UID}.lock"
+
+if [[ "${1:-}" == "--deploy" ]]; then
+  minutes="${2:-5}"
+  [[ "$minutes" =~ ^[0-9]+$ ]] || { echo "usage: $0 --deploy [minutes>=5]" >&2; exit 2; }
+  (( minutes >= 5 )) || { echo "minimum is 5 minutes" >&2; exit 2; }
+
+  for cmd in git rsync flock crontab; do
+    command -v "$cmd" >/dev/null || {
+      printf 'gpt-todos-sync: missing deploy dependency: %s\n' "$cmd" >&2
+      exit 4
+    }
+  done
+
+  [[ -d "$DOTFILES_DIR/.git" ]] || {
+    printf 'gpt-todos-sync: dotfiles checkout not found at %s\n' "$DOTFILES_DIR" >&2
+    exit 3
+  }
+
+  if [[ ! -d "$REPO_DIR/.git" ]]; then
+    mkdir -p "$(dirname "$REPO_DIR")"
+    git clone "$REMOTE" "$REPO_DIR"
+  fi
+
+  /usr/bin/env bash "$DOTFILES_DIR/scripts/gpt-todos-sync"
+  GPT_TODOS_SYNC="$DOTFILES_DIR/scripts/gpt-todos-sync" \
+    /usr/bin/env bash "$DOTFILES_DIR/scripts/install-gpt-todos-cron" "$minutes"
+
+  printf 'gpt-todos sync deployed: %s -> %s every %s minutes\n' \
+    "$TASK_DIR" "$ORG_DIR" "$minutes"
+  exit 0
+fi
 
 mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
 exec 9>"$LOCK"

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -1,0 +1,123 @@
+#+title: GPT TODO sync tooling
+#+author: nsaspy
+#+startup: overview
+
+* Sync
+
+This is the canonical literate source for the task-state sync helper.  It keeps
+only =gpt-todos/agenda/*.org= mirrored into the live Org agenda, reconciles the
+private repository through Git, and refuses to silently tolerate known
+literate/generated drift in dotfiles.
+
+#+begin_src sh :tangle ./gpt-todos-sync :results none
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/.local/share/gpt-todos}"
+TASK_DIR="$REPO_DIR/agenda"
+ORG_DIR="${GPT_TODOS_ORG_DIR:-$HOME/Documents/Notes/org/agenda}"
+REMOTE="${GPT_TODOS_REMOTE:-git@github.com:lost-rob0t/gpt-todos.git}"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+LOCK="${XDG_RUNTIME_DIR:-/tmp}/gpt-todos-sync-${UID}.lock"
+
+mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
+exec 9>"$LOCK"
+flock -n 9 || exit 0
+
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  git clone "$REMOTE" "$REPO_DIR"
+fi
+mkdir -p "$TASK_DIR"
+
+sync_literate_pair() {
+  local src="$1"; shift
+  local relsrc="${src#"$DOTFILES_DIR/"}"
+  [[ -f "$src" ]] || return 0
+
+  local src_dirty=0 out_dirty=0 out
+  git -C "$DOTFILES_DIR" diff --quiet -- "$relsrc" || src_dirty=1
+  git -C "$DOTFILES_DIR" diff --cached --quiet -- "$relsrc" || src_dirty=1
+
+  for out in "$@"; do
+    [[ -e "$DOTFILES_DIR/$out" ]] || continue
+    git -C "$DOTFILES_DIR" diff --quiet -- "$out" || out_dirty=1
+    git -C "$DOTFILES_DIR" diff --cached --quiet -- "$out" || out_dirty=1
+  done
+
+  if (( out_dirty && ! src_dirty )); then
+    printf 'gpt-todos-sync: tangled output changed without literate source: %s\n' "$relsrc" >&2
+    printf 'Edit the Org source too, then rerun sync.\n' >&2
+    return 3
+  fi
+
+  if (( src_dirty )); then
+    command -v emacs >/dev/null || {
+      printf 'gpt-todos-sync: emacs required to tangle %s\n' "$relsrc" >&2
+      return 4
+    }
+    emacs --batch --quick \
+      --eval '(require (quote org))' \
+      --eval '(require (quote ob-tangle))' \
+      --eval "(org-babel-tangle-file \"$src\")" >/dev/null
+  fi
+}
+
+sync_dotfiles_literate() {
+  [[ -d "$DOTFILES_DIR/.git" ]] || return 0
+  sync_literate_pair "$DOTFILES_DIR/bash.org" ".bashrc"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/config.org" ".doom.d/config.el" ".doom.d/init.el"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/packages.org" ".doom.d/packages.el"
+  sync_literate_pair "$DOTFILES_DIR/.doom.d/autoload/gpt-todos.org" ".doom.d/autoload/gpt-todos.el"
+  sync_literate_pair "$DOTFILES_DIR/.config/qtile/qtile-ai.org" ".config/qtile/config.py"
+  sync_literate_pair "$DOTFILES_DIR/.config/qtile/qtile-openrouter.org" ".config/qtile/qtile_openrouter.py"
+  sync_literate_pair "$DOTFILES_DIR/scripts/gpt-todos-sync.org" \
+    "scripts/gpt-todos-sync" "scripts/install-gpt-todos-cron"
+}
+
+sync_dotfiles_literate
+
+# Only repo agenda/ is mirrored into ~/Documents/Notes/org/agenda.
+# Docs/README Org files never enter the live agenda.
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$ORG_DIR/" "$TASK_DIR/"
+
+git -C "$REPO_DIR" pull --rebase --autostash
+
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$TASK_DIR/" "$ORG_DIR/"
+
+mapfile -t org_paths < <(find "$TASK_DIR" -type f -name '*.org' -printf 'agenda/%P\n' | sort -u)
+if ((${#org_paths[@]})); then
+  git -C "$REPO_DIR" add -- "${org_paths[@]}"
+fi
+
+if ! git -C "$REPO_DIR" diff --cached --quiet; then
+  git -C "$REPO_DIR" commit -m "Sync Org task state"
+  git -C "$REPO_DIR" push
+fi
+
+git -C "$REPO_DIR" pull --rebase --autostash
+rsync -a --checksum --update --include='*/' --include='*.org' --exclude='*' \
+  "$TASK_DIR/" "$ORG_DIR/"
+#+end_src
+
+* Cron installer
+
+GitHub-backed task synchronization should not hammer the service.  The helper
+therefore enforces a minimum interval of five minutes.
+
+#+begin_src sh :tangle ./install-gpt-todos-cron :results none
+#!/usr/bin/env bash
+set -euo pipefail
+
+minutes="${1:-5}"
+[[ "$minutes" =~ ^[0-9]+$ ]] || { echo "usage: $0 [minutes>=5]" >&2; exit 2; }
+(( minutes >= 5 )) || { echo "minimum is 5 minutes" >&2; exit 2; }
+
+sync="${GPT_TODOS_SYNC:-$HOME/.dotfiles/scripts/gpt-todos-sync}"
+line="*/$minutes * * * * /usr/bin/env bash '$sync' >>'$HOME/.local/state/gpt-todos-sync.log' 2>&1"
+mkdir -p "$HOME/.local/state"
+
+( crontab -l 2>/dev/null | grep -v 'gpt-todos-sync' || true; echo "$line" ) | crontab -
+echo "$line"
+#+end_src

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -7,18 +7,53 @@
 This is the canonical literate source for the task-state sync helper.  It keeps
 only =gpt-todos/agenda/*.org= mirrored into the live Org agenda, reconciles the
 private repository through Git, and refuses to silently tolerate known
-literate/generated drift in dotfiles.
+literate/generated drift in dotfiles.  The default durable checkout is
+=~/Documents/gpt-todos=.
+
+The same command also owns deployment.  Run =gpt-todos-sync --deploy 5= to
+perform the initial sync and install the five-minute cron entry.
 
 #+begin_src sh :tangle ./gpt-todos-sync :results none
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/.local/share/gpt-todos}"
+REPO_DIR="${GPT_TODOS_REPO_DIR:-$HOME/Documents/gpt-todos}"
 TASK_DIR="$REPO_DIR/agenda"
 ORG_DIR="${GPT_TODOS_ORG_DIR:-$HOME/Documents/Notes/org/agenda}"
 REMOTE="${GPT_TODOS_REMOTE:-git@github.com:lost-rob0t/gpt-todos.git}"
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
 LOCK="${XDG_RUNTIME_DIR:-/tmp}/gpt-todos-sync-${UID}.lock"
+
+if [[ "${1:-}" == "--deploy" ]]; then
+  minutes="${2:-5}"
+  [[ "$minutes" =~ ^[0-9]+$ ]] || { echo "usage: $0 --deploy [minutes>=5]" >&2; exit 2; }
+  (( minutes >= 5 )) || { echo "minimum is 5 minutes" >&2; exit 2; }
+
+  for cmd in git rsync flock crontab; do
+    command -v "$cmd" >/dev/null || {
+      printf 'gpt-todos-sync: missing deploy dependency: %s\n' "$cmd" >&2
+      exit 4
+    }
+  done
+
+  [[ -d "$DOTFILES_DIR/.git" ]] || {
+    printf 'gpt-todos-sync: dotfiles checkout not found at %s\n' "$DOTFILES_DIR" >&2
+    exit 3
+  }
+
+  if [[ ! -d "$REPO_DIR/.git" ]]; then
+    mkdir -p "$(dirname "$REPO_DIR")"
+    git clone "$REMOTE" "$REPO_DIR"
+  fi
+
+  /usr/bin/env bash "$DOTFILES_DIR/scripts/gpt-todos-sync"
+  GPT_TODOS_SYNC="$DOTFILES_DIR/scripts/gpt-todos-sync" \
+    /usr/bin/env bash "$DOTFILES_DIR/scripts/install-gpt-todos-cron" "$minutes"
+
+  printf 'gpt-todos sync deployed: %s -> %s every %s minutes\n' \
+    "$TASK_DIR" "$ORG_DIR" "$minutes"
+  exit 0
+fi
 
 mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
 exec 9>"$LOCK"

--- a/scripts/install-gpt-todos-cron
+++ b/scripts/install-gpt-todos-cron
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+minutes="${1:-5}"
+[[ "$minutes" =~ ^[0-9]+$ ]] || { echo "usage: $0 [minutes>=5]" >&2; exit 2; }
+(( minutes >= 5 )) || { echo "minimum is 5 minutes" >&2; exit 2; }
+
+sync="${GPT_TODOS_SYNC:-$HOME/.dotfiles/scripts/gpt-todos-sync}"
+line="*/$minutes * * * * /usr/bin/env bash '$sync' >>'$HOME/.local/state/gpt-todos-sync.log' 2>&1"
+mkdir -p "$HOME/.local/state"
+
+( crontab -l 2>/dev/null | grep -v 'gpt-todos-sync' || true; echo "$line" ) | crontab -
+echo "$line"


### PR DESCRIPTION
Moves the local gpt-todos runtime/integration into the repository that actually owns workstation configuration.

- canonical Doom source: `.doom.d/autoload/gpt-todos.org`
- tangled Doom counterpart: `.doom.d/autoload/gpt-todos.el`
- canonical shell source: `scripts/gpt-todos-sync.org`
- tangled shell counterparts: `scripts/gpt-todos-sync` and `scripts/install-gpt-todos-cron`
- default durable checkout: `~/Documents/gpt-todos`
- `bash ~/.dotfiles/scripts/gpt-todos-sync --deploy 5` performs the initial sync and installs the cron entry
- `M-x gpt-todos-sync` runs the dotfiles-owned helper asynchronously in hidden buffer ` *gpt-todos-sync*`
- shell sync reconciles `lost-rob0t/gpt-todos`, mirrors only `agenda/*.org`, and commits/pushes durable task-state changes
- cron installer enforces a minimum 5-minute interval
- sync blocks on generated-only drift and tangles dirty canonical Org sources for known Bash, Doom, Qtile, and GPT-TODO pairs
- `AGENTS.md` records the ownership split: `gpt-todos` owns durable Org state; dotfiles owns local sync/runtime integration

This intentionally keeps the sync executable and Emacs integration in dotfiles. Org sources and committed generated counterparts are changed together.