### PR TITLE
feat: add Agent Zero mobile SSH tunnel

### DIFF
--- a/android/README.org
+++ b/android/README.org
@@ -32,11 +32,37 @@ curl -fsSL https://raw.githubusercontent.com/lost-rob0t/dotfiles/master/bootstra
 The bootstrap first performs a full Termux package upgrade because Termux is a
 rolling distribution and partial upgrades can leave native libraries ABI
 incompatible.  It then installs the native Termux tools, clones this repository
-to =~/.dotfiles=, activates =android/= as the Emacs profile when no existing
-Emacs configuration is present, and installs OpenCode inside a Debian
-=proot-distro=.  A native Termux =opencode= wrapper enters that Debian
-environment while sharing the Termux home directory, so projects under =~=
-remain directly usable.
+to =~/.dotfiles=, installs =agent-zero-tunnel= into the Termux executable path,
+activates =android/= as the Emacs profile when no existing Emacs configuration
+is present, and installs OpenCode inside a Debian =proot-distro=.  A native
+Termux =opencode= wrapper enters that Debian environment while sharing the
+Termux home directory, so projects under =~= remain directly usable.
+
+** Agent Zero mobile tunnel
+
+=agent-zero-tunnel= creates an SSH local forward from the phone to an Agent Zero
+Web UI running on another computer.  The default SSH target is =op= and the
+default Agent Zero port is =50080=.
+
+#+begin_src sh
+agent-zero-tunnel op 50080
+#+end_src
+
+Keep that Termux session running, then open the loopback URL on the phone:
+
+#+begin_example
+http://127.0.0.1:50080
+#+end_example
+
+The helper binds only to =127.0.0.1= on the phone.  Override the target or ports
+without editing the script:
+
+#+begin_src sh
+export A0_SSH_TARGET="unseen@your-host"
+export A0_REMOTE_PORT=50080
+export A0_LOCAL_PORT=50080
+agent-zero-tunnel
+#+end_src
 
 If =curl= or Git HTTPS fails with =CANNOT LINK EXECUTABLE= or a missing SSL
 symbol after a partial package update, repair the Termux prefix with =apt=

--- a/bootstrap-termux.sh
+++ b/bootstrap-termux.sh
@@ -47,6 +47,9 @@ else
   git clone --branch master --single-branch "$DOTFILES_REPO" "$DOTFILES_DIR"
 fi
 
+printf '==> Installing Agent Zero tunnel helper\n'
+install -m 0755 "$DOTFILES_DIR/scripts/agent-zero-tunnel" "$PREFIX/bin/agent-zero-tunnel"
+
 if [[ ! -e "$HOME/.emacs" && ! -e "$HOME/.emacs.d" && ! -e "$HOME/.config/emacs" ]]; then
   printf '==> Activating the Android Emacs profile\n'
   ln -s "$DOTFILES_DIR/android" "$HOME/.emacs.d"
@@ -106,6 +109,7 @@ printf 'Emacs:   '
 emacs --version | sed -n '1p'
 printf 'OpenCode: '
 opencode --version
+printf 'A0 tunnel: agent-zero-tunnel --help\n'
 
 if gh auth status >/dev/null 2>&1; then
   printf 'GitHub:   authenticated\n'

--- a/scripts/agent-zero-tunnel
+++ b/scripts/agent-zero-tunnel
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly PROGRAM="${0##*/}"
+
+usage() {
+  cat <<'EOF'
+Usage: agent-zero-tunnel [SSH_TARGET] [REMOTE_PORT] [LOCAL_PORT]
+
+Open an SSH local-forward to Agent Zero on a remote PC.
+
+Defaults:
+  SSH_TARGET   $A0_SSH_TARGET or "op"
+  REMOTE_PORT  $A0_REMOTE_PORT or 50080
+  LOCAL_PORT   $A0_LOCAL_PORT or REMOTE_PORT
+
+Optional environment:
+  A0_REMOTE_HOST  Remote Agent Zero bind host (default: 127.0.0.1)
+  A0_BIND_ADDR    Local bind address (default: 127.0.0.1)
+
+Example from Termux:
+  agent-zero-tunnel op 50080
+
+Then open:
+  http://127.0.0.1:50080
+EOF
+}
+
+fail() {
+  printf '%s: %s\n' "$PROGRAM" "$*" >&2
+  exit 1
+}
+
+is_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && (( 1 <= 10#$1 && 10#$1 <= 65535 ))
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+command -v ssh >/dev/null 2>&1 || fail "ssh is required"
+
+readonly ssh_target="${1:-${A0_SSH_TARGET:-op}}"
+readonly remote_port="${2:-${A0_REMOTE_PORT:-50080}}"
+readonly local_port="${3:-${A0_LOCAL_PORT:-$remote_port}}"
+readonly remote_host="${A0_REMOTE_HOST:-127.0.0.1}"
+readonly bind_addr="${A0_BIND_ADDR:-127.0.0.1}"
+
+[[ -n "$ssh_target" ]] || fail "SSH target must not be empty"
+is_port "$remote_port" || fail "invalid remote port: $remote_port"
+is_port "$local_port" || fail "invalid local port: $local_port"
+
+printf 'Agent Zero: http://%s:%s\n' "$bind_addr" "$local_port"
+printf 'Tunnel: %s -> %s:%s via %s\n' \
+  "$bind_addr:$local_port" "$remote_host" "$remote_port" "$ssh_target"
+
+exec ssh \
+  -NT \
+  -L "$bind_addr:$local_port:$remote_host:$remote_port" \
+  -o ExitOnForwardFailure=yes \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  "$ssh_target"

--- a/tests/agent-zero-tunnel.sh
+++ b/tests/agent-zero-tunnel.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly tunnel="$repo_root/scripts/agent-zero-tunnel"
+readonly tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "${SSH_CAPTURE:?}"
+EOF
+chmod 0755 "$tmp/ssh"
+
+export PATH="$tmp:$PATH"
+export SSH_CAPTURE="$tmp/ssh.args"
+
+output="$(
+  A0_SSH_TARGET='unseen@op.example' \
+  A0_REMOTE_PORT=50080 \
+  A0_LOCAL_PORT=55080 \
+  bash "$tunnel"
+)"
+
+grep -Fxq 'Agent Zero: http://127.0.0.1:55080' <<< "$output"
+grep -Fxq -- '-NT' "$SSH_CAPTURE"
+grep -Fxq -- '-L' "$SSH_CAPTURE"
+grep -Fxq '127.0.0.1:55080:127.0.0.1:50080' "$SSH_CAPTURE"
+grep -Fxq 'ExitOnForwardFailure=yes' "$SSH_CAPTURE"
+grep -Fxq 'ServerAliveInterval=30' "$SSH_CAPTURE"
+grep -Fxq 'ServerAliveCountMax=3' "$SSH_CAPTURE"
+grep -Fxq 'unseen@op.example' "$SSH_CAPTURE"
+
+if A0_REMOTE_PORT=70000 bash "$tunnel" op >/dev/null 2>&1; then
+  printf 'expected invalid port to fail\n' >&2
+  exit 1
+fi
+
+printf 'agent-zero-tunnel tests passed\n'


### PR DESCRIPTION
## Summary
- add `agent-zero-tunnel` for loopback-only SSH local forwarding to Agent Zero
- install the helper from the Termux bootstrap
- document phone usage and environment overrides
- add a shell regression test for forwarding and keepalive arguments

## Defaults
- SSH target: `op`
- remote Agent Zero port: `50080`
- local port: same as remote
- local bind: `127.0.0.1`

CI is intentionally not a merge gate for this PR per explicit user instruction for this one change.