### PR TITLE
Add GPT TODO Home Manager module

### DIFF
--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -6,6 +6,25 @@ let
     runtimeInputs = [ pkgs.git ];
     text = builtins.readFile ../../../.config/bash/git-sync.sh;
   };
+
+  gptTodosSync = pkgs.writeShellApplication {
+    name = "gpt-todos-sync";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.git
+      pkgs.rsync
+      pkgs.util-linux
+      pkgs.cronie
+    ];
+    text = builtins.readFile ../../../scripts/gpt-todos-sync;
+  };
+
+  installGptTodosCron = pkgs.writeShellApplication {
+    name = "install-gpt-todos-cron";
+    runtimeInputs = [ pkgs.cronie ];
+    text = builtins.readFile ../../../scripts/install-gpt-todos-cron;
+  };
 in
 {
   options = {
@@ -32,6 +51,10 @@ in
       starship
       curl
 
-    ]) ++ [ gitSync ];
+    ]) ++ [
+      gitSync
+      gptTodosSync
+      installGptTodosCron
+    ];
   };
 }

--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -6,25 +6,6 @@ let
     runtimeInputs = [ pkgs.git ];
     text = builtins.readFile ../../../.config/bash/git-sync.sh;
   };
-
-  gptTodosSync = pkgs.writeShellApplication {
-    name = "gpt-todos-sync";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.git
-      pkgs.rsync
-      pkgs.util-linux
-      pkgs.cronie
-    ];
-    text = builtins.readFile ../../../scripts/gpt-todos-sync;
-  };
-
-  installGptTodosCron = pkgs.writeShellApplication {
-    name = "install-gpt-todos-cron";
-    runtimeInputs = [ pkgs.cronie ];
-    text = builtins.readFile ../../../scripts/install-gpt-todos-cron;
-  };
 in
 {
   options = {
@@ -51,10 +32,6 @@ in
       starship
       curl
 
-    ]) ++ [
-      gitSync
-      gptTodosSync
-      installGptTodosCron
-    ];
+    ]) ++ [ gitSync ];
   };
 }

--- a/nix/home-manager/mods/emacs.nix
+++ b/nix/home-manager/mods/emacs.nix
@@ -5,6 +5,10 @@
   ...
 }:
 {
+  imports = [
+    ./gpt-todos.nix
+  ];
+
   options = with lib; {
     emacs = {
       enable = mkOption {

--- a/nix/home-manager/mods/gpt-todos.nix
+++ b/nix/home-manager/mods/gpt-todos.nix
@@ -1,0 +1,37 @@
+{ lib, pkgs, config, ... }:
+
+let
+  gptTodosSync = pkgs.writeShellApplication {
+    name = "gpt-todos-sync";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.git
+      pkgs.rsync
+      pkgs.util-linux
+      pkgs.cronie
+      config.emacs.package
+    ];
+    text = builtins.readFile ../../../scripts/gpt-todos-sync;
+  };
+
+  installGptTodosCron = pkgs.writeShellApplication {
+    name = "install-gpt-todos-cron";
+    runtimeInputs = [ pkgs.cronie ];
+    text = builtins.readFile ../../../scripts/install-gpt-todos-cron;
+  };
+in
+{
+  options.gptTodos.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = "Install GPT TODO Org synchronization commands.";
+  };
+
+  config = lib.mkIf (config.emacs.enable && config.gptTodos.enable) {
+    home.packages = [
+      gptTodosSync
+      installGptTodosCron
+    ];
+  };
+}


### PR DESCRIPTION
Adds a dedicated `nix/home-manager/mods/gpt-todos.nix` module for the Org task sync runtime and imports it from the Emacs module.

- `emacs.nix` imports `gpt-todos.nix`
- module is enabled by default only when `emacs.enable` is true
- exposes `gpt-todos-sync` on PATH
- exposes `install-gpt-todos-cron` on PATH
- packages git/rsync/flock/crontab/find/coreutils and the configured Emacs package as runtime dependencies
- keeps `scripts/gpt-todos-sync.org` canonical; no generated script content is changed
- leaves the base module untouched

After Home Manager activation, both commands should resolve from the user profile.