### PR TITLE
docs: add Org-mode dotfiles wiki

### DIFF
--- a/.config/qtile/qtile.org
+++ b/.config/qtile/qtile.org
@@ -1,11 +1,11 @@
 #+title: Qtile Configuration
 
 * Canonical configuration
-The active Qtile configuration is [[file:config.py][config.py]].
+The active Qtile configuration is generated at [[file:config.py][config.py]], but its canonical editable source is [[file:qtile-ai.org][qtile-ai.org]].
 
-This file previously duplicated the complete Python configuration and tangled it into =config.py=. The two copies had drifted and the literate copy retained the same runtime bugs as the generated file. The duplicate source has been retired so future fixes and features have one canonical implementation.
+Do not make lasting edits directly in =config.py=. Edit =qtile-ai.org= first, tangle it, and commit the generated =config.py= in the same change. The repository-wide literate source rules are documented in [[file:../../AGENTS.md][AGENTS.md]] and [[file:../../docs/wiki/literate-config.org][the dotfiles wiki]].
 
-Edit =config.py= directly.
+The OpenRouter telemetry helper follows the same rule: [[file:qtile-openrouter.org][qtile-openrouter.org]] is canonical and generates =qtile_openrouter.py=.
 
 * Monitor configuration
 Before Qtile starts, =.xinitrc= runs =scripts/setup-monitors.sh=. The loader looks
@@ -51,7 +51,7 @@ When enabled:
 
 When disabled, Qtile stops enforcing routes and layout thresholds. Existing windows and layouts are left in their current state so they can be rearranged manually.
 
-Application routes are configured in =auto_group_routes= in =config.py=.
+Application routes are configured in =auto_group_routes= in =config.py= and therefore must be changed through =qtile-ai.org=.
 
 * Usage telemetry
 Qtile appends structured JSONL events to:
@@ -84,7 +84,7 @@ The report ranks keybind use, focused and managed applications, unmatched applic
 The raw telemetry includes window titles. Browser page names, document names, terminal titles, and other private information may therefore appear in the JSONL files. Review the raw log or generated report before sharing it.
 
 * Validation
-Run these checks after modifying the configuration:
+After modifying =qtile-ai.org= or related Qtile sources, tangle first and then run:
 
 #+begin_src sh
 python -m py_compile config.py qtile_telemetry.py scripts/qtile-telemetry-summary.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Read this first
+
+Before editing this repository, read this file and treat it as the repository editing contract.
+
 ## Source of truth
 
 This repository uses literate Org configuration. Treat the Org files as source code and tangled files as generated artifacts.
@@ -17,6 +21,25 @@ When a change touches a literate configuration:
 4. Run syntax checks and the relevant tests before merging.
 
 If an existing generated file has no literate source but belongs to a literate subsystem, add or identify the source before extending it. Do not create parallel sources of truth.
+
+## Documentation is part of the change
+
+Keep repository documentation synchronized with the implementation. Documentation drift is a blocking consistency error, just like literate/generated drift.
+
+For every change, determine whether it affects documented behavior or repository structure. If it changes behavior, architecture, ownership, deployment, interfaces, workflows, host/profile names, commands, important invariants, or a canonical source/generated mapping, update the relevant documentation in the same branch and PR.
+
+Documentation locations include:
+
+- `README.org` for repository entry points and high-level setup;
+- `docs/wiki/` for architecture, ownership, workflows, host/profile maps, maintenance procedures, and cross-subsystem navigation;
+- the canonical literate Org source for configuration-specific rationale, keybindings, widgets, and behavior that belongs next to executable configuration;
+- subsystem-specific docs when they already exist.
+
+Do not create duplicate sources of truth by copying large configuration details into the wiki. Link to the canonical source and document the architecture, invariant, or workflow instead.
+
+When adding or renaming a major subsystem, host/profile, canonical Org source, generated output, or deployment path, update `docs/wiki/index.org` and any affected wiki page so navigation remains accurate.
+
+A change is not complete if the implementation and relevant documentation disagree.
 
 ## Qtile
 

