### PR TITLE
feat(opencode): add Nix-packaged Prolog MCP

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -61,6 +61,8 @@ jobs:
           name: nix-community
       - name: Evaluate flake checks without building system closures
         run: nix flake check --no-build --show-trace
+      - name: Build and test Prolog MCP package
+        run: nix build .#checks.x86_64-linux.prolog-mcp --no-link
       - name: Evaluate desktop Home Manager configuration
         run: nix eval --raw '.#homeConfigurations."unseen@desktop".activationPackage.drvPath'
       - name: Evaluate flake Home Manager configuration

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
       system = "x86_64-linux";
       lib = nixpkgs.lib;
       pkgs = nixpkgs.legacyPackages.${system};
+      prologMcp = pkgs.callPackage ./nix/packages/prolog-mcp.nix { };
 
       sharedArgs = {
         inherit self disko;
@@ -160,6 +161,7 @@
         logos-iso = logosIso.config.system.build.isoImage;
         install-logos = installLogos;
         install-logos-gui = installLogosGui;
+        prolog-mcp = prologMcp;
         inherit flash-logos;
         unseen-home = homeConfigurations."unseen@logos".activationPackage;
       };
@@ -178,6 +180,7 @@
       checks.${system} = {
         logos = logos.config.system.build.toplevel;
         install-logos = installLogos;
+        prolog-mcp = prologMcp;
         unseen-home = homeConfigurations."unseen@logos".activationPackage;
         unseen-flake-home = homeConfigurations."unseen@flake".activationPackage;
       };

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -13,6 +13,7 @@
     ./media.nix
     ./pentesting.nix
     ./llm.nix
+    ./prolog-mcp.nix
     ./proxmox-mcp.nix
     ./discord-mcp.nix
     ./unifi-mcp.nix

--- a/nix/home-manager/mods/prolog-mcp.nix
+++ b/nix/home-manager/mods/prolog-mcp.nix
@@ -24,7 +24,7 @@ in
 
     skillRevision = lib.mkOption {
       type = lib.types.str;
-      default = "ecc1bbfd35039c0d3155e10efca6ad768b46807b";
+      default = "b60b658ecad86cddb9cfec4113ff32f6f734933a";
       description = "Pinned lost-rob0t/skills revision containing the OpenCode Prolog skill.";
     };
   };

