### PR TITLE
fix(qtile): replace OpenRouter credit meter with TPM telemetry

### DIFF
--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -4,8 +4,16 @@
 * Runtime helper
 
 This file is the source of truth for the OpenRouter status widgets and the
-=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding.  Tangle this file whenever
+=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding. Tangle this file whenever
 that runtime helper changes.
+
+OpenRouter telemetry is intentionally rate-oriented: the text widget reports
+prompt and completion tokens consumed during the trailing 60 seconds as tokens
+per minute. The balance and 30-day counters are not shown. The API poll is
+bounded to once every five seconds, and the graph keeps five minutes of those
+samples. Constant series are hidden rather than drawing fake full-height rails;
+when a rate moves, each stream gets an adaptive visual range so its shape stays
+visible even when prompt traffic dwarfs completion traffic.
 
 #+begin_src python
 """OpenRouter telemetry widgets and small Qtile runtime helpers."""
@@ -25,12 +33,10 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
-POLL_SECONDS = 1
+POLL_SECONDS = 5
 GRAPH_SAMPLES = 60
 GRAPH_WIDTH = 76
-CREDIT_FONTSIZE = 14
-IO_FONTSIZE = 12
-ROLLING_FONTSIZE = 13
+RATE_FONTSIZE = 12
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
@@ -68,24 +74,16 @@ def _compact_count(value):
     return str(int(round(value)))
 
 
-def _credit_color(value, colors):
-    if value < 5:
-        return _color(colors, 8)
-    if value < 10:
-        return _color(colors, 3)
-    return _color(colors, 7)
-
-
 def _fetch_payload(script):
     global _last_payload, _last_poll_at
 
     with _poll_lock:
         now = time.monotonic()
-        if _last_payload is not None and now - _last_poll_at < 0.9:
+        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
             return _last_payload
 
         completed = subprocess.run(
-            ["python3", script, "--json", "--force"],
+            ["python3", script, "--json"],
             check=False,
             capture_output=True,
             text=True,
@@ -97,7 +95,7 @@ def _fetch_payload(script):
             payload = None
 
         _last_poll_at = time.monotonic()
-        if isinstance(payload, dict) and "credits_remaining" in payload:
+        if isinstance(payload, dict) and "input_tokens_per_minute" in payload:
             _last_payload = payload
             return payload
 
@@ -189,8 +187,8 @@ def _sync_and_reload(qtile):
     ).start()
 
 