--- a/README.org
+++ b/README.org
@@ -1,6 +1,7 @@
 #+TITLE: Readme
 
 * Index
++ [[./docs/wiki/index.org][Dotfiles wiki]]
 + [[./bash.org][Bash]]
 + [[./.doom.d/config.org][Emacs config]]
 + [[./.config/qtile/qtile.org][Qtile Config]]

--- a/README.org
+++ b/README.org
@@ -4,9 +4,10 @@
 + [[./docs/wiki/index.org][Dotfiles wiki]]
 + [[./bash.org][Bash]]
 + [[./.doom.d/config.org][Emacs config]]
-+ [[./.config/qtile/qtile.org][Qtile Config]]
++ [[./.config/qtile/qtile-ai.org][Qtile literate config]]
++ [[./.config/qtile/qtile.org][Qtile runtime notes]]
 + [[./.config/dunst/dunst.org][Dunst Config]]
-+ [[./todo.org][Todo List]]
++ [[./tasks.org][Todo List]]
 
 
 

--- a/README.org
+++ b/README.org
@@ -1,7 +1,13 @@
 #+TITLE: Readme
 
+* Agent instructions
+Before editing this repository, read [[./AGENTS.md][AGENTS.md]] and follow it as the repository editing contract.
+
+In particular, keep literate Org sources and their tangled/generated outputs synchronized, and update the relevant documentation in the same change whenever behavior, architecture, ownership, deployment, interfaces, workflows, host/profile names, or important invariants change.
+
 * Index
 + [[./docs/wiki/index.org][Dotfiles wiki]]
++ [[./AGENTS.md][Agent instructions]]
 + [[./bash.org][Bash]]
 + [[./.doom.d/config.org][Emacs config]]
 + [[./.config/qtile/qtile-ai.org][Qtile literate config]]

--- a/docs/wiki/desktop.org
+++ b/docs/wiki/desktop.org
@@ -1,0 +1,50 @@
+#+TITLE: Dotfiles Wiki - Desktop and Qtile
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Qtile ownership
+The primary Qtile configuration is literate:
+
+| Source | Generated output | Responsibility |
+|--------+------------------+----------------|
+| [[file:../../.config/qtile/qtile-ai.org][qtile-ai.org]] | [[file:../../.config/qtile/config.py][config.py]] | Core Qtile configuration, groups, layouts, keybindings, widgets, hooks, and screens. |
+| [[file:../../.config/qtile/qtile-openrouter.org][qtile-openrouter.org]] | [[file:../../.config/qtile/qtile_openrouter.py][qtile_openrouter.py]] | OpenRouter telemetry and its dynamic sync/reload integration. |
+
+The main Org source describes itself as modular and self-documenting.  Prefer improving that source when documenting a concrete keybinding or widget rather than duplicating the detail here.
+
+* Important invariants
+The repository editing rules require Qtile sync/reload behavior to:
+- use the shared =git-sync= implementation;
+- avoid blocking Qtile's event loop while Git runs;
+- reload only after a successful sync;
+- send desktop notifications for start, success, and failure;
+- retain the existing 1 Hz OpenRouter telemetry behavior unless deliberately changed.
+
+The dynamic =Super+Ctrl+Shift+R= binding belongs to the OpenRouter telemetry helper.  Keep its documentation and generated implementation synchronized with =qtile-openrouter.org=.
+
+* Desktop integration map
+Qtile-related files live under [[file:../../.config/qtile/][.config/qtile/]].  Besides the generated main config, that tree contains widgets, helper scripts, icons, autostart integration, and support code.
+
+Related desktop configuration is spread through =.config/= and Home Manager modules.  Before moving a file into Home Manager, check whether it is currently Stow-managed.  Avoid creating two deployment owners for the same path.
+
+* Edit and test cycle
+1. Edit the relevant Qtile Org source.
+2. Tangle it.
+3. Confirm only the expected generated Python files changed.
+4. Compile the generated Python.
+5. Exercise the affected keybinding/widget/hook in a running Qtile session.
+
+#+begin_src shell
+  cd ~/.dotfiles
+  python -m py_compile .config/qtile/config.py
+  python -m py_compile .config/qtile/qtile_openrouter.py
+#+end_src
+
+For a sync/reload change, test both successful and failed Git sync paths so notification and reload behavior do not quietly rot.
+
+* Other desktop sources
+- [[file:../../.config/dunst/dunst.org][Dunst literate config]] - notification daemon configuration.
+- [[file:../../.xprofile][.xprofile]] and [[file:../../.xinitrc][.xinitrc]] - X session startup pieces.
+- [[file:../../nix/home-manager/][Home Manager modules]] - declarative desktop packages/files where ownership has moved into Nix.
+
+When a desktop file has a literate source, treat that source as canonical even if the generated file is the one the application actually reads.

