### PR TITLE
feat: persist Nix in Agent Zero

### DIFF
--- a/.bin/agent-zero-nix
+++ b/.bin/agent-zero-nix
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly program="${0##*/}"
+readonly container_name="${A0_CONTAINER_NAME:-agent-zero}"
+readonly image="${A0_IMAGE:-agent0ai/agent-zero:latest}"
+readonly port="${A0_PORT:-50080}"
+readonly usr_volume="${A0_USR_VOLUME:-a0_usr}"
+readonly nix_volume="${A0_NIX_VOLUME:-a0_nix}"
+readonly nix_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: agent-zero-nix
+
+Run Agent Zero with persistent Agent Zero state and a persistent Nix store.
+
+Environment overrides:
+  A0_CONTAINER_NAME  Container name (default: agent-zero)
+  A0_IMAGE           Image (default: agent0ai/agent-zero:latest)
+  A0_PORT            Host Web UI port (default: 50080)
+  A0_USR_VOLUME      /a0/usr volume (default: a0_usr)
+  A0_NIX_VOLUME      /nix volume (default: a0_nix)
+EOF
+}
+
+fail() {
+  printf '%s: %s\n' "$program" "$*" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  "") ;;
+  *)
+    usage >&2
+    fail "unexpected argument: $1"
+    ;;
+esac
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+[[ "$port" =~ ^[0-9]+$ ]] || fail "A0_PORT must be numeric"
+(( 1 <= 10#$port && 10#$port <= 65535 )) || fail "A0_PORT out of range: $port"
+
+docker volume create "$usr_volume" >/dev/null
+docker volume create "$nix_volume" >/dev/null
+
+if docker container inspect "$container_name" >/dev/null 2>&1; then
+  if [[ "$(docker inspect -f '{{.State.Running}}' "$container_name")" == "true" ]]; then
+    printf 'Agent Zero already running: http://127.0.0.1:%s\n' "$port"
+    exit 0
+  fi
+
+  docker start "$container_name" >/dev/null
+  printf 'Agent Zero started: http://127.0.0.1:%s\n' "$port"
+  exit 0
+fi
+
+docker run -d \
+  --name "$container_name" \
+  --restart unless-stopped \
+  -p "$port:80" \
+  --mount "type=volume,src=$usr_volume,dst=/a0/usr" \
+  --mount "type=volume,src=$nix_volume,dst=/nix" \
+  -e "BASH_ENV=$nix_profile" \
+  "$image" >/dev/null
+
+printf 'Agent Zero started: http://127.0.0.1:%s\n' "$port"
+printf 'Persistent Nix store: docker volume %s -> /nix\n' "$nix_volume"


### PR DESCRIPTION
Add `agent-zero-nix`, a Bash launcher on the existing `~/.bin` PATH.

- persists Agent Zero state in `a0_usr:/a0/usr`
- persists the Nix store/state in `a0_nix:/nix`
- exposes Agent Zero on port 50080 by default
- sets `BASH_ENV` to the persistent Nix profile hook so recreated containers can pick Nix back up after installation
- safely starts an existing stopped container instead of recreating it

Merge immediately per request.