--- a/nix/home-manager/mods/prolog-mcp.nix
+++ b/nix/home-manager/mods/prolog-mcp.nix
@@ -1,0 +1,98 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.prologMcp;
+
+  prologMcpSource = builtins.fetchGit {
+    url = "https://github.com/dicelab-rhul/PrologMCP.git";
+    rev = cfg.revision;
+  };
+
+  skillSource = builtins.fetchGit {
+    url = "https://github.com/lost-rob0t/skills.git";
+    rev = cfg.skillRevision;
+  };
+
+  prologMcpPackage = pkgs.python3Packages.buildPythonApplication {
+    pname = "prolog-mcp";
+    version = "0.1.0";
+    pyproject = true;
+    src = prologMcpSource;
+
+    build-system = [ pkgs.python3Packages.hatchling ];
+    dependencies = [ pkgs.python3Packages.mcp ];
+
+    # Upstream keeps harness.pl at the repository root, but its wheel only
+    # contains src/prolog_mcp. Point the installed session manager at the
+    # immutable pinned source tree rather than relying on a missing wheel file.
+    postPatch = ''
+      substituteInPlace src/prolog_mcp/session.py \
+        --replace-fail \
+          '_HARNESS_PL = _HERE.parent.parent / "harness.pl"' \
+          '_HARNESS_PL = Path("${prologMcpSource}/harness.pl")'
+    '';
+
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    nativeCheckInputs = with pkgs.python3Packages; [
+      pytestCheckHook
+      pytest-asyncio
+      pkgs.swi-prolog
+    ];
+
+    preCheck = ''
+      export HOME="$TMPDIR/home"
+      mkdir -p "$HOME"
+      export PATH="${lib.makeBinPath [ pkgs.swi-prolog ]}:$PATH"
+    '';
+
+    # PrologMCP launches `swipl` subprocesses by name. Keep that dependency
+    # explicit even when OpenCode is started from a minimal environment.
+    postFixup = ''
+      wrapProgram "$out/bin/prolog-mcp" \
+        --prefix PATH : "${lib.makeBinPath [ pkgs.swi-prolog ]}"
+    '';
+
+    meta = {
+      description = "MCP server exposing isolated SWI-Prolog sessions over stdio";
+      homepage = "https://github.com/dicelab-rhul/PrologMCP";
+      license = lib.licenses.mit;
+      mainProgram = "prolog-mcp";
+      platforms = lib.platforms.linux;
+    };
+  };
+in
+{
+  options.prologMcp = {
+    enable = lib.mkEnableOption "local Prolog MCP integration for OpenCode";
+
+    revision = lib.mkOption {
+      type = lib.types.str;
+      default = "4ae536fd9b1cef8419d1798b5d4cb1569cba3cae";
+      description = "Pinned dicelab-rhul/PrologMCP Git revision.";
+    };
+
+    skillRevision = lib.mkOption {
+      type = lib.types.str;
+      default = "ecc1bbfd35039c0d3155e10efca6ad768b46807b";
+      description = "Pinned lost-rob0t/skills revision containing the OpenCode Prolog skill.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ prologMcpPackage ];
+
+    programs.mcp = {
+      enable = true;
+      servers.prolog = {
+        command = "${prologMcpPackage}/bin/prolog-mcp";
+        enabled = true;
+      };
+    };
+
+    programs.opencode = {
+      enable = lib.mkDefault true;
+      enableMcpIntegration = true;
+      skills.prolog-reasoning = "${skillSource}/opencode/prolog-reasoning";
+    };
+  };
+}

--- a/nix/home-manager/mods/prolog-mcp.nix
+++ b/nix/home-manager/mods/prolog-mcp.nix
@@ -3,62 +3,13 @@
 let
   cfg = config.prologMcp;
 
-  prologMcpSource = builtins.fetchGit {
-    url = "https://github.com/dicelab-rhul/PrologMCP.git";
-    rev = cfg.revision;
+  prologMcpPackage = pkgs.callPackage ../../packages/prolog-mcp.nix {
+    revision = cfg.revision;
   };
 
   skillSource = builtins.fetchGit {
     url = "https://github.com/lost-rob0t/skills.git";
     rev = cfg.skillRevision;
-  };
-
-  prologMcpPackage = pkgs.python3Packages.buildPythonApplication {
-    pname = "prolog-mcp";
-    version = "0.1.0";
-    pyproject = true;
-    src = prologMcpSource;
-
-    build-system = [ pkgs.python3Packages.hatchling ];
-    dependencies = [ pkgs.python3Packages.mcp ];
-
-    # Upstream keeps harness.pl at the repository root, but its wheel only
-    # contains src/prolog_mcp. Point the installed session manager at the
-    # immutable pinned source tree rather than relying on a missing wheel file.
-    postPatch = ''
-      substituteInPlace src/prolog_mcp/session.py \
-        --replace-fail \
-          '_HARNESS_PL = _HERE.parent.parent / "harness.pl"' \
-          '_HARNESS_PL = Path("${prologMcpSource}/harness.pl")'
-    '';
-
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-    nativeCheckInputs = with pkgs.python3Packages; [
-      pytestCheckHook
-      pytest-asyncio
-      pkgs.swi-prolog
-    ];
-
-    preCheck = ''
-      export HOME="$TMPDIR/home"
-      mkdir -p "$HOME"
-      export PATH="${lib.makeBinPath [ pkgs.swi-prolog ]}:$PATH"
-    '';
-
-    # PrologMCP launches `swipl` subprocesses by name. Keep that dependency
-    # explicit even when OpenCode is started from a minimal environment.
-    postFixup = ''
-      wrapProgram "$out/bin/prolog-mcp" \
-        --prefix PATH : "${lib.makeBinPath [ pkgs.swi-prolog ]}"
-    '';
-
-    meta = {
-      description = "MCP server exposing isolated SWI-Prolog sessions over stdio";
-      homepage = "https://github.com/dicelab-rhul/PrologMCP";
-      license = lib.licenses.mit;
-      mainProgram = "prolog-mcp";
-      platforms = lib.platforms.linux;
-    };
   };
 in
 {

--- a/nix/home-manager/mods/prolog-mcp.nix
+++ b/nix/home-manager/mods/prolog-mcp.nix
@@ -6,11 +6,6 @@ let
   prologMcpPackage = pkgs.callPackage ../../packages/prolog-mcp.nix {
     revision = cfg.revision;
   };
-
-  skillSource = builtins.fetchGit {
-    url = "https://github.com/lost-rob0t/skills.git";
-    rev = cfg.skillRevision;
-  };
 in
 {
   options.prologMcp = {
@@ -20,12 +15,6 @@ in
       type = lib.types.str;
       default = "4ae536fd9b1cef8419d1798b5d4cb1569cba3cae";
       description = "Pinned dicelab-rhul/PrologMCP Git revision.";
-    };
-
-    skillRevision = lib.mkOption {
-      type = lib.types.str;
-      default = "b60b658ecad86cddb9cfec4113ff32f6f734933a";
-      description = "Pinned lost-rob0t/skills revision containing the OpenCode Prolog skill.";
     };
   };
 
@@ -43,7 +32,6 @@ in
     programs.opencode = {
       enable = lib.mkDefault true;
       enableMcpIntegration = true;
-      skills.prolog-reasoning = "${skillSource}/opencode/prolog-reasoning";
     };
   };
 }

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -20,6 +20,10 @@
     enable = true;
   };
 