--- a/docs/wiki/emacs.org
+++ b/docs/wiki/emacs.org
@@ -9,7 +9,7 @@ The Doom configuration is literate.
 |--------+----------------------------+---------|
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/config.el][config.el]] | Main Emacs/Doom behavior. |
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][init.el]] | Doom module selection from an explicitly tangled block. |
-| [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][packages.el]] | Package declarations and package configuration. |
+| [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][packages.el]] | Doom package declarations. |
 | [[file:../../.doom.d/snippets/][.doom.d/snippets/]] | n/a | Yasnippet and Org helper snippets. |
 
 The top of =config.org= declares =config.el= as its default tangle target, while individual blocks may override the target.  Read block-level =:tangle= arguments before assuming one Org file produces only one output.
@@ -40,14 +40,14 @@ Batch tangle example:
 #+end_src
 
 * Useful verification
-Check generated Elisp can at least be read by Emacs before blaming Doom, Mercury retrograde, or package maintainers.
+A lightweight structural check can run without booting the full Doom environment:
 
 #+begin_src shell
   emacs --batch -Q \
-    --eval '(progn (byte-compile-file ".doom.d/config.el") t)'
+    --eval '(with-temp-buffer (insert-file-contents ".doom.d/config.el") (emacs-lisp-mode) (check-parens))'
 #+end_src
 
-Byte compilation may expose environment-dependent package warnings, so treat it as a fast syntax/static check rather than a complete Doom integration test.
+This catches unbalanced delimiters but is not a substitute for loading the configuration under Doom.
 
 For package/module changes:
 

--- a/docs/wiki/emacs.org
+++ b/docs/wiki/emacs.org
@@ -1,0 +1,59 @@
+#+TITLE: Dotfiles Wiki - Emacs and Doom
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Main Doom sources
+The Doom configuration is literate.
+
+| Source | Generated / related output | Purpose |
+|--------+----------------------------+---------|
+| [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/config.el][config.el]] | Main Emacs/Doom behavior. |
+| [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][init.el]] | Doom module selection from an explicitly tangled block. |
+| [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][packages.el]] | Package declarations and package configuration. |
+| [[file:../../.doom.d/snippets/][.doom.d/snippets/]] | n/a | Yasnippet and Org helper snippets. |
+
+The top of =config.org= declares =config.el= as its default tangle target, while individual blocks may override the target.  Read block-level =:tangle= arguments before assuming one Org file produces only one output.
+
+* Other Emacs code
+The repository also contains reusable or experimental Emacs-related code outside =.doom.d=:
+- [[file:../../emacs/][emacs/]] - Emacs packages/tools maintained in the dotfiles tree;
+- [[file:../../hackmode/][hackmode/]] - hackmode-related code;
+- [[file:../../lisp/][lisp/]] - Lisp utilities and older components;
+- [[file:../../exwm/][exwm/]] - EXWM configuration/code.
+
+Several of these areas contain their own Org literate sources.  Apply the same source-first/tangle-second rule described in [[file:literate-config.org][Literate configuration]].
+
+* Normal edit cycle
+1. Edit =.doom.d/config.org= or =.doom.d/packages.org=.
+2. Tangle the changed Org file.
+3. Inspect =config.el=, =init.el=, or =packages.el= diffs.
+4. Run =doom sync= when module/package state changed.
+5. Start or reload Doom and exercise the changed feature.
+
+Batch tangle example:
+
+#+begin_src shell
+  cd ~/.dotfiles
+  emacs --batch \
+    --eval '(require (quote org))' \
+    --eval '(org-babel-tangle-file ".doom.d/config.org")'
+#+end_src
+
+* Useful verification
+Check generated Elisp can at least be read by Emacs before blaming Doom, Mercury retrograde, or package maintainers.
+
+#+begin_src shell
+  emacs --batch -Q \
+    --eval '(progn (byte-compile-file ".doom.d/config.el") t)'
+#+end_src
+
+Byte compilation may expose environment-dependent package warnings, so treat it as a fast syntax/static check rather than a complete Doom integration test.
+
+For package/module changes:
+
+#+begin_src shell
+  doom sync
+#+end_src
+
+* Documentation discipline
+Put configuration rationale next to the executable Org source whenever it explains a specific setting.  Use this wiki for architecture, ownership, workflow, and navigation.  This keeps the literate config genuinely literate instead of making readers hunt through two competing manuals.

