### PR TITLE
feat(opencode): install skills from public flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,31 +53,12 @@ jobs:
   logos:
     needs: workflows
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
-      - name: Refresh flake lock on PR branch
-        if: github.event_name == 'pull_request'
-        env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          set -euo pipefail
-          nix flake lock
-          if ! git diff --quiet -- flake.lock; then
-            git config user.name 'github-actions[bot]'
-            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-            git add flake.lock
-            git commit -m 'chore(nix): lock skills input'
-            git push origin "HEAD:$PR_HEAD_REF"
-            exit 1
-          fi
       - name: Check flake lock is current
         run: |
           set -euo pipefail

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,12 +53,29 @@ jobs:
   logos:
     needs: workflows
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
+      - name: Refresh flake lock on PR branch
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          nix flake lock
+          if ! git diff --quiet -- flake.lock; then
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add flake.lock
+            git commit -m 'chore(nix): lock skills input'
+            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+            exit 1
+          fi
       - name: Check flake lock is current
         run: |
           set -euo pipefail

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -65,6 +65,8 @@ jobs:
           name: nix-community
       - name: Refresh flake lock on PR branch
         if: github.event_name == 'pull_request'
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           nix flake lock
@@ -73,7 +75,7 @@ jobs:
             git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
             git add flake.lock
             git commit -m 'chore(nix): lock skills input'
-            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+            git push origin "HEAD:$PR_HEAD_REF"
             exit 1
           fi
       - name: Check flake lock is current

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -59,6 +59,12 @@ jobs:
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
+      - name: Check flake lock is current
+        run: |
+          set -euo pipefail
+          nix flake lock
+          git diff -- flake.lock
+          git diff --exit-code -- flake.lock
       - name: Evaluate flake checks without building system closures
         run: nix flake check --no-build --show-trace
       - name: Build and test Prolog MCP package

--- a/flake.lock
+++ b/flake.lock
@@ -279,7 +279,23 @@
         "mousetrap": "mousetrap",
         "nixpkgs": "nixpkgs_3",
         "org-vector": "org-vector",
+        "skills": "skills",
         "zara": "zara"
+      }
+    },
+    "skills": {
+      "locked": {
+        "lastModified": 1787370155,
+        "narHash": "sha256-qi1vjlNgLomfBgaJmLGjDIo/75i0I1pqkWf2gKMII/8=",
+        "owner": "lost-rob0t",
+        "repo": "skills",
+        "rev": "976f3912a9c8f8cc155492f2511ecdbc2508cbbc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lost-rob0t",
+        "repo": "skills",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    skills.url = "github:lost-rob0t/skills";
     chatgpt-desktop = {
       url = "github:lost-rob0t/chatgpt-desktop";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -27,6 +28,7 @@
       nixpkgs,
       disko,
       home-manager,
+      skills,
       chatgpt-desktop,
       zara,
       org-vector,

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -1,6 +1,7 @@
-{ config, pkgs, ... }:
+{ config, pkgs, inputs, ... }:
 {
   imports = [
+    inputs.skills.homeManagerModules.opencode
     ./base.nix
     ./desktop.nix
     ./fonts.nix


### PR DESCRIPTION
## Summary

Consume the public `lost-rob0t/skills` repository as a Nix flake input and install its OpenCode skills through the flake's Home Manager module.

### Changes

- add `inputs.skills = github:lost-rob0t/skills`;
- pin the merged skills flake revision in `flake.lock`;
- pass the input through the existing Home Manager `inputs` special arg;
- import `inputs.skills.homeManagerModules.opencode` from the shared Home Manager module stack;
- keep `lost-rob0t/skills` as the source of truth for `SKILL.md` content;
- keep dotfiles responsible only for deployment/pinning;
- require CI to verify that `flake.lock` is committed and current.

This installs the current exported skills declaratively:
- `dotfiles-workflow`
- `prolog-reasoning`

The skills workflow uses `/home/unseen/Documents/AI/skills` as the canonical local checkout and clones `lost-rob0t/skills` there when absent. Dotfiles remains `$HOME/.dotfiles`.

## Validation

CI must verify the committed lockfile, evaluate the flake, build/test Prolog MCP, and evaluate the desktop + flake Home Manager profiles before merge.