+  prologMcp = {
+    enable = true;
+  };
+
   proxmoxMcp = {
     enable = true;
   };
@@ -60,14 +64,14 @@
     homeDirectory = "/home/unseen";
     stateVersion = "23.11";
   };
-  # This value determines the Home Manager release that your
+  # This value determines which Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
-  # changes in each release.
+  # changes.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -64,14 +64,14 @@
     homeDirectory = "/home/unseen";
     stateVersion = "23.11";
   };
-  # This value determines which Home Manager release that your
+  # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
-  # changes.
+  # changes in each release.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/packages/prolog-mcp.nix
+++ b/nix/packages/prolog-mcp.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  makeWrapper,
+  python3Packages,
+  swi-prolog,
+  revision ? "4ae536fd9b1cef8419d1798b5d4cb1569cba3cae",
+}:
+
+let
+  source = builtins.fetchGit {
+    url = "https://github.com/dicelab-rhul/PrologMCP.git";
+    rev = revision;
+  };
+in
+python3Packages.buildPythonApplication {
+  pname = "prolog-mcp";
+  version = "0.1.0";
+  pyproject = true;
+  src = source;
+
+  build-system = [ python3Packages.hatchling ];
+  dependencies = [ python3Packages.mcp ];
+
+  # Upstream keeps harness.pl at the repository root, but its wheel only
+  # contains src/prolog_mcp. Point the installed session manager at the
+  # immutable pinned source tree rather than relying on a missing wheel file.
+  postPatch = ''
+    substituteInPlace src/prolog_mcp/session.py \
+      --replace-fail \
+        '_HARNESS_PL = _HERE.parent.parent / "harness.pl"' \
+        '_HARNESS_PL = Path("${source}/harness.pl")'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    python3Packages.pytest-asyncio
+    swi-prolog
+  ];
+
+  preCheck = ''
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+    export PATH="${lib.makeBinPath [ swi-prolog ]}:$PATH"
+  '';
+
+  # PrologMCP launches `swipl` subprocesses by name. Keep that dependency
+  # explicit even when OpenCode is started from a minimal environment.
+  postFixup = ''
+    wrapProgram "$out/bin/prolog-mcp" \
+      --prefix PATH : "${lib.makeBinPath [ swi-prolog ]}"
+  '';
+
+  meta = {
+    description = "MCP server exposing isolated SWI-Prolog sessions over stdio";
+    homepage = "https://github.com/dicelab-rhul/PrologMCP";
+    license = lib.licenses.mit;
+    mainProgram = "prolog-mcp";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

Add a local Prolog reasoning MCP to OpenCode, packaged and configured entirely through Nix/Home Manager.

### MCP choice

Use `dicelab-rhul/PrologMCP` pinned at `4ae536fd9b1cef8419d1798b5d4cb1569cba3cae`.

It is a small stdio MCP designed specifically around isolated SWI-Prolog sessions. Its tool surface includes session creation/consultation, bounded goals, predicate inspection, PlUnit tests, proof tracing, predicate replacement, source reconstruction, and cleanup. Upstream explicitly supports SWI-Prolog 9.0–9.2+, matching nixos-26.05's SWI 9.2.9.

### Nix packaging

- add `nix/packages/prolog-mcp.nix` as a real `buildPythonApplication` derivation;
- use nixpkgs' MCP Python SDK instead of `uvx`/pip at runtime;
- patch upstream's wheel-layout `harness.pl` issue to the immutable pinned source path;
- wrap `prolog-mcp` so spawned sessions always resolve the Nix SWI-Prolog;
- run upstream pytest coverage during the package build;
- expose `.#prolog-mcp` and include it in `flake check`.

### Home Manager / OpenCode

- add `prologMcp.enable` with a pinned upstream revision;
- register the server once through Home Manager's generic `programs.mcp.servers.prolog`;
- enable Home Manager's OpenCode MCP integration rather than hand-writing `opencode.json`;
- enable it for desktop-derived profiles (`desktop`, `flake`, and `logos`).

### OpenCode skill

Companion skill is already merged in `lost-rob0t/skills#2` at `b60b658ecad86cddb9cfec4113ff32f6f734933a`.

The private skills repository is intentionally not fetched during dotfiles/Nix evaluation. That keeps dotfiles evaluation reproducible in CI and leaves skill distribution in the skills repository where it belongs.

## Validation

CI / `nix flake check` is authoritative. The `prolog-mcp` check builds the package and runs upstream tests against the pinned SWI-Prolog dependency.