--- a/docs/wiki/getting-started.org
+++ b/docs/wiki/getting-started.org
@@ -1,0 +1,57 @@
+#+TITLE: Dotfiles Wiki - Getting Started
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Repository
+The repository is intended to be cloned as =~/.dotfiles=.
+
+#+begin_src shell
+  git clone git@github.com:lost-rob0t/dotfiles.git ~/.dotfiles
+  cd ~/.dotfiles
+#+end_src
+
+The root [[file:../../README.org][README.org]] remains the short public entry point.  This wiki carries the operational detail.
+
+* Two deployment models
+** GNU Stow
+For files managed directly from the repository tree, run Stow from the repository root.
+
+#+begin_src shell
+  cd ~/.dotfiles
+  stow .
+#+end_src
+
+Use this for the traditional dotfile tree where the repository path mirrors =$HOME=.
+
+** Home Manager / Nix
+The flake exposes standalone Home Manager profiles and NixOS outputs.  Inspect them first rather than guessing at a hostname like a civilized mammal.
+
+#+begin_src shell
+  cd ~/.dotfiles
+  nix flake show
+#+end_src
+
+Current Home Manager outputs include:
+- =unseen@logos=
+- =unseen@flake=
+- =unseen@desktop=
+- =unseen@hunter02=
+
+A first activation can be run without a globally installed =home-manager= command:
+
+#+begin_src shell
+  nix run github:nix-community/home-manager/release-26.05 -- switch --flake '.#unseen@logos'
+#+end_src
+
+For the more detailed Logos bootstrap path, see [[file:../logos-home-manager-bootstrap.md][Logos Home Manager bootstrap]].
+
+* Main entry points
+- [[file:../../flake.nix][flake.nix]] - Nix outputs, applications, installers, checks, and profiles.
+- [[file:../../bash.org][bash.org]] - Bash configuration source.
+- [[file:../../.doom.d/config.org][.doom.d/config.org]] - Doom Emacs configuration source.
+- [[file:../../.doom.d/packages.org][.doom.d/packages.org]] - Doom package source.
+- [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] - primary Qtile source.
+- [[file:../../AGENTS.md][AGENTS.md]] - editing rules that apply before changing literate configuration.
+
+* Before changing anything
+Read [[file:literate-config.org][Literate configuration]].  If an Org file tangles a generated file, edit the Org source first and update the generated counterpart in the same change.