-class OpenRouterCredit(base.BackgroundPoll):
-    """Poll OpenRouter once per second across all monitor instances."""
+class OpenRouterRate(base.BackgroundPoll):
+    """Display a rolling 60-second OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -204,56 +202,23 @@ class OpenRouterCredit(base.BackgroundPoll):
         if not payload:
             return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
 
-        credits = float(payload["credits_remaining"])
+        incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
+        outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
         stale = " ~" if payload.get("stale") else ""
-        color = _credit_color(credits, self.colors)
         return (
-            f'<span foreground="{color}">'
-            f"\U000F09D1 ${credits:.2f}{stale}</span>"
-        )
-
-
-class OpenRouterCacheText(base.InLoopPollText):
-    """Read the shared OpenRouter cache without spawning more API requests."""
-
-    orientations = base.ORIENTATION_HORIZONTAL
-
-    def __init__(self, mode, colors, **config):
-        self.mode = mode
-        self.colors = colors
-        super().__init__(default_text="", **config)
-
-    def poll(self):
-        status = _read_cached_status()
-        if not status:
-            return ""
-
-        if self.mode == "io":
-            incoming = _compact_count(status.get("live_input_tokens", 0))
-            outgoing = _compact_count(status.get("live_output_tokens", 0))
-            return (
-                f'<span foreground="{_color(self.colors, 6)}">{incoming}↓</span>\n'
-                f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑</span>'
-            )
-
-        rolling = (
-            int(status.get("rolling_input_tokens", 0))
-            + int(status.get("rolling_output_tokens", 0))
-        )
-        return (
-            f'<span foreground="{_color(self.colors, 4)}">'
-            f"30d:{_compact_count(rolling)}</span>"
+            f'<span foreground="{_color(self.colors, 6)}">{incoming}↓/m</span>\n'
+            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{stale}</span>'
         )
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Mirrored one-minute token I/O sparkline fed from the shared cache."""
+    """Five-minute sparkline of sampled input/output tokens per minute."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Number of one-second samples."),
+        ("samples", GRAPH_SAMPLES, "Number of rate samples."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -265,26 +230,34 @@ class OpenRouterIOGraph(base._Widget):
     def __init__(self, width=GRAPH_WIDTH, **config):
         super().__init__(width, **config)
         self.add_defaults(self.defaults)
-        self.input_values = deque([0.0] * self.samples, maxlen=self.samples)
-        self.output_values = deque([0.0] * self.samples, maxlen=self.samples)
+        self.input_values = deque(maxlen=self.samples)
+        self.output_values = deque(maxlen=self.samples)
 
     def timer_setup(self):
         self._update()
         self.timeout_add(self.frequency, self.timer_setup)
 
     def _update(self):
-        status = _read_cached_status() or {}
-        self.input_values.append(float(status.get("live_input_tokens", 0)))
-        self.output_values.append(float(status.get("live_output_tokens", 0)))
+        status = _read_cached_status()
+        if status:
+            self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
+            self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
         self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
             return
 
-        # Each stream gets its own scale. Prompt traffic can be orders of
-        # magnitude larger than completion traffic and must not flatten it.
-        maximum = max(max(values, default=0), 1)
+        values = list(values)
+        minimum = min(values)
+        maximum = max(values)
+        if maximum <= minimum:
+            return
+
+        # Absolute rates are printed beside the graph. The sparkline uses an
+        # adaptive per-stream range so real movement remains visible even when
+        # prompt and completion traffic differ by orders of magnitude.
+        span = maximum - minimum
         usable_width = max(self.width - 2 * self.margin_x, 1)
         step = usable_width / max(len(values) - 1, 1)
 
@@ -293,7 +266,8 @@ class OpenRouterIOGraph(base._Widget):
 
         for index, value in enumerate(values):
             x = self.margin_x + index * step
-            distance = (float(value) / maximum) * half_height
+            normalized = (float(value) - minimum) / span
+            distance = (0.15 + 0.85 * normalized) * half_height
             y = center_y + direction * distance
             if index == 0:
                 self.drawer.ctx.move_to(x, y)
@@ -359,26 +333,14 @@ def _telemetry_widgets(home, colors):
     background = _color(colors, 1)
 
     return [
-        OpenRouterCredit(
+        OpenRouterRate(
             script,
             colors,
-            name="openrouter_credit",
+            name="openrouter_rate",
             update_interval=POLL_SECONDS,
             markup=True,
             font="Hack Nerd Regular",
-            fontsize=CREDIT_FONTSIZE,
-            padding=4,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
-        OpenRouterCacheText(
-            "io",
-            colors,
-            name="openrouter_io",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=IO_FONTSIZE,
+            fontsize=RATE_FONTSIZE,
             padding=3,
             foreground=_color(colors, 5),
             background=background,
@@ -390,18 +352,6 @@ def _telemetry_widgets(home, colors):
             input_color=_color(colors, 6),
             output_color=_color(colors, 4),
             midline_color=_color(colors, 2),
-            background=background,
-        ),
-        OpenRouterCacheText(
-            "rolling",
-            colors,
-            name="openrouter_rolling",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=ROLLING_FONTSIZE,
-            padding=4,
-            foreground=_color(colors, 4),
             background=background,
         ),
     ]

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -15,12 +15,10 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
-POLL_SECONDS = 1
+POLL_SECONDS = 5
 GRAPH_SAMPLES = 60
 GRAPH_WIDTH = 76
-CREDIT_FONTSIZE = 14
-IO_FONTSIZE = 12
-ROLLING_FONTSIZE = 13
+RATE_FONTSIZE = 12
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
@@ -58,24 +56,16 @@ def _compact_count(value):
     return str(int(round(value)))
 
 
-def _credit_color(value, colors):
-    if value < 5:
-        return _color(colors, 8)
-    if value < 10:
-        return _color(colors, 3)
-    return _color(colors, 7)
-
-
 def _fetch_payload(script):
     global _last_payload, _last_poll_at
 
     with _poll_lock:
         now = time.monotonic()
-        if _last_payload is not None and now - _last_poll_at < 0.9:
+        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
             return _last_payload
 
         completed = subprocess.run(
-            ["python3", script, "--json", "--force"],
+            ["python3", script, "--json"],
             check=False,
             capture_output=True,
             text=True,
@@ -87,7 +77,7 @@ def _fetch_payload(script):
             payload = None
 
         _last_poll_at = time.monotonic()
-        if isinstance(payload, dict) and "credits_remaining" in payload:
+        if isinstance(payload, dict) and "input_tokens_per_minute" in payload:
             _last_payload = payload
             return payload
 
@@ -179,8 +169,8 @@ def _sync_and_reload(qtile):
     ).start()
 
 
-class OpenRouterCredit(base.BackgroundPoll):
-    """Poll OpenRouter once per second across all monitor instances."""
+class OpenRouterRate(base.BackgroundPoll):
+    """Display a rolling 60-second OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -194,56 +184,23 @@ class OpenRouterCredit(base.BackgroundPoll):
         if not payload:
             return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
 
