### PR TITLE
feat(home-manager): add checked daily auto-updates

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n scripts/*.sh .bash_profile .config/bash/git-sync.sh
-          shellcheck --severity=warning scripts/*.sh .bash_profile .config/bash/git-sync.sh
+          bash -n scripts/*.sh tests/home-manager-updater.sh .bash_profile .config/bash/git-sync.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh .bash_profile .config/bash/git-sync.sh
+      - name: Run Home Manager updater recovery tests
+        run: bash tests/home-manager-updater.sh
       - name: Check Qtile Python helpers
         run: >-
           python3 -m py_compile
@@ -59,3 +61,5 @@ jobs:
         run: nix flake check --no-build --show-trace
       - name: Evaluate desktop Home Manager configuration
         run: nix eval --raw '.#homeConfigurations."unseen@desktop".activationPackage.drvPath'
+      - name: Evaluate flake Home Manager configuration
+        run: nix eval --raw '.#homeConfigurations."unseen@flake".activationPackage.drvPath'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b
+      - uses: devops-actions/actionlint@f9ec6b423d04a7f7a9f6872b1a16fd8313a7db62
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Check shell scripts

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          issues="$(gh issue list --state open --limit 100 --json number,title)"
+          issues="$(gh issue list --state open --search "\"$FAILURE_ISSUE_TITLE\" in:title" --limit 100 --json number,title)"
           number="$(printf '%s\n' "$issues" | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1)"
           if [[ -n "$number" ]]; then
             gh issue close "$number" --comment "Daily flake update recovered successfully in run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          issues="$(gh issue list --state all --limit 100 --json number,title,state 2>/dev/null || printf '[]')"
+          issues="$(gh issue list --state all --search "\"$FAILURE_ISSUE_TITLE\" in:title" --limit 100 --json number,title,state 2>/dev/null || printf '[]')"
           number="$(printf '%s\n' "$issues" | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1)"
           body_file="$(mktemp)"
           cat >"$body_file" <<EOF

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,102 @@
+name: Daily flake update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+      timezone: "America/New_York"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: daily-flake-update
+  cancel-in-progress: false
+
+env:
+  FAILURE_ISSUE_TITLE: "Daily flake update failed"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: nix-community
+
+      - name: Update flake inputs in the candidate checkout
+        run: nix flake update
+
+      - name: Check candidate flake before publishing lockfile
+        run: nix flake check --show-trace
+
+      - name: Detect lockfile changes
+        id: lockfile
+        shell: bash
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish checked lockfile
+        if: steps.lockfile.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- flake.lock
+          git commit -m "chore(nix): update flake inputs"
+          git push origin HEAD:master
+
+      - name: Close recovered failure issue
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          issues="$(gh issue list --state open --limit 100 --json number,title)"
+          number="$(printf '%s\n' "$issues" | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1)"
+          if [[ -n "$number" ]]; then
+            gh issue close "$number" --comment "Daily flake update recovered successfully in run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
+          fi
+
+      - name: Create or update canonical failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          issues="$(gh issue list --state all --limit 100 --json number,title,state 2>/dev/null || printf '[]')"
+          number="$(printf '%s\n' "$issues" | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1)"
+          body_file="$(mktemp)"
+          cat >"$body_file" <<EOF
+          The scheduled flake input update failed before a checked lockfile could be published.
+
+          - Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          - Commit checked out: \`$GITHUB_SHA\`
+          - Time: \`$(date --iso-8601=seconds)\`
+
+          The workflow updates inputs in its checkout, runs \`nix flake check --show-trace\`, and only pushes \`flake.lock\` after that check succeeds. This issue is intentionally reused across failures.
+          EOF
+
+          if [[ -n "$number" ]]; then
+            gh issue reopen "$number" >/dev/null 2>&1 || true
+            gh issue edit "$number" --body-file "$body_file"
+          else
+            gh issue create --title "$FAILURE_ISSUE_TITLE" --body-file "$body_file"
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
           inherit pkgs;
           extraSpecialArgs = homeArgs;
           modules = [
-            ./nix/home-manager/systems/desktop/home.nix
+            ./nix/home-manager/systems/flake/home.nix
           ];
         };
         "unseen@desktop" = home-manager.lib.homeManagerConfiguration {
@@ -179,6 +179,7 @@
         logos = logos.config.system.build.toplevel;
         install-logos = installLogos;
         unseen-home = homeConfigurations."unseen@logos".activationPackage;
+        unseen-flake-home = homeConfigurations."unseen@flake".activationPackage;
       };
 
       formatter.${system} = pkgs.nixfmt-rfc-style;

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -16,5 +16,6 @@
     ./proxmox-mcp.nix
     ./discord-mcp.nix
     ./unifi-mcp.nix
+    ./home-manager-updater.nix
   ];
 }

--- a/nix/home-manager/mods/home-manager-updater.nix
+++ b/nix/home-manager/mods/home-manager-updater.nix
@@ -89,8 +89,6 @@ in
     systemd.user.services.home-manager-updater = {
       Unit = {
         Description = "Update and activate Home Manager configuration ${configuration}";
-        Wants = [ "network-online.target" ];
-        After = [ "network-online.target" ];
         OnFailure = [ "home-manager-updater-failure-notification.service" ];
       };
       Service = {

--- a/nix/home-manager/mods/home-manager-updater.nix
+++ b/nix/home-manager/mods/home-manager-updater.nix
@@ -40,10 +40,19 @@ let
       if [[ ! -s "$failure_file" ]]; then
         exit 0
       fi
-      notification_id="$(notify-send --print-id --urgency=critical --expire-time=0 \
-        --app-name="Home Manager Updater" \
-        "Home Manager auto-update failed" \
-        "$(cat "$failure_file")")"
+      if [[ -s "$id_file" ]]; then
+        old_id="$(cat "$id_file")"
+        notification_id="$(notify-send --print-id --replace-id="$old_id" \
+          --urgency=critical --expire-time=0 \
+          --app-name="Home Manager Updater" \
+          "Home Manager auto-update failed" \
+          "$(cat "$failure_file")")"
+      else
+        notification_id="$(notify-send --print-id --urgency=critical --expire-time=0 \
+          --app-name="Home Manager Updater" \
+          "Home Manager auto-update failed" \
+          "$(cat "$failure_file")")"
+      fi
       printf '%s\n' "$notification_id" >"$id_file"
     '';
   };

--- a/nix/home-manager/mods/home-manager-updater.nix
+++ b/nix/home-manager/mods/home-manager-updater.nix
@@ -1,0 +1,136 @@
+{ config, inputs, lib, pkgs, ... }:
+let
+  cfg = config.homeManagerUpdater;
+  configuration = "${config.home.username}@${cfg.hostName}";
+  dataDir = "${config.home.homeDirectory}/.local/share/home-manager-updater";
+  logrotateConfig = pkgs.writeText "home-manager-updater-logrotate.conf" ''
+    ${dataDir}/update.log {
+      daily
+      rotate 14
+      compress
+      delaycompress
+      missingok
+      notifempty
+      dateext
+    }
+  '';
+  updater = pkgs.writeShellApplication {
+    name = "home-manager-updater";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.git
+      pkgs.gh
+      pkgs.gnused
+      pkgs.jq
+      pkgs.libnotify
+      pkgs.logrotate
+      pkgs.nix
+      inputs.home-manager.packages.${pkgs.system}.home-manager
+    ];
+    text = ''
+      exec ${pkgs.bash}/bin/bash ${../../../scripts/home-manager-updater.sh}
+    '';
+  };
+  notifyFailure = pkgs.writeShellApplication {
+    name = "home-manager-updater-notify-failure";
+    runtimeInputs = [ pkgs.coreutils pkgs.libnotify ];
+    text = ''
+      failure_file=${lib.escapeShellArg "${dataDir}/failure.txt"}
+      id_file=${lib.escapeShellArg "${dataDir}/notification-id"}
+      if [[ ! -s "$failure_file" ]]; then
+        exit 0
+      fi
+      notification_id="$(notify-send --print-id --urgency=critical --expire-time=0 \
+        --app-name="Home Manager Updater" \
+        "Home Manager auto-update failed" \
+        "$(cat "$failure_file")")"
+      printf '%s\n' "$notification_id" >"$id_file"
+    '';
+  };
+in
+{
+  options.homeManagerUpdater = {
+    enable = lib.mkEnableOption "automatic Home Manager updates from a flake";
+
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      description = "Host component used to derive the <user>@<host> Home Manager configuration name.";
+      example = "flake";
+    };
+
+    repository = lib.mkOption {
+      type = lib.types.str;
+      default = "lost-rob0t/dotfiles";
+      description = "GitHub repository containing the Home Manager flake.";
+    };
+
+    branch = lib.mkOption {
+      type = lib.types.str;
+      default = "master";
+      description = "Branch fetched by the updater.";
+    };
+
+    schedule = lib.mkOption {
+      type = lib.types.str;
+      default = "03:00:00";
+      description = "Local systemd calendar time for the daily updater run.";
+    };
+
+    randomizedDelaySec = lib.mkOption {
+      type = lib.types.str;
+      default = "30m";
+      description = "Maximum randomized delay applied to the daily updater timer.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ updater ];
+
+    systemd.user.services.home-manager-updater = {
+      Unit = {
+        Description = "Update and activate Home Manager configuration ${configuration}";
+        Wants = [ "network-online.target" ];
+        After = [ "network-online.target" ];
+        OnFailure = [ "home-manager-updater-failure-notification.service" ];
+      };
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${updater}/bin/home-manager-updater";
+        Environment = [
+          "HM_UPDATER_DATA_DIR=${dataDir}"
+          "HM_UPDATER_REPOSITORY=${cfg.repository}"
+          "HM_UPDATER_REMOTE_URL=https://github.com/${cfg.repository}.git"
+          "HM_UPDATER_BRANCH=${cfg.branch}"
+          "HM_UPDATER_CONFIGURATION=${configuration}"
+          "HM_UPDATER_LOGROTATE_CONFIG=${logrotateConfig}"
+          "GIT_TERMINAL_PROMPT=0"
+        ];
+      };
+    };
+
+    systemd.user.timers.home-manager-updater = {
+      Unit.Description = "Daily Home Manager updater for ${configuration}";
+      Timer = {
+        OnCalendar = "*-*-* ${cfg.schedule}";
+        Persistent = true;
+        RandomizedDelaySec = cfg.randomizedDelaySec;
+        AccuracySec = "5m";
+        Unit = "home-manager-updater.service";
+      };
+      Install.WantedBy = [ "timers.target" ];
+    };
+
+    systemd.user.services.home-manager-updater-failure-notification = {
+      Unit = {
+        Description = "Persistent Home Manager updater failure notification";
+        After = [ "graphical-session.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        ExecCondition = "${pkgs.coreutils}/bin/test -s ${dataDir}/failure.txt";
+        ExecStart = "${notifyFailure}/bin/home-manager-updater-notify-failure";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/nix/home-manager/mods/home-manager-updater.nix
+++ b/nix/home-manager/mods/home-manager-updater.nix
@@ -1,4 +1,4 @@
-{ config, inputs, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 let
   cfg = config.homeManagerUpdater;
   configuration = "${config.home.username}@${cfg.hostName}";
@@ -25,7 +25,7 @@ let
       pkgs.libnotify
       pkgs.logrotate
       pkgs.nix
-      inputs.home-manager.packages.${pkgs.system}.home-manager
+      config.programs.home-manager.package
     ];
     text = ''
       exec ${pkgs.bash}/bin/bash ${../../../scripts/home-manager-updater.sh}

--- a/nix/home-manager/systems/flake/home.nix
+++ b/nix/home-manager/systems/flake/home.nix
@@ -1,0 +1,9 @@
+{ ... }:
+{
+  imports = [ ../desktop/home.nix ];
+
+  homeManagerUpdater = {
+    enable = true;
+    hostName = "flake";
+  };
+}

--- a/scripts/home-manager-updater.sh
+++ b/scripts/home-manager-updater.sh
@@ -32,7 +32,8 @@ current_generation() {
 find_issue_number() {
   local state="${1:-all}"
   local json
-  if ! json="$(gh issue list --repo "$HM_UPDATER_REPOSITORY" --state "$state" --limit 100 --json number,title 2>/dev/null)"; then
+  if ! json="$(gh issue list --repo "$HM_UPDATER_REPOSITORY" --state "$state" \
+    --search "\"$ISSUE_TITLE\" in:title" --limit 100 --json number,title 2>/dev/null)"; then
     return 1
   fi
   printf '%s\n' "$json" | jq -r --arg title "$ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1

--- a/scripts/home-manager-updater.sh
+++ b/scripts/home-manager-updater.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+umask 077
+
+: "${HM_UPDATER_DATA_DIR:?HM_UPDATER_DATA_DIR is required}"
+: "${HM_UPDATER_REPOSITORY:?HM_UPDATER_REPOSITORY is required}"
+: "${HM_UPDATER_REMOTE_URL:?HM_UPDATER_REMOTE_URL is required}"
+: "${HM_UPDATER_BRANCH:?HM_UPDATER_BRANCH is required}"
+: "${HM_UPDATER_CONFIGURATION:?HM_UPDATER_CONFIGURATION is required}"
+: "${HM_UPDATER_LOGROTATE_CONFIG:?HM_UPDATER_LOGROTATE_CONFIG is required}"
+
+DATA_DIR="$HM_UPDATER_DATA_DIR"
+CHECKOUT="$DATA_DIR/repo"
+LOG_FILE="$DATA_DIR/update.log"
+FAILURE_FILE="$DATA_DIR/failure.txt"
+NOTIFICATION_ID_FILE="$DATA_DIR/notification-id"
+ISSUE_TITLE="Home Manager auto-update failed: $HM_UPDATER_CONFIGURATION"
+
+mkdir -p "$DATA_DIR"
+logrotate -s "$DATA_DIR/logrotate.state" "$HM_UPDATER_LOGROTATE_CONFIG" || true
+exec >>"$LOG_FILE" 2>&1
+
+log() {
+  printf '[%s] %s\n' "$(date --iso-8601=seconds)" "$*"
+}
+
+current_generation() {
+  home-manager generations 2>/dev/null | sed -n '1s/.* -> //p'
+}
+
+find_issue_number() {
+  local state="${1:-all}"
+  local json
+  if ! json="$(gh issue list --repo "$HM_UPDATER_REPOSITORY" --state "$state" --limit 100 --json number,title 2>/dev/null)"; then
+    return 1
+  fi
+  printf '%s\n' "$json" | jq -r --arg title "$ISSUE_TITLE" '.[] | select(.title == $title) | .number' | head -n1
+}
+
+report_issue() {
+  local stage="$1"
+  local detail="$2"
+  local issue_number body commit_sha
+
+  if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+    log "WARNING: gh is not authenticated; cannot create/update failure issue"
+    return 1
+  fi
+
+  commit_sha="$(git -C "$CHECKOUT" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+  body=$(cat <<EOF
+The automatic Home Manager update for \`$HM_UPDATER_CONFIGURATION\` failed.
+
+- Stage: \`$stage\`
+- Branch: \`$HM_UPDATER_BRANCH\`
+- Commit: \`$commit_sha\`
+- Host configuration: \`$HM_UPDATER_CONFIGURATION\`
+- Local log: \`$LOG_FILE\`
+- Last failure: \`$(date --iso-8601=seconds)\`
+
+$detail
+
+This is the canonical updater failure issue. Subsequent failures update/reopen this issue instead of creating duplicates.
+EOF
+)
+
+  issue_number="$(find_issue_number all || true)"
+  if [[ -n "$issue_number" ]]; then
+    gh issue reopen "$issue_number" --repo "$HM_UPDATER_REPOSITORY" >/dev/null 2>&1 || true
+    gh issue edit "$issue_number" --repo "$HM_UPDATER_REPOSITORY" --body "$body" >/dev/null
+    log "Updated GitHub issue #$issue_number"
+  else
+    gh issue create --repo "$HM_UPDATER_REPOSITORY" --title "$ISSUE_TITLE" --body "$body" >/dev/null
+    log "Created GitHub issue: $ISSUE_TITLE"
+  fi
+}
+
+close_issue() {
+  local issue_number
+  if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+    return 0
+  fi
+  issue_number="$(find_issue_number open || true)"
+  if [[ -n "$issue_number" ]]; then
+    gh issue close "$issue_number" --repo "$HM_UPDATER_REPOSITORY" \
+      --comment "Automatic update recovered successfully at $(date --iso-8601=seconds)." >/dev/null || true
+    log "Closed recovered GitHub issue #$issue_number"
+  fi
+}
+
+clear_failure_notification() {
+  local notification_id
+  rm -f "$FAILURE_FILE"
+  if [[ -s "$NOTIFICATION_ID_FILE" ]]; then
+    notification_id="$(cat "$NOTIFICATION_ID_FILE")"
+    notify-send --replace-id="$notification_id" --expire-time=1 \
+      --app-name="Home Manager Updater" \
+      "Home Manager updater recovered" \
+      "$HM_UPDATER_CONFIGURATION updated successfully." >/dev/null 2>&1 || true
+    rm -f "$NOTIFICATION_ID_FILE"
+  fi
+}
+
+fail_update() {
+  local stage="$1"
+  local detail="$2"
+  {
+    printf 'Home Manager update failed for %s\n' "$HM_UPDATER_CONFIGURATION"
+    printf 'Stage: %s\n' "$stage"
+    printf 'Time: %s\n' "$(date --iso-8601=seconds)"
+    printf '%s\n' "$detail"
+    printf 'Log: %s\n' "$LOG_FILE"
+  } >"$FAILURE_FILE"
+  log "FAILURE [$stage]: $detail"
+  report_issue "$stage" "$detail" || true
+  exit 1
+}
+
+log "Starting Home Manager update for $HM_UPDATER_CONFIGURATION"
+
+if [[ ! -d "$CHECKOUT/.git" ]]; then
+  rm -rf "$CHECKOUT"
+  if ! git clone --no-checkout "$HM_UPDATER_REMOTE_URL" "$CHECKOUT"; then
+    fail_update "checkout" "Could not clone $HM_UPDATER_REMOTE_URL."
+  fi
+fi
+
+if ! git -C "$CHECKOUT" remote set-url origin "$HM_UPDATER_REMOTE_URL"; then
+  fail_update "checkout" "Could not configure the updater checkout remote."
+fi
+if ! git -C "$CHECKOUT" fetch --prune origin "$HM_UPDATER_BRANCH"; then
+  fail_update "fetch" "Could not fetch origin/$HM_UPDATER_BRANCH."
+fi
+if ! git -C "$CHECKOUT" checkout -B "$HM_UPDATER_BRANCH" "origin/$HM_UPDATER_BRANCH"; then
+  fail_update "checkout" "Could not reset the dedicated checkout to origin/$HM_UPDATER_BRANCH."
+fi
+git -C "$CHECKOUT" reset --hard "origin/$HM_UPDATER_BRANCH"
+git -C "$CHECKOUT" clean -fdx
+
+flake_attr="$CHECKOUT#homeConfigurations.\"$HM_UPDATER_CONFIGURATION\".activationPackage"
+if ! nix build --no-link --show-trace "$flake_attr"; then
+  fail_update "build" "The candidate Home Manager activation package failed to build. The active generation was not changed."
+fi
+
+before_generation="$(current_generation)"
+log "Current generation before activation: ${before_generation:-unknown}"
+
+if ! home-manager switch --flake "$CHECKOUT#$HM_UPDATER_CONFIGURATION" --show-trace; then
+  after_generation="$(current_generation)"
+  log "Generation after failed activation: ${after_generation:-unknown}"
+
+  if [[ -n "$before_generation" && -n "$after_generation" && "$after_generation" != "$before_generation" ]]; then
+    log "Activation advanced the generation; rolling back once"
+    if ! home-manager switch --rollback; then
+      fail_update "rollback" "Activation failed and the one-shot rollback also failed. Manual recovery is required."
+    fi
+    rolled_generation="$(current_generation)"
+    if [[ "$rolled_generation" != "$before_generation" ]]; then
+      fail_update "rollback" "Rollback command completed but did not restore the previous generation ($before_generation). Current: ${rolled_generation:-unknown}."
+    fi
+    fail_update "activation" "Activation failed. The previous Home Manager generation was restored successfully."
+  fi
+
+  fail_update "activation" "Activation failed before the Home Manager generation advanced, so no rollback was necessary."
+fi
+
+clear_failure_notification
+close_issue
+log "Home Manager update completed successfully"

--- a/scripts/home-manager-updater.sh
+++ b/scripts/home-manager-updater.sh
@@ -136,27 +136,38 @@ fi
 if ! git -C "$CHECKOUT" checkout -B "$HM_UPDATER_BRANCH" "origin/$HM_UPDATER_BRANCH"; then
   fail_update "checkout" "Could not reset the dedicated checkout to origin/$HM_UPDATER_BRANCH."
 fi
-git -C "$CHECKOUT" reset --hard "origin/$HM_UPDATER_BRANCH"
-git -C "$CHECKOUT" clean -fdx
+if ! git -C "$CHECKOUT" reset --hard "origin/$HM_UPDATER_BRANCH"; then
+  fail_update "checkout" "Could not hard-reset the dedicated updater checkout."
+fi
+if ! git -C "$CHECKOUT" clean -fdx; then
+  fail_update "checkout" "Could not clean the dedicated updater checkout."
+fi
 
 flake_attr="$CHECKOUT#homeConfigurations.\"$HM_UPDATER_CONFIGURATION\".activationPackage"
 if ! nix build --no-link --show-trace "$flake_attr"; then
   fail_update "build" "The candidate Home Manager activation package failed to build. The active generation was not changed."
 fi
 
-before_generation="$(current_generation)"
-log "Current generation before activation: ${before_generation:-unknown}"
+before_generation="$(current_generation || true)"
+if [[ -z "$before_generation" ]]; then
+  fail_update "preflight" "Could not determine the current Home Manager generation. Refusing activation because there is no trustworthy rollback baseline."
+fi
+log "Current generation before activation: $before_generation"
 
 if ! home-manager switch --flake "$CHECKOUT#$HM_UPDATER_CONFIGURATION" --show-trace; then
-  after_generation="$(current_generation)"
+  after_generation="$(current_generation || true)"
   log "Generation after failed activation: ${after_generation:-unknown}"
 
-  if [[ -n "$before_generation" && -n "$after_generation" && "$after_generation" != "$before_generation" ]]; then
+  if [[ -z "$after_generation" ]]; then
+    fail_update "activation" "Activation failed and the current generation could not be determined afterward. No blind rollback was attempted; manual recovery is required."
+  fi
+
+  if [[ "$after_generation" != "$before_generation" ]]; then
     log "Activation advanced the generation; rolling back once"
     if ! home-manager switch --rollback; then
       fail_update "rollback" "Activation failed and the one-shot rollback also failed. Manual recovery is required."
     fi
-    rolled_generation="$(current_generation)"
+    rolled_generation="$(current_generation || true)"
     if [[ "$rolled_generation" != "$before_generation" ]]; then
       fail_update "rollback" "Rollback command completed but did not restore the previous generation ($before_generation). Current: ${rolled_generation:-unknown}."
     fi

--- a/tests/home-manager-updater.sh
+++ b/tests/home-manager-updater.sh
@@ -32,6 +32,9 @@ old="${MOCK_OLD_GENERATION:?}"
 new="${MOCK_NEW_GENERATION:?}"
 
 if [[ "${1:-}" == "generations" ]]; then
+  if [[ "${MOCK_GENERATIONS_RC:-0}" -ne 0 ]]; then
+    exit "$MOCK_GENERATIONS_RC"
+  fi
   printf '2026-08-21 00:00 : id 1 -> %s\n' "$(cat "$state")"
   exit 0
 fi
@@ -119,6 +122,7 @@ reset_case() {
   printf '%s\n' "$MOCK_OLD_GENERATION" >"$MOCK_GENERATION_STATE"
   : >"$MOCK_COUNTS"
   export MOCK_NIX_RC=0
+  export MOCK_GENERATIONS_RC=0
   export MOCK_SWITCH_RC=0
   export MOCK_ROLLBACK_RC=0
   export MOCK_ADVANCE_ON_SWITCH=0
@@ -137,6 +141,14 @@ assert_count switch 0
 assert_count rollback 0
 [[ "$(cat "$MOCK_GENERATION_STATE")" == "$MOCK_OLD_GENERATION" ]] || fail_test "build failure changed generation"
 assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "Stage: build"
+
+reset_case missing-rollback-baseline
+export MOCK_GENERATIONS_RC=1
+run_expect_failure
+assert_count switch 0
+assert_count rollback 0
+assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "Stage: preflight"
+assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "no trustworthy rollback baseline"
 
 reset_case activation-before-generation
 export MOCK_SWITCH_RC=1

--- a/tests/home-manager-updater.sh
+++ b/tests/home-manager-updater.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+updater="$repo_root/scripts/home-manager-updater.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mockbin="$tmp/bin"
+mkdir -p "$mockbin"
+
+cat >"$mockbin/git" <<'EOF'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == *"rev-parse HEAD"* ]]; then
+  printf 'deadbeef\n'
+fi
+exit 0
+EOF
+
+cat >"$mockbin/nix" <<'EOF'
+#!/usr/bin/env bash
+exit "${MOCK_NIX_RC:-0}"
+EOF
+
+cat >"$mockbin/home-manager" <<'EOF'
+#!/usr/bin/env bash
+set -u
+state="${MOCK_GENERATION_STATE:?}"
+counts="${MOCK_COUNTS:?}"
+old="${MOCK_OLD_GENERATION:?}"
+new="${MOCK_NEW_GENERATION:?}"
+
+if [[ "${1:-}" == "generations" ]]; then
+  printf '2026-08-21 00:00 : id 1 -> %s\n' "$(cat "$state")"
+  exit 0
+fi
+
+if [[ "${1:-}" == "switch" && "${2:-}" == "--rollback" ]]; then
+  printf 'rollback\n' >>"$counts"
+  if [[ "${MOCK_ROLLBACK_RC:-0}" -eq 0 ]]; then
+    printf '%s\n' "$old" >"$state"
+  fi
+  exit "${MOCK_ROLLBACK_RC:-0}"
+fi
+
+if [[ "${1:-}" == "switch" ]]; then
+  printf 'switch\n' >>"$counts"
+  if [[ "${MOCK_ADVANCE_ON_SWITCH:-0}" -eq 1 ]]; then
+    printf '%s\n' "$new" >"$state"
+  fi
+  exit "${MOCK_SWITCH_RC:-0}"
+fi
+
+exit 2
+EOF
+
+cat >"$mockbin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Tests deliberately model an unauthenticated gh client so issue reporting is
+# best-effort and cannot interfere with the recovery assertions.
+if [[ "${1:-}" == "auth" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$mockbin/logrotate" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat >"$mockbin/notify-send" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"--print-id"* ]]; then
+  printf '42\n'
+fi
+exit 0
+EOF
+
+chmod +x "$mockbin"/*
+
+export PATH="$mockbin:$PATH"
+export HM_UPDATER_REPOSITORY="lost-rob0t/dotfiles"
+export HM_UPDATER_REMOTE_URL="https://github.com/lost-rob0t/dotfiles.git"
+export HM_UPDATER_BRANCH="master"
+export HM_UPDATER_CONFIGURATION="unseen@flake"
+export HM_UPDATER_LOGROTATE_CONFIG="$tmp/logrotate.conf"
+export MOCK_OLD_GENERATION="/nix/store/old-home-manager-generation"
+export MOCK_NEW_GENERATION="/nix/store/new-home-manager-generation"
+
+printf 'unused\n' >"$HM_UPDATER_LOGROTATE_CONFIG"
+
+fail_test() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -Fq -- "$expected" "$file" || fail_test "$file does not contain: $expected"
+}
+
+assert_count() {
+  local needle="$1"
+  local expected="$2"
+  local actual
+  actual="$(grep -c -x "$needle" "$MOCK_COUNTS" 2>/dev/null || true)"
+  [[ "$actual" == "$expected" ]] || fail_test "expected $expected '$needle' calls, got $actual"
+}
+
+reset_case() {
+  local name="$1"
+  export HM_UPDATER_DATA_DIR="$tmp/$name/data"
+  export MOCK_GENERATION_STATE="$tmp/$name/generation"
+  export MOCK_COUNTS="$tmp/$name/counts"
+  mkdir -p "$HM_UPDATER_DATA_DIR/repo/.git"
+  printf '%s\n' "$MOCK_OLD_GENERATION" >"$MOCK_GENERATION_STATE"
+  : >"$MOCK_COUNTS"
+  export MOCK_NIX_RC=0
+  export MOCK_SWITCH_RC=0
+  export MOCK_ROLLBACK_RC=0
+  export MOCK_ADVANCE_ON_SWITCH=0
+}
+
+run_expect_failure() {
+  if bash "$updater"; then
+    fail_test "updater unexpectedly succeeded"
+  fi
+}
+
+reset_case build-failure
+export MOCK_NIX_RC=1
+run_expect_failure
+assert_count switch 0
+assert_count rollback 0
+[[ "$(cat "$MOCK_GENERATION_STATE")" == "$MOCK_OLD_GENERATION" ]] || fail_test "build failure changed generation"
+assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "Stage: build"
+
+reset_case activation-before-generation
+export MOCK_SWITCH_RC=1
+run_expect_failure
+assert_count switch 1
+assert_count rollback 0
+[[ "$(cat "$MOCK_GENERATION_STATE")" == "$MOCK_OLD_GENERATION" ]] || fail_test "unchanged activation failure changed generation"
+assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "no rollback was necessary"
+
+reset_case activation-after-generation
+export MOCK_SWITCH_RC=1
+export MOCK_ADVANCE_ON_SWITCH=1
+run_expect_failure
+assert_count switch 1
+assert_count rollback 1
+[[ "$(cat "$MOCK_GENERATION_STATE")" == "$MOCK_OLD_GENERATION" ]] || fail_test "rollback did not restore previous generation"
+assert_contains "$HM_UPDATER_DATA_DIR/failure.txt" "previous Home Manager generation was restored successfully"
+
+reset_case success
+export MOCK_ADVANCE_ON_SWITCH=1
+printf 'stale failure\n' >"$HM_UPDATER_DATA_DIR/failure.txt"
+printf '42\n' >"$HM_UPDATER_DATA_DIR/notification-id"
+bash "$updater"
+assert_count switch 1
+assert_count rollback 0
+[[ ! -e "$HM_UPDATER_DATA_DIR/failure.txt" ]] || fail_test "success did not clear failure marker"
+[[ ! -e "$HM_UPDATER_DATA_DIR/notification-id" ]] || fail_test "success did not clear notification id"
+[[ "$(cat "$MOCK_GENERATION_STATE")" == "$MOCK_NEW_GENERATION" ]] || fail_test "success did not advance generation"
+
+printf 'home-manager-updater tests: PASS\n'


### PR DESCRIPTION
## Summary

- update all flake inputs daily at 00:00 America/New_York
- run `nix flake check --show-trace` against the candidate lockfile before publishing it
- reuse/reopen one canonical GitHub Actions failure issue and close it after recovery
- add a reusable Home Manager updater module with a daily ~03:00 local timer
- derive the target Home Manager configuration as `<user>@<host>`
- build the target activation package before touching the active generation
- require a known current Home Manager generation before activation so rollback has a trustworthy baseline
- rollback exactly once only when a failed activation actually advanced the generation
- persist failure state and a critical desktop notification across sessions
- rotate logs under `~/.local/share/home-manager-updater/`
- reuse/reopen one canonical local updater failure issue per Home Manager configuration
- enable the updater only for `unseen@flake`; `unseen@desktop` remains unchanged
- update the pinned actionlint wrapper so CI understands GitHub's timezone-aware schedule syntax

## Safety properties

- dedicated updater checkout; never mutates the user's working dotfiles tree
- build failure leaves the active Home Manager generation untouched
- unknown generation state blocks activation instead of guessing at rollback
- no retry loop
- activation failure performs at most one rollback
- a successful later run clears the failure marker/notification and closes the updater issue

## Tests

- ShellCheck + Bash syntax checks
- recovery regression harness covers build failure, missing rollback baseline, pre-generation activation failure, post-generation rollback, and success cleanup
- Nix CI evaluates both `unseen@desktop` and `unseen@flake`