--- a/docs/wiki/index.org
+++ b/docs/wiki/index.org
@@ -1,0 +1,34 @@
+#+TITLE: Dotfiles Wiki
+#+AUTHOR: nsaspy
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Purpose
+This wiki is the operational map for the dotfiles repository.
+
+The configuration itself remains the source of truth.  In particular, literate Org files are executable documentation and their tangled files are generated artifacts.  The wiki should explain where things live, how they fit together, and how to change them without creating a second source of truth.
+
+* Start here
+- [[file:getting-started.org][Getting started]] - clone, Stow, Home Manager, and the main repository entry points.
+- [[file:literate-config.org][Literate configuration]] - canonical Org sources, generated files, tangling, and consistency rules.
+- [[file:nix.org][Nix and Home Manager]] - flake outputs, hosts, profiles, installers, and module layout.
+- [[file:emacs.org][Emacs and Doom]] - Doom literate sources and Emacs-related code in the repository.
+- [[file:desktop.org][Desktop and Qtile]] - Qtile, widgets, keybindings, notifications, and desktop integration.
+- [[file:maintenance.org][Maintenance]] - safe edit/tangle/test workflow and useful verification commands.
+
+* Repository map
+| Area | Canonical entry point | Notes |
+|------+-----------------------+-------|
+| Shell | [[file:../../bash.org][bash.org]] | Literate Bash configuration; tangles to =.bashrc=. |
+| Doom Emacs | [[file:../../.doom.d/config.org][.doom.d/config.org]] | Main Doom configuration and =init.el= source blocks. |
+| Doom packages | [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | Package declarations; tangles to =packages.el=. |
+| Qtile | [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | Main Qtile literate source; tangles to =config.py=. |
+| OpenRouter widget | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | Telemetry/widget helper; tangles to =qtile_openrouter.py=. |
+| Nix flake | [[file:../../flake.nix][flake.nix]] | NixOS, Home Manager, installer, and package outputs. |
+| Home Manager | [[file:../../nix/home-manager/][nix/home-manager/]] | Shared modules/files and per-system profiles. |
+| NixOS | [[file:../../nix/nixos/][nix/nixos/]] | Hosts and installer definitions. |
+| Scripts | [[file:../../scripts/][scripts/]] | Provisioning/install/maintenance helpers. |
+| Agent rules | [[file:../../AGENTS.md][AGENTS.md]] | Repository editing and parity requirements. |
+
+* Wiki rule
+Do not copy large sections of configuration into this wiki merely to describe them.  Link to the canonical Org source and document the architecture, workflow, or invariant instead.  Humans already invented stale documentation once; there is no need to perfect the mistake.

--- a/docs/wiki/literate-config.org
+++ b/docs/wiki/literate-config.org
@@ -1,0 +1,64 @@
+#+TITLE: Dotfiles Wiki - Literate Configuration
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Source-of-truth rule
+This repository uses Org Babel as a configuration source format.  When a literate source exists, the Org file is canonical and the tangled output is generated.
+
+Never make a lasting change only in a generated file.  A generated-file-only edit is configuration drift wearing a fake mustache.
+
+* Known canonical pairs
+| Org source | Generated output | Role |
+|------------+------------------+------|
+| [[file:../../bash.org][bash.org]] | [[file:../../.bashrc][.bashrc]] | Interactive Bash configuration. |
+| [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/config.el][.doom.d/config.el]] | Main Doom configuration. |
+| [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][.doom.d/init.el]] | Doom module selection, tangled from an explicit block. |
+| [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][.doom.d/packages.el]] | Doom package declarations. |
+| [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | [[file:../../.config/qtile/config.py][.config/qtile/config.py]] | Main Qtile configuration. |
+| [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | [[file:../../.config/qtile/qtile_openrouter.py][.config/qtile/qtile_openrouter.py]] | OpenRouter telemetry helper. |
+
+Other Org files may also tangle generated outputs.  Check their =#+property: header-args= lines and individual source-block =:tangle= arguments before editing related generated files.
+
+* Change workflow
+1. Identify the canonical Org source.
+2. Edit the Org source first.
+3. Tangle the affected source.
+4. Inspect the generated diff.
+5. Verify source and generated output remain synchronized.
+6. Run syntax checks and subsystem tests.
+7. Commit the Org source and generated files together.
+
+* Tangling
+From Emacs, open the canonical Org file and use =org-babel-tangle=.
+
+A batch form is useful for repeatable verification:
+
+#+begin_src shell
+  emacs --batch \
+    --eval '(require (quote org))' \
+    --eval '(org-babel-tangle-file ".doom.d/config.org")'
+#+end_src
+
+Substitute the actual Org source being changed.  Tangling may write more than one file when a source contains per-block =:tangle= destinations.
+
+* Drift checks
+After tangling, inspect exactly what changed:
+
+#+begin_src shell
+  git status --short
+  git diff --check
+  git diff -- bash.org .bashrc
+#+end_src
+
+For another subsystem, replace the final paths with that subsystem's canonical/generated pair.
+
+A clean retangle followed by no unexpected diff is the simplest useful parity test.
+
+* New literate configuration
+When adding a configuration file to a subsystem that is already literate:
+- prefer adding it to an existing appropriate Org source, or create a clearly named Org source;
+- declare the generated destination explicitly with =:tangle=;
+- commit both source and generated output when the generated file belongs in the repository;
+- document the new canonical pair in this page if it is a major entry point.
+
+Do not create parallel editable Org and generated sources with unclear authority.  Future-you has enough enemies already.

--- a/docs/wiki/maintenance.org
+++ b/docs/wiki/maintenance.org
@@ -1,0 +1,89 @@
+#+TITLE: Dotfiles Wiki - Maintenance
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Safe change loop
+For ordinary changes:
+1. Pull/rebase onto the intended base branch.
+2. Identify the deployment owner and, for literate subsystems, the canonical Org source.
+3. Edit the canonical source.
+4. Tangle generated outputs when applicable.
+5. Inspect the diff before running broad formatters or sync commands.
+6. Run focused syntax/tests first, then repository-level checks.
+7. Commit source and generated counterparts together.
+
+* Quick status
+#+begin_src shell
+  cd ~/.dotfiles
+  git status --short
+  git diff --check
+#+end_src
+
+* Literate parity
+See [[file:literate-config.org][Literate configuration]] for the source map.
+
+A useful manual parity pattern is:
+#+begin_src shell
+  # tangle the canonical Org source, then inspect what changed
+  git status --short
+  git diff --check
+#+end_src
+
+Unexpected generated changes are a reason to investigate, not free bonus code.
+
+* Focused checks
+** Bash
+#+begin_src shell
+  bash -n .bashrc
+#+end_src
+
+** Qtile
+#+begin_src shell
+  python -m py_compile .config/qtile/config.py
+  python -m py_compile .config/qtile/qtile_openrouter.py
+#+end_src
+
+** Emacs Lisp structure
+This checks balanced delimiters without trying to boot the full Doom environment:
+
+#+begin_src shell
+  emacs --batch -Q \
+    --eval '(with-temp-buffer (insert-file-contents ".doom.d/config.el") (emacs-lisp-mode) (check-parens))'
+#+end_src
+
+For package/module changes, also run:
+
+#+begin_src shell
+  doom sync
+#+end_src
+
+** Nix
+#+begin_src shell
+  nix flake check
+#+end_src
+
+Run =nix fmt= when Nix files need formatting, then inspect the diff.
+
+* Git sync ownership
+The shared Git synchronization helper is intentionally reusable.  Bash, Qtile, and Home Manager integrations should consume the same implementation rather than growing slightly different copies that eventually disagree in entertaining ways.
+
+See [[file:../../AGENTS.md][AGENTS.md]] for the current =git-sync= invariants.
+
+* Stow versus Home Manager
+Before changing where a file is installed, determine who owns the target path:
+- repository/Stow;
+- Home Manager;
+- an application-generated file;
+- a tangled output.
+
+Do not have Stow and Home Manager both own the same target merely because both mechanisms can.  The resulting conflict is technically deterministic and emotionally stupid.
+
+* Updating this wiki
+Update the wiki when one of these changes:
+- a major canonical Org/generated pair;
+- a host or Home Manager profile name;
+- a deployment mechanism;
+- a subsystem ownership boundary;
+- an important maintenance/test invariant.
+
+Do not mirror routine keybindings, package lists, or line-by-line configuration here.  Those belong in the literate source itself.

--- a/docs/wiki/nix.org
+++ b/docs/wiki/nix.org
@@ -1,0 +1,78 @@
+#+TITLE: Dotfiles Wiki - Nix and Home Manager
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:nil
+
+* Flake overview
+[[file:../../flake.nix][flake.nix]] is the main Nix entry point.  The repository currently tracks NixOS 26.05 and Home Manager 26.05 inputs.
+
+The flake provides:
+- NixOS configurations;
+- standalone Home Manager configurations;
+- installer applications;
+- buildable packages;
+- checks;
+- a Nix formatter.
+
+* NixOS outputs
+| Output | Source | Purpose |
+|--------+--------+---------|
+| =nixosConfigurations.logos= | [[file:../../nix/nixos/hosts/logos/][nix/nixos/hosts/logos/]] | Main Logos NixOS host. |
+| =nixosConfigurations.logos-iso= | [[file:../../nix/nixos/installer/logos-iso.nix][nix/nixos/installer/logos-iso.nix]] | Installer ISO configuration. |
+
+* Home Manager outputs
+| Output | System source |
+|--------+---------------|
+| =unseen@logos= | [[file:../../nix/home-manager/systems/logos/home.nix][systems/logos/home.nix]] |
+| =unseen@flake= | [[file:../../nix/home-manager/systems/desktop/home.nix][systems/desktop/home.nix]] |
+| =unseen@desktop= | [[file:../../nix/home-manager/systems/desktop/home.nix][systems/desktop/home.nix]] |
+| =unseen@hunter02= | [[file:../../nix/home-manager/systems/hunter02/home.nix][systems/hunter02/home.nix]] |
+
+The Home Manager tree is split into:
+- [[file:../../nix/home-manager/files/][files/]] - file payloads managed by Home Manager;
+- [[file:../../nix/home-manager/mods/][mods/]] - reusable modules;
+- [[file:../../nix/home-manager/systems/][systems/]] - host/profile composition.
+
+* Installer applications
+The flake exposes =install-logos= and =install-logos-gui=.  Their shell implementations live under [[file:../../scripts/][scripts/]].
+
+Useful discovery commands:
+
+#+begin_src shell
+  cd ~/.dotfiles
+  nix flake show
+  nix flake check
+#+end_src
+
+To build a specific Home Manager activation without switching:
+
+#+begin_src shell
+  nix build '.#homeConfigurations."unseen@desktop".activationPackage'
+#+end_src
+
+* Switching a Home Manager profile
+For an existing machine with Nix installed:
+
+#+begin_src shell
+  cd ~/.dotfiles
+  home-manager switch --flake '.#unseen@desktop'
+#+end_src
+
+If =home-manager= is not installed globally, bootstrap through Nix:
+
+#+begin_src shell
+  nix run github:nix-community/home-manager/release-26.05 -- switch --flake '.#unseen@logos'
+#+end_src
+
+See [[file:../logos-home-manager-bootstrap.md][Logos Home Manager bootstrap]] for the existing Logos-specific notes.
+
+* Editing rule
+Host-specific composition belongs under =nix/home-manager/systems/= or =nix/nixos/hosts/=.  Reusable behavior belongs in modules rather than being copied between hosts.  Keep =flake.nix= focused on wiring outputs together.
+
+After Nix changes, run at minimum:
+
+#+begin_src shell
+  nix fmt -- --check
+  nix flake check
+#+end_src
+
+If the formatter invocation differs on the installed Nix version, run =nix fmt= and inspect the resulting diff before committing.


### PR DESCRIPTION
## Summary

- add an Org-mode wiki under `docs/wiki/` covering setup, literate configuration, Nix/Home Manager, Doom Emacs, Qtile/desktop, and maintenance
- link the wiki from `README.org`
- require agents to read `AGENTS.md` before editing
- make documentation updates part of the same change as behavior/architecture/ownership/deployment/workflow changes
- align `.config/qtile/qtile.org` with the repository rule that `qtile-ai.org` is canonical and `config.py` is generated

## Consistency

This change is documentation-only. No tangled runtime output was modified. The branch diff contains only Org/Markdown documentation and navigation changes.

## Validation

- reviewed canonical Org/generated mappings against `AGENTS.md` and source file tangle declarations
- verified the branch is based directly on current `master`
- verified the final compare contains only the intended documentation files