### PR TITLE
Fix GPT TODO bidirectional Org sync

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n scripts/*.sh tests/home-manager-updater.sh .bash_profile .config/bash/git-sync.sh
-          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh .bash_profile .config/bash/git-sync.sh
+          bash -n scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh .bash_profile .config/bash/git-sync.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh .bash_profile .config/bash/git-sync.sh
       - name: Run Home Manager updater recovery tests
         run: bash tests/home-manager-updater.sh
+      - name: Run GPT TODO bidirectional sync tests
+        run: bash tests/gpt-todos-sync.sh
       - name: Check Qtile Python helpers
         run: >-
           python3 -m py_compile

--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -10,8 +10,6 @@ LOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}"
 [[ -d "$LOCK_DIR" ]] || LOCK_DIR=/tmp
 LOCK="$LOCK_DIR/gpt-todos-sync-${UID}.lock"
 
-# This runs from cron too. Never allow Git/SSH/GPG to open an interactive
-# prompt and wedge the sync indefinitely.
 export GIT_TERMINAL_PROMPT=0
 if [[ -z "${GIT_SSH_COMMAND:-}" ]]; then
   export GIT_SSH_COMMAND="ssh -o BatchMode=yes"
@@ -108,10 +106,9 @@ repair_legacy_imports() {
 
   local rel local_rel
   local removed=0
+  local -a staged_added=()
+  local -a untracked=()
 
-  # The broken bootstrap could have stopped after `git add`, so clean staged
-  # additions as well as ordinary untracked copies. Only byte-identical files
-  # that also exist in the live agenda qualify for automatic repair.
   mapfile -t staged_added < <(
     git -C "$REPO_DIR" diff --cached --name-only --diff-filter=A -- 'agenda/*.org'
   )
@@ -142,51 +139,122 @@ repair_legacy_imports() {
   (( removed == 0 )) || printf 'gpt-todos-sync: repaired %d legacy import(s)\n' "$removed"
 }
 
+blob_at() {
+  local ref="$1"
+  local rel="$2"
+  git -C "$REPO_DIR" rev-parse --verify "$ref:$rel" 2>/dev/null || printf '%s\n' '-'
+}
+
+file_blob() {
+  local file="$1"
+  [[ -f "$file" ]] || {
+    printf '%s\n' '-'
+    return
+  }
+  git -C "$REPO_DIR" hash-object "$file"
+}
+
+list_org_paths() {
+  local ref="$1"
+  local rel
+  while IFS= read -r rel; do
+    [[ "$rel" == agenda/*.org ]] && printf '%s\n' "$rel"
+  done < <(git -C "$REPO_DIR" ls-tree -r --name-only "$ref" -- agenda)
+}
+
 sync_dotfiles_literate
 repair_legacy_imports
 
-# Pull first, then derive the sync set from files already tracked by gpt-todos.
-# Local agenda files that are not tracked by gpt-todos are never imported.
-git -C "$REPO_DIR" pull --rebase --autostash
+if [[ -n "$(git -C "$REPO_DIR" status --porcelain --untracked-files=all -- agenda)" ]]; then
+  printf 'gpt-todos-sync: durable agenda checkout is dirty; refusing to guess ownership\n' >&2
+  git -C "$REPO_DIR" status --short -- agenda >&2
+  exit 6
+fi
+
+git -C "$REPO_DIR" fetch --prune
+UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)" || {
+  printf 'gpt-todos-sync: current branch has no upstream\n' >&2
+  exit 7
+}
+BASE="$(git -C "$REPO_DIR" rev-parse HEAD)"
+REMOTE_HEAD="$(git -C "$REPO_DIR" rev-parse "$UPSTREAM")"
 
 mapfile -t org_paths < <(
-  git -C "$REPO_DIR" ls-files -- 'agenda/*.org' | sort -u
+  {
+    list_org_paths "$BASE"
+    list_org_paths "$REMOTE_HEAD"
+  } | sort -u
 )
+
 if ((${#org_paths[@]} == 0)); then
   printf 'gpt-todos-sync: no tracked agenda/*.org files; nothing to sync\n'
   exit 0
 fi
 
+local_changes=()
+conflicts=0
+
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
-  repo_file="$REPO_DIR/$rel"
   org_file="$ORG_DIR/$local_rel"
-  mkdir -p "$(dirname "$org_file")"
+  base_hash="$(blob_at "$BASE" "$rel")"
+  remote_hash="$(blob_at "$REMOTE_HEAD" "$rel")"
+  local_hash="$(file_blob "$org_file")"
 
-  if [[ ! -e "$org_file" ]]; then
-    cp -p -- "$repo_file" "$org_file"
-  elif [[ "$org_file" -nt "$repo_file" ]]; then
-    cp -p -- "$org_file" "$repo_file"
-  elif [[ "$repo_file" -nt "$org_file" ]]; then
-    cp -p -- "$repo_file" "$org_file"
-  elif ! cmp -s "$repo_file" "$org_file"; then
-    printf 'gpt-todos-sync: conflict for %s (different contents, same mtime)\n' "$rel" >&2
-    exit 5
+  if [[ "$base_hash" != "-" && "$remote_hash" == "-" ]]; then
+    printf 'gpt-todos-sync: remote deletion requires manual resolution: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
+    continue
+  fi
+
+  if [[ "$base_hash" == "-" ]]; then
+    if [[ "$local_hash" != "-" && "$local_hash" != "$remote_hash" ]]; then
+      printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
+      conflicts=$((conflicts + 1))
+    fi
+    continue
+  fi
+
+  if [[ "$local_hash" == "-" || "$local_hash" == "$remote_hash" ]]; then
+    continue
+  fi
+
+  local_changed=0
+  remote_changed=0
+  [[ "$local_hash" != "$base_hash" ]] && local_changed=1
+  [[ "$remote_hash" != "$base_hash" ]] && remote_changed=1
+
+  if (( local_changed && remote_changed )); then
+    printf 'gpt-todos-sync: concurrent local/remote edit conflict: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
+  elif (( local_changed )); then
+    local_changes+=("$rel")
   fi
 done
 
-git -C "$REPO_DIR" add -- "${org_paths[@]}"
+(( conflicts == 0 )) || exit 5
+
+git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
+
+for rel in "${local_changes[@]}"; do
+  local_rel="${rel#agenda/}"
+  cp -p -- "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
+done
+
+if ((${#local_changes[@]})); then
+  git -C "$REPO_DIR" add -- "${local_changes[@]}"
+fi
 
 if ! git -C "$REPO_DIR" diff --cached --quiet; then
-  # Automated task-state commits must not inherit interactive GPG signing.
   git -C "$REPO_DIR" -c commit.gpgsign=false commit --no-gpg-sign \
     -m "Sync Org task state"
   git -C "$REPO_DIR" push
 fi
 
-# A concurrent remote update after our push is reconciled once more, and the
-# repository copy is authoritative for the final local projection.
-git -C "$REPO_DIR" pull --rebase --autostash
+git -C "$REPO_DIR" fetch --prune
+git -C "$REPO_DIR" merge --ff-only "$UPSTREAM"
+
+mapfile -t org_paths < <(list_org_paths HEAD | sort -u)
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
   mkdir -p "$(dirname "$ORG_DIR/$local_rel")"

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -4,12 +4,19 @@
 
 * Sync
 
-This is the canonical literate source for the task-state sync helper.  It
-mirrors only Org files already tracked under =gpt-todos/agenda/= into the live
-Org agenda, reconciles the private repository through Git, and refuses to
-silently tolerate known literate/generated drift in dotfiles.  Arbitrary files
-from =~/Documents/Notes/org/agenda/= are never imported merely because they
-exist there.  The default durable checkout is =~/Documents/gpt-todos=.
+This is the canonical literate source for the task-state sync helper.  Org files
+already tracked under =gpt-todos/agenda/= are synchronized bidirectionally with
+the live Org agenda.  The durable checkout's current =HEAD= is the synchronization
+baseline: the helper fetches the upstream ref, compares Git blob identities, and
+only copies a side when that side changed relative to the baseline.  Concurrent
+local and remote edits to the same file are rejected instead of being resolved
+by filesystem timestamps.
+
+Untracked files from =~/Documents/Notes/org/agenda/= are deliberately not
+imported, so unrelated agenda data cannot leak into the GPT TODO repository.
+Missing local copies are restored from the repository; repository-side deletion
+requires manual resolution.  The default durable checkout is
+=~/Documents/gpt-todos=.
 
 The same command also owns deployment.  Run =gpt-todos-sync --deploy 5= to
 perform the initial sync and install the five-minute cron entry.  Git operations
@@ -29,8 +36,6 @@ LOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}"
 [[ -d "$LOCK_DIR" ]] || LOCK_DIR=/tmp
 LOCK="$LOCK_DIR/gpt-todos-sync-${UID}.lock"
 
-# This runs from cron too. Never allow Git/SSH/GPG to open an interactive
-# prompt and wedge the sync indefinitely.
 export GIT_TERMINAL_PROMPT=0
 if [[ -z "${GIT_SSH_COMMAND:-}" ]]; then
   export GIT_SSH_COMMAND="ssh -o BatchMode=yes"
@@ -127,10 +132,9 @@ repair_legacy_imports() {
 
   local rel local_rel
   local removed=0
+  local -a staged_added=()
+  local -a untracked=()
 
-  # The broken bootstrap could have stopped after `git add`, so clean staged
-  # additions as well as ordinary untracked copies. Only byte-identical files
-  # that also exist in the live agenda qualify for automatic repair.
   mapfile -t staged_added < <(
     git -C "$REPO_DIR" diff --cached --name-only --diff-filter=A -- 'agenda/*.org'
   )
@@ -161,51 +165,122 @@ repair_legacy_imports() {
   (( removed == 0 )) || printf 'gpt-todos-sync: repaired %d legacy import(s)\n' "$removed"
 }
 
+blob_at() {
+  local ref="$1"
+  local rel="$2"
+  git -C "$REPO_DIR" rev-parse --verify "$ref:$rel" 2>/dev/null || printf '%s\n' '-'
+}
+
+file_blob() {
+  local file="$1"
+  [[ -f "$file" ]] || {
+    printf '%s\n' '-'
+    return
+  }
+  git -C "$REPO_DIR" hash-object "$file"
+}
+
+list_org_paths() {
+  local ref="$1"
+  local rel
+  while IFS= read -r rel; do
+    [[ "$rel" == agenda/*.org ]] && printf '%s\n' "$rel"
+  done < <(git -C "$REPO_DIR" ls-tree -r --name-only "$ref" -- agenda)
+}
+
 sync_dotfiles_literate
 repair_legacy_imports
 
-# Pull first, then derive the sync set from files already tracked by gpt-todos.
-# Local agenda files that are not tracked by gpt-todos are never imported.
-git -C "$REPO_DIR" pull --rebase --autostash
+if [[ -n "$(git -C "$REPO_DIR" status --porcelain --untracked-files=all -- agenda)" ]]; then
+  printf 'gpt-todos-sync: durable agenda checkout is dirty; refusing to guess ownership\n' >&2
+  git -C "$REPO_DIR" status --short -- agenda >&2
+  exit 6
+fi
+
+git -C "$REPO_DIR" fetch --prune
+UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)" || {
+  printf 'gpt-todos-sync: current branch has no upstream\n' >&2
+  exit 7
+}
+BASE="$(git -C "$REPO_DIR" rev-parse HEAD)"
+REMOTE_HEAD="$(git -C "$REPO_DIR" rev-parse "$UPSTREAM")"
 
 mapfile -t org_paths < <(
-  git -C "$REPO_DIR" ls-files -- 'agenda/*.org' | sort -u
+  {
+    list_org_paths "$BASE"
+    list_org_paths "$REMOTE_HEAD"
+  } | sort -u
 )
+
 if ((${#org_paths[@]} == 0)); then
   printf 'gpt-todos-sync: no tracked agenda/*.org files; nothing to sync\n'
   exit 0
 fi
 
+local_changes=()
+conflicts=0
+
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
-  repo_file="$REPO_DIR/$rel"
   org_file="$ORG_DIR/$local_rel"
-  mkdir -p "$(dirname "$org_file")"
+  base_hash="$(blob_at "$BASE" "$rel")"
+  remote_hash="$(blob_at "$REMOTE_HEAD" "$rel")"
+  local_hash="$(file_blob "$org_file")"
 
-  if [[ ! -e "$org_file" ]]; then
-    cp -p -- "$repo_file" "$org_file"
-  elif [[ "$org_file" -nt "$repo_file" ]]; then
-    cp -p -- "$org_file" "$repo_file"
-  elif [[ "$repo_file" -nt "$org_file" ]]; then
-    cp -p -- "$repo_file" "$org_file"
-  elif ! cmp -s "$repo_file" "$org_file"; then
-    printf 'gpt-todos-sync: conflict for %s (different contents, same mtime)\n' "$rel" >&2
-    exit 5
+  if [[ "$base_hash" != "-" && "$remote_hash" == "-" ]]; then
+    printf 'gpt-todos-sync: remote deletion requires manual resolution: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
+    continue
+  fi
+
+  if [[ "$base_hash" == "-" ]]; then
+    if [[ "$local_hash" != "-" && "$local_hash" != "$remote_hash" ]]; then
+      printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
+      conflicts=$((conflicts + 1))
+    fi
+    continue
+  fi
+
+  if [[ "$local_hash" == "-" || "$local_hash" == "$remote_hash" ]]; then
+    continue
+  fi
+
+  local_changed=0
+  remote_changed=0
+  [[ "$local_hash" != "$base_hash" ]] && local_changed=1
+  [[ "$remote_hash" != "$base_hash" ]] && remote_changed=1
+
+  if (( local_changed && remote_changed )); then
+    printf 'gpt-todos-sync: concurrent local/remote edit conflict: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
+  elif (( local_changed )); then
+    local_changes+=("$rel")
   fi
 done
 
-git -C "$REPO_DIR" add -- "${org_paths[@]}"
+(( conflicts == 0 )) || exit 5
+
+git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
+
+for rel in "${local_changes[@]}"; do
+  local_rel="${rel#agenda/}"
+  cp -p -- "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
+done
+
+if ((${#local_changes[@]})); then
+  git -C "$REPO_DIR" add -- "${local_changes[@]}"
+fi
 
 if ! git -C "$REPO_DIR" diff --cached --quiet; then
-  # Automated task-state commits must not inherit interactive GPG signing.
   git -C "$REPO_DIR" -c commit.gpgsign=false commit --no-gpg-sign \
     -m "Sync Org task state"
   git -C "$REPO_DIR" push
 fi
 
-# A concurrent remote update after our push is reconciled once more, and the
-# repository copy is authoritative for the final local projection.
-git -C "$REPO_DIR" pull --rebase --autostash
+git -C "$REPO_DIR" fetch --prune
+git -C "$REPO_DIR" merge --ff-only "$UPSTREAM"
+
+mapfile -t org_paths < <(list_org_paths HEAD | sort -u)
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
   mkdir -p "$(dirname "$ORG_DIR/$local_rel")"

--- a/tests/gpt-todos-sync.sh
+++ b/tests/gpt-todos-sync.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SYNC="$ROOT/scripts/gpt-todos-sync"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REMOTE="$TMP/remote.git"
+SEED="$TMP/seed"
+REPO="$TMP/durable"
+ORG="$TMP/org"
+RUN="$TMP/run"
+
+mkdir -p "$ORG" "$RUN"
+git init --bare "$REMOTE" >/dev/null
+git clone "$REMOTE" "$SEED" >/dev/null 2>&1
+mkdir -p "$SEED/agenda"
+
+printf '* TODO shared\n' > "$SEED/agenda/shared.org"
+printf '* TODO remote\n' > "$SEED/agenda/remote.org"
+git -C "$SEED" add agenda
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -m seed >/dev/null
+git -C "$SEED" push -u origin HEAD >/dev/null 2>&1
+
+run_sync() {
+  HOME="$TMP/home" \
+  XDG_RUNTIME_DIR="$RUN" \
+  DOTFILES_DIR="$TMP/no-dotfiles" \
+  GPT_TODOS_REPO_DIR="$REPO" \
+  GPT_TODOS_ORG_DIR="$ORG" \
+  GPT_TODOS_REMOTE="$REMOTE" \
+  GIT_AUTHOR_NAME=test \
+  GIT_AUTHOR_EMAIL=test@example.invalid \
+  GIT_COMMITTER_NAME=test \
+  GIT_COMMITTER_EMAIL=test@example.invalid \
+    bash "$SYNC"
+}
+
+run_sync
+cmp "$ORG/shared.org" "$SEED/agenda/shared.org"
+cmp "$ORG/remote.org" "$SEED/agenda/remote.org"
+
+printf '* TODO private-local-only\n' > "$ORG/private.org"
+printf '* DONE shared-local\n' > "$ORG/shared.org"
+run_sync
+git -C "$SEED" pull >/dev/null 2>&1
+cmp "$ORG/shared.org" "$SEED/agenda/shared.org"
+if git -C "$SEED" ls-files --error-unmatch agenda/private.org >/dev/null 2>&1; then
+  printf 'untracked local agenda file leaked into gpt-todos\n' >&2
+  exit 1
+fi
+
+printf '* DONE remote-change\n' > "$SEED/agenda/remote.org"
+git -C "$SEED" add agenda/remote.org
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -m remote >/dev/null
+git -C "$SEED" push >/dev/null 2>&1
+run_sync
+grep -q 'remote-change' "$ORG/remote.org"
+
+printf '* TODO local-conflict\n' > "$ORG/shared.org"
+git -C "$SEED" pull >/dev/null 2>&1
+printf '* TODO remote-conflict\n' > "$SEED/agenda/shared.org"
+git -C "$SEED" add agenda/shared.org
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -m conflict >/dev/null
+git -C "$SEED" push >/dev/null 2>&1
+
+set +e
+run_sync
+rc=$?
+set -e
+[[ "$rc" -eq 5 ]]
+grep -q 'local-conflict' "$ORG/shared.org"
+
+printf 'gpt-todos bidirectional sync tests passed\n'


### PR DESCRIPTION
## Fix
- replace mtime-based direction selection with Git-blob comparisons against the durable checkout HEAD baseline
- fetch upstream before resolving changes, so local-only edits push and remote-only edits pull
- reject concurrent edits to the same tracked Org file instead of overwriting either side
- restore missing local tracked files from the repository
- keep unrelated/untracked local agenda files out of `gpt-todos`
- treat repository-side deletions as manual-resolution events

## Regression coverage
- repo -> Org bootstrap
- Org tracked edit -> repo commit/push
- remote tracked edit -> Org
- concurrent local/remote same-file conflict -> exit 5 and preserve local content
- unrelated local agenda file is never imported

## Literate source
`scripts/gpt-todos-sync.org` remains canonical and is updated alongside the tangled `scripts/gpt-todos-sync` output.