-        credits = float(payload["credits_remaining"])
+        incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
+        outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
         stale = " ~" if payload.get("stale") else ""
-        color = _credit_color(credits, self.colors)
         return (
-            f'<span foreground="{color}">'
-            f"\U000F09D1 ${credits:.2f}{stale}</span>"
-        )
-
-
-class OpenRouterCacheText(base.InLoopPollText):
-    """Read the shared OpenRouter cache without spawning more API requests."""
-
-    orientations = base.ORIENTATION_HORIZONTAL
-
-    def __init__(self, mode, colors, **config):
-        self.mode = mode
-        self.colors = colors
-        super().__init__(default_text="", **config)
-
-    def poll(self):
-        status = _read_cached_status()
-        if not status:
-            return ""
-
-        if self.mode == "io":
-            incoming = _compact_count(status.get("live_input_tokens", 0))
-            outgoing = _compact_count(status.get("live_output_tokens", 0))
-            return (
-                f'<span foreground="{_color(self.colors, 6)}">{incoming}↓</span>\n'
-                f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑</span>'
-            )
-
-        rolling = (
-            int(status.get("rolling_input_tokens", 0))
-            + int(status.get("rolling_output_tokens", 0))
-        )
-        return (
-            f'<span foreground="{_color(self.colors, 4)}">'
-            f"30d:{_compact_count(rolling)}</span>"
+            f'<span foreground="{_color(self.colors, 6)}">{incoming}↓/m</span>\n'
+            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{stale}</span>'
         )
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Mirrored one-minute token I/O sparkline fed from the shared cache."""
+    """Five-minute sparkline of sampled input/output tokens per minute."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Number of one-second samples."),
+        ("samples", GRAPH_SAMPLES, "Number of rate samples."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -255,26 +212,34 @@ class OpenRouterIOGraph(base._Widget):
     def __init__(self, width=GRAPH_WIDTH, **config):
         super().__init__(width, **config)
         self.add_defaults(self.defaults)
-        self.input_values = deque([0.0] * self.samples, maxlen=self.samples)
-        self.output_values = deque([0.0] * self.samples, maxlen=self.samples)
+        self.input_values = deque(maxlen=self.samples)
+        self.output_values = deque(maxlen=self.samples)
 
     def timer_setup(self):
         self._update()
         self.timeout_add(self.frequency, self.timer_setup)
 
     def _update(self):
-        status = _read_cached_status() or {}
-        self.input_values.append(float(status.get("live_input_tokens", 0)))
-        self.output_values.append(float(status.get("live_output_tokens", 0)))
+        status = _read_cached_status()
+        if status:
+            self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
+            self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
         self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
             return
 
-        # Each stream gets its own scale. Prompt traffic can be orders of
-        # magnitude larger than completion traffic and must not flatten it.
-        maximum = max(max(values, default=0), 1)
+        values = list(values)
+        minimum = min(values)
+        maximum = max(values)
+        if maximum <= minimum:
+            return
+
+        # Absolute rates are printed beside the graph. The sparkline uses an
+        # adaptive per-stream range so real movement remains visible even when
+        # prompt and completion traffic differ by orders of magnitude.
+        span = maximum - minimum
         usable_width = max(self.width - 2 * self.margin_x, 1)
         step = usable_width / max(len(values) - 1, 1)
 
@@ -283,7 +248,8 @@ class OpenRouterIOGraph(base._Widget):
 
         for index, value in enumerate(values):
             x = self.margin_x + index * step
-            distance = (float(value) / maximum) * half_height
+            normalized = (float(value) - minimum) / span
+            distance = (0.15 + 0.85 * normalized) * half_height
             y = center_y + direction * distance
             if index == 0:
                 self.drawer.ctx.move_to(x, y)
@@ -349,26 +315,14 @@ def _telemetry_widgets(home, colors):
     background = _color(colors, 1)
 
     return [
-        OpenRouterCredit(
+        OpenRouterRate(
             script,
             colors,
-            name="openrouter_credit",
+            name="openrouter_rate",
             update_interval=POLL_SECONDS,
             markup=True,
             font="Hack Nerd Regular",
-            fontsize=CREDIT_FONTSIZE,
-            padding=4,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
-        OpenRouterCacheText(
-            "io",
-            colors,
-            name="openrouter_io",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=IO_FONTSIZE,
+            fontsize=RATE_FONTSIZE,
             padding=3,
             foreground=_color(colors, 5),
             background=background,
@@ -380,18 +334,6 @@ def _telemetry_widgets(home, colors):
             input_color=_color(colors, 6),
             output_color=_color(colors, 4),
             midline_color=_color(colors, 2),
-            background=background,
-        ),
-        OpenRouterCacheText(
-            "rolling",
-            colors,
-            name="openrouter_rolling",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=ROLLING_FONTSIZE,
-            padding=4,
-            foreground=_color(colors, 4),
             background=background,
         ),
     ]

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render OpenRouter credits and token telemetry for the Qtile bar."""
+"""Render OpenRouter token-per-minute telemetry for the Qtile bar."""
 
 from __future__ import annotations
 
@@ -18,33 +18,25 @@ from typing import Any
 
 API_BASE = "https://openrouter.ai/api/v1"
 # Nerd Fonts v3+ Material Design "brain" (nf-md-brain).
-# The old U+F5DC Material Design range was removed in Nerd Fonts v3.
 AI_ICON = "\U000F09D1"
 
 RED = "#dd546e"
-YELLOW = "#fba922"
-GREEN = "#62FF00"
 IO = "#f6019d"
 ACCENT = "#2de2e6"
 
-CACHE_TTL_SECONDS = 12
-ROLLING_TTL_SECONDS = 300
-LIVE_WINDOW_SECONDS = 60
-ROLLING_DAYS = 30
+CACHE_TTL_SECONDS = 4
+RATE_WINDOW_SECONDS = 60
 REQUEST_TIMEOUT_SECONDS = 5
 
 
 @dataclass(frozen=True)
 class Status:
-    credits_remaining: float
-    live_input_tokens: int
-    live_output_tokens: int
-    rolling_input_tokens: int
-    rolling_output_tokens: int
+    input_tokens_per_minute: int
+    output_tokens_per_minute: int
 
     @property
-    def rolling_tokens(self) -> int:
-        return self.rolling_input_tokens + self.rolling_output_tokens
+    def total_tokens_per_minute(self) -> int:
+        return self.input_tokens_per_minute + self.output_tokens_per_minute
 
 
 def compact_count(value: int | float) -> str:
@@ -56,24 +48,13 @@ def compact_count(value: int | float) -> str:
     return str(int(round(value)))
 
 
-def credit_color(credits_remaining: float) -> str:
-    if credits_remaining < 5:
-        return RED
-    if credits_remaining < 10:
-        return YELLOW
-    return GREEN
-
-
 def render(status: Status, *, stale: bool = False) -> str:
     stale_marker = " ~" if stale else ""
     return (
-        f'<span foreground="{credit_color(status.credits_remaining)}">'
-        f"{AI_ICON} ${status.credits_remaining:.2f}</span>"
-        f' <span foreground="{IO}">'
-        f"tok:{compact_count(status.live_input_tokens)}↓ "
-        f"{compact_count(status.live_output_tokens)}↑</span>"
-        f' <span foreground="{ACCENT}">'
-        f"30d:{compact_count(status.rolling_tokens)}{stale_marker}</span>"
+        f'<span foreground="{IO}">{AI_ICON} '
+        f"{compact_count(status.input_tokens_per_minute)}↓/m</span> "
+        f'<span foreground="{ACCENT}">'
+        f"{compact_count(status.output_tokens_per_minute)}↑/m{stale_marker}</span>"
     )
 
 
@@ -111,7 +92,7 @@ def _request_json(
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}",
-        "User-Agent": "qtile-openrouter-status/1",
+        "User-Agent": "qtile-openrouter-status/2",
     }
     if payload is not None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -139,20 +120,11 @@ def _request_json(
         raise RuntimeError("OpenRouter unavailable") from exc
 
 
-def parse_credits(payload: dict[str, Any]) -> float:
-    data = payload["data"]
-    return max(0.0, float(data["total_credits"]) - float(data["total_usage"]))
-
-
 def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
     rows = payload.get("data", {}).get("data", [])
     prompt = sum(float(row.get("tokens_prompt") or 0) for row in rows)
     completion = sum(float(row.get("tokens_completion") or 0) for row in rows)
     return int(round(prompt)), int(round(completion))
-
-
-def fetch_credits(key: str) -> float:
-    return parse_credits(_request_json("GET", "/credits", key))
 
 
 def fetch_tokens(
@@ -194,20 +166,13 @@ def _status_from_cache(cache: dict[str, Any] | None) -> Status | None:
         return None
 
 
-def _write_cache(
-    path: Path,
-    status: Status,
-    *,
-    fetched_at: float,
-    rolling_updated_at: float,
-) -> None:
+def _write_cache(path: Path, status: Status, *, fetched_at: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(".tmp")
     temporary.write_text(
         json.dumps(
             {
                 "fetched_at": fetched_at,
-                "rolling_updated_at": rolling_updated_at,
                 "status": asdict(status),
             },
             separators=(",", ":"),
@@ -217,39 +182,16 @@ def _write_cache(
     temporary.replace(path)
 
 
-def fetch_status(key: str, cache: dict[str, Any] | None = None) -> tuple[Status, float]:
+def fetch_status(key: str) -> Status:
     now = datetime.now(timezone.utc)
-    cached_status = _status_from_cache(cache)
-    rolling_updated_at = float((cache or {}).get("rolling_updated_at", 0))
-    rolling_is_fresh = time.time() - rolling_updated_at < ROLLING_TTL_SECONDS
-
-    credits = fetch_credits(key)
-    live_input, live_output = fetch_tokens(
+    input_tokens, output_tokens = fetch_tokens(
         key,
-        now - timedelta(seconds=LIVE_WINDOW_SECONDS),
+        now - timedelta(seconds=RATE_WINDOW_SECONDS),
         now,
     )
-
-    if cached_status and rolling_is_fresh:
-        rolling_input = cached_status.rolling_input_tokens
-        rolling_output = cached_status.rolling_output_tokens
-    else:
-        rolling_input, rolling_output = fetch_tokens(
-            key,
-            now - timedelta(days=ROLLING_DAYS),
-            now,
-        )
-        rolling_updated_at = time.time()
-
-    return (
-        Status(
-            credits_remaining=credits,
-            live_input_tokens=live_input,
-            live_output_tokens=live_output,
-            rolling_input_tokens=rolling_input,
-            rolling_output_tokens=rolling_output,
-        ),
-        rolling_updated_at,
+    return Status(
+        input_tokens_per_minute=input_tokens,
+        output_tokens_per_minute=output_tokens,
     )
 
 
@@ -268,18 +210,13 @@ def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
             return cached_status, False
 
         try:
-            status, rolling_updated_at = fetch_status(key, cache)
+            status = fetch_status(key)
         except RuntimeError:
             if cached_status:
                 return cached_status, True
             raise
 
-        _write_cache(
-            path,
-            status,
-            fetched_at=time.time(),
-            rolling_updated_at=rolling_updated_at,
-        )
+        _write_cache(path, status, fetched_at=time.time())
         return status, False
 
 
@@ -304,7 +241,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.json:
         payload = asdict(status)
-        payload["rolling_tokens"] = status.rolling_tokens
+        payload["total_tokens_per_minute"] = status.total_tokens_per_minute
         payload["stale"] = stale
         print(json.dumps(payload, sort_keys=True))
     else:

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Qtile OpenRouter status helper."""
+"""Tests for the Qtile OpenRouter token-rate helper."""
 
 from __future__ import annotations
 
@@ -20,12 +20,6 @@ SPEC.loader.exec_module(MODULE)
 
 
 class OpenRouterStatusTests(unittest.TestCase):
-    def test_credit_color_thresholds(self):
-        self.assertEqual(MODULE.credit_color(4.99), MODULE.RED)
-        self.assertEqual(MODULE.credit_color(5.0), MODULE.YELLOW)
-        self.assertEqual(MODULE.credit_color(9.99), MODULE.YELLOW)
-        self.assertEqual(MODULE.credit_color(10.0), MODULE.GREEN)
-
     def test_compact_count(self):
         self.assertEqual(MODULE.compact_count(999), "999")
         self.assertEqual(MODULE.compact_count(1_200), "1.2k")
@@ -35,14 +29,6 @@ class OpenRouterStatusTests(unittest.TestCase):
     def test_uses_current_nerd_font_brain_codepoint(self):
         self.assertEqual(ord(MODULE.AI_ICON), 0xF09D1)
         self.assertFalse(0xF500 <= ord(MODULE.AI_ICON) <= 0xFD46)
-
-    def test_parse_credits_subtracts_usage(self):
-        payload = {"data": {"total_credits": 25.0, "total_usage": 17.25}}
-        self.assertEqual(MODULE.parse_credits(payload), 7.75)
-
-    def test_parse_credits_never_goes_negative(self):
-        payload = {"data": {"total_credits": 5.0, "total_usage": 8.0}}
-        self.assertEqual(MODULE.parse_credits(payload), 0.0)
 
     def test_parse_token_totals_sums_rows(self):
         payload = {
@@ -55,22 +41,17 @@ class OpenRouterStatusTests(unittest.TestCase):
         }
         self.assertEqual(MODULE.parse_token_totals(payload), (350, 35))
 
-    def test_render_matches_net_direction_style(self):
+    def test_render_labels_tokens_per_minute(self):
         status = MODULE.Status(
-            credits_remaining=7.5,
-            live_input_tokens=12_300,
-            live_output_tokens=4_500,
-            rolling_input_tokens=40_000_000,
-            rolling_output_tokens=10_000_000,
+            input_tokens_per_minute=12_300,
+            output_tokens_per_minute=4_500,
         )
         rendered = MODULE.render(status)
         self.assertIn(MODULE.AI_ICON, rendered)
-        self.assertIn(MODULE.YELLOW, rendered)
-        self.assertIn(MODULE.IO, rendered)
-        self.assertIn("$7.50", rendered)
-        self.assertIn("tok:12.3k↓ 4.5k↑", rendered)
-        self.assertIn("30d:50M", rendered)
-        self.assertNotIn("/m", rendered)
+        self.assertIn("12.3k↓/m", rendered)
+        self.assertIn("4.5k↑/m", rendered)
+        self.assertNotIn("$", rendered)
+        self.assertNotIn("30d:", rendered)
 
     def test_management_key_prefers_dedicated_environment_variable(self):
         with mock.patch.dict(
@@ -94,54 +75,51 @@ class OpenRouterStatusTests(unittest.TestCase):
             ):
                 self.assertEqual(MODULE.load_management_key(), "file-key")
 
-    def test_fetch_status_reuses_fresh_rolling_total(self):
-        cached = MODULE.Status(
-            credits_remaining=12.0,
-            live_input_tokens=1,
-            live_output_tokens=2,
-            rolling_input_tokens=1_000,
-            rolling_output_tokens=500,
-        )
-        cache = {
-            "rolling_updated_at": MODULE.time.time(),
-            "status": MODULE.asdict(cached),
+    def test_fetch_tokens_requests_prompt_and_completion_metrics(self):
+        start = MODULE.datetime(2026, 8, 22, 1, 0, tzinfo=MODULE.timezone.utc)
+        end = MODULE.datetime(2026, 8, 22, 1, 1, tzinfo=MODULE.timezone.utc)
+        response = {
+            "data": {
+                "data": [
+                    {"tokens_prompt": 1_000, "tokens_completion": 100},
+                ]
+            }
         }
-        with (
-            mock.patch.object(MODULE, "fetch_credits", return_value=11.0),
-            mock.patch.object(MODULE, "fetch_tokens", return_value=(10, 20)) as fetch_tokens,
-        ):
-            status, _ = MODULE.fetch_status("key", cache)
+        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
+            self.assertEqual(MODULE.fetch_tokens("key", start, end), (1_000, 100))
 
-        self.assertEqual(fetch_tokens.call_count, 1)
-        self.assertEqual(status.live_input_tokens, 10)
-        self.assertEqual(status.live_output_tokens, 20)
-        self.assertEqual(status.rolling_tokens, 1_500)
+        payload = request.call_args.args[3]
+        self.assertEqual(payload["metrics"], ["tokens_prompt", "tokens_completion"])
+        self.assertNotIn("granularity", payload)
 
-    def test_fetch_status_refreshes_stale_rolling_total(self):
-        cached = MODULE.Status(
-            credits_remaining=12.0,
-            live_input_tokens=1,
-            live_output_tokens=2,
-            rolling_input_tokens=1_000,
-            rolling_output_tokens=500,
+    def test_fetch_status_is_a_rolling_sixty_second_rate(self):
+        with mock.patch.object(MODULE, "fetch_tokens", return_value=(10_000, 500)) as fetch_tokens:
+            status = MODULE.fetch_status("key")
+
+        _, start, end = fetch_tokens.call_args.args
+        self.assertAlmostEqual((end - start).total_seconds(), 60.0)
+        self.assertEqual(status.input_tokens_per_minute, 10_000)
+        self.assertEqual(status.output_tokens_per_minute, 500)
+        self.assertEqual(status.total_tokens_per_minute, 10_500)
+
+    def test_status_cache_bounds_api_polling(self):
+        status = MODULE.Status(
+            input_tokens_per_minute=1_000,
+            output_tokens_per_minute=100,
         )
-        cache = {
-            "rolling_updated_at": 0,
-            "status": MODULE.asdict(cached),
-        }
-        with (
-            mock.patch.object(MODULE, "fetch_credits", return_value=11.0),
-            mock.patch.object(
-                MODULE,
-                "fetch_tokens",
-                side_effect=[(10, 20), (2_000, 1_000)],
-            ) as fetch_tokens,
-        ):
-            status, rolling_updated_at = MODULE.fetch_status("key", cache)
+        with tempfile.TemporaryDirectory() as directory:
+            with (
+                mock.patch.dict(os.environ, {"XDG_CACHE_HOME": directory}),
+                mock.patch.object(MODULE, "fetch_status", return_value=status) as fetch_status,
+            ):
+                first, first_stale = MODULE.status_with_cache("key")
+                second, second_stale = MODULE.status_with_cache("key")
 
-        self.assertEqual(fetch_tokens.call_count, 2)
-        self.assertGreater(rolling_updated_at, 0)
-        self.assertEqual(status.rolling_tokens, 3_000)
+        self.assertEqual(first, status)
+        self.assertEqual(second, status)
+        self.assertFalse(first_stale)
+        self.assertFalse(second_stale)
+        self.assertEqual(fetch_status.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -22,38 +22,43 @@ def assigned_constant(name):
 
 
 class OpenRouterWidgetStructureTests(unittest.TestCase):
-    def test_one_hz_polling_and_one_minute_graph(self):
-        self.assertEqual(assigned_constant("POLL_SECONDS"), 1)
+    def test_five_second_rate_polling_and_five_minute_graph(self):
+        self.assertEqual(assigned_constant("POLL_SECONDS"), 5)
         self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 60)
 
-    def test_readable_font_sizes(self):
-        self.assertGreaterEqual(assigned_constant("CREDIT_FONTSIZE"), 14)
-        self.assertGreaterEqual(assigned_constant("IO_FONTSIZE"), 12)
-        self.assertGreaterEqual(assigned_constant("ROLLING_FONTSIZE"), 13)
+    def test_readable_rate_font_size(self):
+        self.assertGreaterEqual(assigned_constant("RATE_FONTSIZE"), 12)
 
-    def test_graph_widget_exists(self):
+    def test_rate_and_graph_widgets_exist_without_credit_or_rolling_widgets(self):
         classes = {
             node.name
             for node in TREE.body
             if isinstance(node, ast.ClassDef)
         }
+        self.assertIn("OpenRouterRate", classes)
         self.assertIn("OpenRouterIOGraph", classes)
-        self.assertIn("OpenRouterCredit", classes)
-        self.assertIn("OpenRouterCacheText", classes)
+        self.assertNotIn("OpenRouterCredit", classes)
+        self.assertNotIn("OpenRouterCacheText", classes)
 
-    def test_live_poll_forces_short_cache_but_not_rolling_window(self):
-        self.assertIn('"--json", "--force"', SOURCE_TEXT)
+    def test_rate_poll_respects_status_cache(self):
+        self.assertIn('["python3", script, "--json"]', SOURCE_TEXT)
+        self.assertNotIn('"--force"', SOURCE_TEXT)
         self.assertIn('"openrouter_io_graph"', SOURCE_TEXT)
-        self.assertIn('"rolling"', SOURCE_TEXT)
+        self.assertNotIn('"rolling"', SOURCE_TEXT)
 
-    def test_io_is_rendered_as_two_lines(self):
-        self.assertIn("{incoming}↓</span>\\n", SOURCE_TEXT)
-        self.assertIn("{outgoing}↑</span>", SOURCE_TEXT)
+    def test_rate_is_rendered_as_two_tokens_per_minute_lines(self):
+        self.assertIn("{incoming}↓/m</span>\\n", SOURCE_TEXT)
+        self.assertIn("{outgoing}↑/m{stale}</span>", SOURCE_TEXT)
 
-    def test_graph_scales_each_series_independently(self):
-        self.assertIn("maximum = max(max(values, default=0), 1)", SOURCE_TEXT)
-        self.assertNotIn("max(self.input_values, default=0)", SOURCE_TEXT)
-        self.assertNotIn("max(self.output_values, default=0)", SOURCE_TEXT)
+    def test_graph_does_not_seed_fake_zero_history(self):
+        self.assertIn("deque(maxlen=self.samples)", SOURCE_TEXT)
+        self.assertNotIn("[0.0] * self.samples", SOURCE_TEXT)
+
+    def test_graph_uses_adaptive_range_and_hides_constant_series(self):
+        self.assertIn("minimum = min(values)", SOURCE_TEXT)
+        self.assertIn("maximum = max(values)", SOURCE_TEXT)
+        self.assertIn("if maximum <= minimum:", SOURCE_TEXT)
+        self.assertIn("return", SOURCE_TEXT)
 
     def test_sync_reload_uses_qtile_process_not_external_cli(self):
         self.assertIn("lazy.function(_sync_and_reload)", SOURCE_TEXT)

--- a/docs/wiki/desktop.org
+++ b/docs/wiki/desktop.org
@@ -17,8 +17,9 @@ The repository editing rules require Qtile sync/reload behavior to:
 - use the shared =git-sync= implementation;
 - avoid blocking Qtile's event loop while Git runs;
 - reload only after a successful sync;
-- send desktop notifications for start, success, and failure;
-- retain the existing 1 Hz OpenRouter telemetry behavior unless deliberately changed.
+- send desktop notifications for start, success, and failure.
+
+OpenRouter telemetry is rate-oriented rather than balance-oriented. The bar reports prompt and completion tokens from the trailing 60-second window as tokens per minute, polls the analytics helper every five seconds, and graphs five minutes of sampled rates. The balance and 30-day counters are deliberately omitted. The graph suppresses constant series and adaptively scales moving series so a much larger prompt stream does not visually erase completion traffic.
 
 The dynamic =Super+Ctrl+Shift+R= binding belongs to the OpenRouter telemetry helper.  Keep its documentation and generated implementation synchronized with =qtile-openrouter.org=.
 


### PR DESCRIPTION
## Summary

- remove the OpenRouter credit balance and 30-day token counters from the Qtile bar;
- report prompt/completion usage over the trailing 60 seconds explicitly as tokens per minute;
- stop bypassing the helper cache on every poll and bound Analytics API refreshes to once every five seconds;
- replace the prefilled, max-pinned graph with a five-minute sampled TPM sparkline;
- hide constant series instead of rendering permanent horizontal rails;
- use adaptive per-stream graph ranges so completion movement remains visible beside much larger prompt traffic;
- keep `qtile-openrouter.org` and `qtile_openrouter.py` exactly synchronized;
- update Qtile docs and regression tests for the new semantics.

## Root cause

The old graph sampled a rolling 60-second total every second, seeded 60 zero values, and scaled every sample against the current maximum. Once traffic was steady, almost every point sat at the same normalized height, producing the fixed horizontal lines visible in the bar. The text also exposed raw rolling-window counts without saying they were effectively a one-minute rate.

The credit widget added another API call and occupied bar space without helping with live throughput.

## Validation

The `workflows` GitHub Actions job is the merge gate for this change: it compiles both Qtile helpers, runs the complete `.config/qtile/tests/test_*.py` suite, and checks literate/generated parity.