### PR TITLE
chore(opencode): deploy corrected skills revision

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,12 +53,31 @@ jobs:
   logos:
     needs: workflows
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
+      - name: Refresh skills lock on PR branch
+        if: github.event_name == 'pull_request'
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          nix flake update skills
+          if ! git diff --quiet -- flake.lock; then
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add flake.lock
+            git commit -m 'chore(nix): update skills input'
+            git push origin "HEAD:$PR_HEAD_REF"
+            exit 1
+          fi
       - name: Check flake lock is current
         run: |
           set -euo pipefail

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,31 +53,12 @@ jobs:
   logos:
     needs: workflows
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:
           name: nix-community
-      - name: Refresh skills lock on PR branch
-        if: github.event_name == 'pull_request'
-        env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          set -euo pipefail
-          nix flake update skills
-          if ! git diff --quiet -- flake.lock; then
-            git config user.name 'github-actions[bot]'
-            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-            git add flake.lock
-            git commit -m 'chore(nix): update skills input'
-            git push origin "HEAD:$PR_HEAD_REF"
-            exit 1
-          fi
       - name: Check flake lock is current
         run: |
           set -euo pipefail

--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
     },
     "skills": {
       "locked": {
-        "lastModified": 1787370155,
-        "narHash": "sha256-qi1vjlNgLomfBgaJmLGjDIo/75i0I1pqkWf2gKMII/8=",
+        "lastModified": 1787370831,
+        "narHash": "sha256-36HQ45W87qRaLvOkN7/TWyUzkqfIvsuMjc7sH4tA9TM=",
         "owner": "lost-rob0t",
         "repo": "skills",
-        "rev": "976f3912a9c8f8cc155492f2511ecdbc2508cbbc",
+        "rev": "5eb82b878f8906fc6462c179334ff45ee197db17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Update the `skills` flake lock to the corrected public `lost-rob0t/skills` revision after skills PR #5.

The corrected `dotfiles-workflow` uses `$HOME/skills` as the canonical skill checkout and `$HOME/.dotfiles` for dotfiles.

This PR changes deployment metadata only. CI temporarily refreshes the `skills` lock on this feature branch; that write-capable helper is removed again before merge.

## Validation

Final head must pass the permanent read-only lock freshness gate, flake evaluation, Prolog MCP build/tests, and desktop + flake Home Manager evaluation.