### PR TITLE
fix(desktop): make Brave launch/discovery reliable under Qtile

### DIFF
--- a/.config/qtile/tests/test_brave_launcher_session.py
+++ b/.config/qtile/tests/test_brave_launcher_session.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regression coverage for Brave launch/discovery under the Qtile LightDM session."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+XPROFILE = ROOT / ".xprofile"
+DESKTOP_NIX = ROOT / "nix" / "home-manager" / "mods" / "desktop.nix"
+QTILE_CONFIG = ROOT / ".config" / "qtile" / "config.py"
+
+
+class BraveLauncherSessionTests(unittest.TestCase):
+    def test_xprofile_loads_home_manager_session_and_application_data(self):
+        source = XPROFILE.read_text(encoding="utf-8")
+        self.assertIn("hm-session-vars.sh", source)
+        self.assertIn('$HOME/.nix-profile/share', source)
+        self.assertIn("XDG_DATA_DIRS", source)
+
+    def test_desktop_home_manager_owns_xprofile_link(self):
+        source = DESKTOP_NIX.read_text(encoding="utf-8")
+        self.assertIn('home.file.".xprofile"', source)
+        self.assertIn("mkOutOfStoreSymlink", source)
+        self.assertIn('"${config.home.homeDirectory}/.dotfiles/.xprofile"', source)
+        self.assertIn("force = true;", source)
+
+    def test_desktop_home_manager_declares_local_brave_desktop_entry(self):
+        source = DESKTOP_NIX.read_text(encoding="utf-8")
+        self.assertIn("xdg.desktopEntries.brave", source)
+        self.assertIn('exec = "${pkgs.brave}/bin/brave %U";', source)
+        self.assertIn('categories = [ "Network" "WebBrowser" ];', source)
+
+    def test_qtile_super_w_still_targets_brave(self):
+        source = QTILE_CONFIG.read_text(encoding="utf-8")
+        self.assertIn('Key([mod], "w", lazy.spawn("brave"), desc="Launch Brave")', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_brave_launcher_session.py
+++ b/.config/qtile/tests/test_brave_launcher_session.py
@@ -19,11 +19,10 @@ class BraveLauncherSessionTests(unittest.TestCase):
         self.assertIn('$HOME/.nix-profile/share', source)
         self.assertIn("XDG_DATA_DIRS", source)
 
-    def test_desktop_home_manager_owns_xprofile_link(self):
+    def test_desktop_home_manager_owns_xprofile(self):
         source = DESKTOP_NIX.read_text(encoding="utf-8")
         self.assertIn('home.file.".xprofile"', source)
-        self.assertIn("mkOutOfStoreSymlink", source)
-        self.assertIn('"${config.home.homeDirectory}/.dotfiles/.xprofile"', source)
+        self.assertIn("source = ../../../.xprofile;", source)
         self.assertIn("force = true;", source)
 
     def test_desktop_home_manager_declares_local_brave_desktop_entry(self):

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -16,11 +16,11 @@
   };
 
   config = lib.mkIf config.desktop.enable {
-    # LightDM sources ~/.xprofile before starting Qtile. Keep that link under
+    # LightDM sources ~/.xprofile before starting Qtile. Keep that file under
     # Home Manager ownership so a fresh checkout/activation cannot silently
     # omit the session environment merely because `stow .` was not re-run.
     home.file.".xprofile" = {
-      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/.xprofile";
+      source = ../../../.xprofile;
       force = true;
     };
 

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -16,6 +16,26 @@
   };
 
   config = lib.mkIf config.desktop.enable {
+    # LightDM sources ~/.xprofile before starting Qtile. Keep that link under
+    # Home Manager ownership so a fresh checkout/activation cannot silently
+    # omit the session environment merely because `stow .` was not re-run.
+    home.file.".xprofile" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/.xprofile";
+      force = true;
+    };
+
+    # Put Brave in XDG_DATA_HOME as well as the Nix profile. j4-dmenu-desktop
+    # always searches the user application directory, so discovery no longer
+    # depends solely on XDG_DATA_DIRS inherited by the current X session.
+    xdg.desktopEntries.brave = {
+      name = "Brave";
+      genericName = "Web Browser";
+      exec = "${pkgs.brave}/bin/brave %U";
+      icon = "brave-browser";
+      terminal = false;
+      categories = [ "Network" "WebBrowser" ];
+    };
+
     # Define a desktop item (for example, a Hibernate shortcut)
     desktop.hibernateDesktop = pkgs.makeDesktopItem {
       name = "Hibernate";


### PR DESCRIPTION
## Root cause

The existing LightDM fix in `.xprofile` is correct, but the file is still deployed only through GNU Stow. Pulling dotfiles or running the standalone Home Manager activation does not create a newly-added `~/.xprofile` symlink, so Qtile can start without the Home Manager `PATH`/`XDG_DATA_DIRS`. In that state the existing `Super+W -> brave` binding cannot resolve Brave and `j4-dmenu-desktop` cannot see Brave's profile desktop entry.

## Fix

- make the desktop Home Manager module own `~/.xprofile` from the canonical tracked root `.xprofile`, with `force = true` so it replaces the stale/missing Stow deployment path;
- add an explicit `xdg.desktopEntries.brave` entry whose `Exec` uses the absolute Nix package path, so application-menu discovery no longer depends solely on inherited `XDG_DATA_DIRS`;
- leave `.config/qtile/config.py` untouched because its declared canonical source `qtile-ai.org` is already drifted on `master`; do not deepen generated-only drift merely to special-case Brave;
- add regression tests for the session bootstrap, Home Manager ownership, local Brave desktop entry, and the existing `Super+W` binding.

## Deployment

After merge/pull, activate `.#homeConfigurations."unseen@desktop"`. The application-menu entry is then present immediately. A LightDM logout/login is required once so the already-running Qtile process inherits the corrected Home Manager `PATH` for the bare `brave` keybinding.

## Validation

- branch is based directly on current `master`;
- compare contains exactly the desktop Home Manager module plus the new regression test;
- GitHub CI is the executable Nix/test gate for this connector-authored change.