### PR TITLE
fix(lightdm): expose Nix desktop entries on Arch

### DIFF
--- a/.config/qtile/tests/test_brave_launcher_session.py
+++ b/.config/qtile/tests/test_brave_launcher_session.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-"""Regression coverage for Brave launch/discovery under the Qtile LightDM session."""
+"""Regression coverage for application discovery under the Qtile LightDM session."""
 
 from __future__ import annotations
 
+import os
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -13,11 +16,50 @@ QTILE_CONFIG = ROOT / ".config" / "qtile" / "config.py"
 
 
 class BraveLauncherSessionTests(unittest.TestCase):
-    def test_xprofile_loads_home_manager_session_and_application_data(self):
-        source = XPROFILE.read_text(encoding="utf-8")
-        self.assertIn("hm-session-vars.sh", source)
-        self.assertIn('$HOME/.nix-profile/share', source)
-        self.assertIn("XDG_DATA_DIRS", source)
+    def test_xprofile_preserves_arch_application_dirs_after_home_manager(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            profile_dir = home / ".nix-profile" / "etc" / "profile.d"
+            bin_dir = home / "bin"
+            profile_dir.mkdir(parents=True)
+            bin_dir.mkdir()
+
+            (profile_dir / "hm-session-vars.sh").write_text(
+                'export XDG_DATA_DIRS="/nix/hm/share:/nix/default/share"\n',
+                encoding="utf-8",
+            )
+            systemctl = bin_dir / "systemctl"
+            systemctl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            systemctl.chmod(0o755)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+            env.pop("XDG_DATA_HOME", None)
+            env.pop("XDG_DATA_DIRS", None)
+
+            result = subprocess.run(
+                [
+                    "/bin/sh",
+                    "-c",
+                    '. "$1"; printf "%s\\n%s\\n" "$XDG_DATA_HOME" "$XDG_DATA_DIRS"',
+                    "sh",
+                    str(XPROFILE),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            data_home, data_dirs = result.stdout.splitlines()
+            dirs = data_dirs.split(":")
+
+            self.assertEqual(data_home, str(home / ".local" / "share"))
+            self.assertIn(str(home / ".nix-profile" / "share"), dirs)
+            self.assertIn("/nix/hm/share", dirs)
+            self.assertIn("/nix/default/share", dirs)
+            self.assertIn("/usr/local/share", dirs)
+            self.assertIn("/usr/share", dirs)
 
     def test_desktop_home_manager_owns_xprofile(self):
         source = DESKTOP_NIX.read_text(encoding="utf-8")

--- a/.config/qtile/tests/test_brave_launcher_session.py
+++ b/.config/qtile/tests/test_brave_launcher_session.py
@@ -16,7 +16,7 @@ QTILE_CONFIG = ROOT / ".config" / "qtile" / "config.py"
 
 
 class BraveLauncherSessionTests(unittest.TestCase):
-    def test_xprofile_preserves_arch_application_dirs_after_home_manager(self):
+    def test_xprofile_exposes_arch_and_nix_application_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             profile_dir = home / ".nix-profile" / "etc" / "profile.d"
@@ -34,6 +34,7 @@ class BraveLauncherSessionTests(unittest.TestCase):
 
             env = os.environ.copy()
             env["HOME"] = str(home)
+            env["USER"] = "tester"
             env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
             env.pop("XDG_DATA_HOME", None)
             env.pop("XDG_DATA_DIRS", None)
@@ -56,10 +57,14 @@ class BraveLauncherSessionTests(unittest.TestCase):
 
             self.assertEqual(data_home, str(home / ".local" / "share"))
             self.assertIn(str(home / ".nix-profile" / "share"), dirs)
+            self.assertIn(str(home / ".local/state/nix/profiles/profile/share"), dirs)
+            self.assertIn("/nix/var/nix/profiles/per-user/tester/profile/share", dirs)
+            self.assertIn("/etc/profiles/per-user/tester/share", dirs)
             self.assertIn("/nix/hm/share", dirs)
             self.assertIn("/nix/default/share", dirs)
             self.assertIn("/usr/local/share", dirs)
             self.assertIn("/usr/share", dirs)
+            self.assertEqual(len(dirs), len(set(dirs)))
 
     def test_desktop_home_manager_owns_xprofile(self):
         source = DESKTOP_NIX.read_text(encoding="utf-8")

--- a/.xprofile
+++ b/.xprofile
@@ -5,11 +5,37 @@ if [ -r "$hm_session_vars" ]; then
     . "$hm_session_vars"
 fi
 
-# LightDM sources this file on Arch before starting Qtile. Home Manager may
-# already define XDG_DATA_DIRS, so the Arch application directories must be
-# appended unconditionally rather than supplied only as a shell fallback.
+# LightDM starts Qtile outside the interactive shell. Build the desktop-entry
+# search path explicitly so j4-dmenu-desktop can see both Arch applications and
+# packages installed through legacy, modern, and multi-user Nix profiles.
 export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
-export XDG_DATA_DIRS="$HOME/.nix-profile/share:${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}/usr/local/share:/usr/share"
+
+xdg_data_dirs=""
+append_xdg_data_dir() {
+    dir="$1"
+    [ -n "$dir" ] || return 0
+    case ":$xdg_data_dirs:" in
+        *":$dir:"*) return 0 ;;
+    esac
+    xdg_data_dirs="${xdg_data_dirs:+$xdg_data_dirs:}$dir"
+}
+
+append_xdg_data_dir "$HOME/.nix-profile/share"
+append_xdg_data_dir "$HOME/.local/state/nix/profiles/profile/share"
+append_xdg_data_dir "/nix/var/nix/profiles/per-user/$USER/profile/share"
+append_xdg_data_dir "/etc/profiles/per-user/$USER/share"
+
+old_ifs=$IFS
+IFS=:
+for dir in ${XDG_DATA_DIRS:-}; do
+    append_xdg_data_dir "$dir"
+done
+IFS=$old_ifs
+
+append_xdg_data_dir "/usr/local/share"
+append_xdg_data_dir "/usr/share"
+export XDG_DATA_DIRS="$xdg_data_dirs"
+unset xdg_data_dirs old_ifs dir
 
 systemctl --user import-environment \
     DISPLAY XAUTHORITY PATH XDG_DATA_HOME XDG_DATA_DIRS

--- a/.xprofile
+++ b/.xprofile
@@ -5,6 +5,11 @@ if [ -r "$hm_session_vars" ]; then
     . "$hm_session_vars"
 fi
 
-export XDG_DATA_DIRS="$HOME/.nix-profile/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+# LightDM sources this file on Arch before starting Qtile. Home Manager may
+# already define XDG_DATA_DIRS, so the Arch application directories must be
+# appended unconditionally rather than supplied only as a shell fallback.
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_DATA_DIRS="$HOME/.nix-profile/share:${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}/usr/local/share:/usr/share"
 
-systemctl --user import-environment DISPLAY XAUTHORITY PATH XDG_DATA_DIRS
+systemctl --user import-environment \
+    DISPLAY XAUTHORITY PATH XDG_DATA_HOME XDG_DATA_DIRS


### PR DESCRIPTION
## Root cause

After moving the Arch Qtile session to LightDM, `j4-dmenu-desktop` can still see Arch-installed applications such as Firefox but misses applications installed through Nix/Home Manager. LightDM launches Qtile outside the interactive shell, so desktop-entry discovery depends on the environment exported by `.xprofile`.

The previous fix only prepended `~/.nix-profile/share` and trusted whatever Home Manager supplied in `XDG_DATA_DIRS`. That is not sufficient for every Nix profile layout used on a non-NixOS host.

## Fix

- build `XDG_DATA_DIRS` explicitly in `.xprofile` for the LightDM session;
- include legacy `~/.nix-profile/share`;
- include the modern `~/.local/state/nix/profiles/profile/share` path;
- include multi-user `/nix/var/nix/profiles/per-user/$USER/profile/share`;
- include `/etc/profiles/per-user/$USER/share` when present in the deployment model;
- preserve any directories supplied by Home Manager;
- always retain Arch `/usr/local/share` and `/usr/share`;
- import `XDG_DATA_HOME` and the corrected `XDG_DATA_DIRS` into the user systemd environment.

## Regression coverage

The launcher regression now executes `.xprofile` in a synthetic LightDM-style environment with Home Manager supplying its own `XDG_DATA_DIRS`, then verifies both Arch and Nix application roots survive and no duplicate directories are introduced.

No NixOS host/session configuration is changed.