### PR TITLE
Fix Logos GNOME theming, Agent Zero forwarding, and flake checks

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -115,7 +115,7 @@ ex ()
       *.gz)        gunzip $1    ;;
       *.tar)       tar xf $1    ;;
       *.tbz2)      tar xjf $1   ;;
-      *.tgz)        tar xzf $1   ;;
+      *.tgz)       tar xzf $1   ;;
       *.zip)       unzip $1     ;;
       *.Z)         uncompress $1;;
       *.7z)        7z x $1      ;;
@@ -160,6 +160,13 @@ function install_doom() {
         return 1
     fi
 }
+
+# if [ ! -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+#     source ~/.nix-profile/etc/profile.d/nix.sh
+#     export NIX_PATH=$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels${NIX_PATH:+:$NIX_PATH}
+# fi
+
+PKG_CONFIG_PATH="$HOME/.nix-profile/lib/pkgconfig:$HOME/.nix-profile/lib64/pkgconfig:$HOME/.nix-profile/share/pkgconfig;"
 
 function nim-init () {
  # Init a nim project and start a git repo

--- a/.bashrc
+++ b/.bashrc
@@ -115,7 +115,7 @@ ex ()
       *.gz)        gunzip $1    ;;
       *.tar)       tar xf $1    ;;
       *.tbz2)      tar xjf $1   ;;
-      *.tgz)       tar xzf $1   ;;
+      *.tgz)        tar xzf $1   ;;
       *.zip)       unzip $1     ;;
       *.Z)         uncompress $1;;
       *.7z)        7z x $1      ;;
@@ -284,6 +284,16 @@ alias npm-init-dir="mkdir -p ~/.node"
 alias npm-install="npm install --prefix ~/.node -g"
 
 alias ai-proxy="ssh -N -L 7860:127.0.0.1:7860 unseen@10.50.50.18"
+
+agent-zero-forward() {
+    local session="agent-zero-forward"
+
+    tmux has-session -t "$session" 2>/dev/null &&
+        tmux kill-session -t "$session"
+
+    tmux new-session -d -s "$session" \
+        "ssh -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -N -L 5080:127.0.0.1:5080 unseen@10.50.50.28"
+}
 
 alias sync-music="rsync --progress -av ~/Music/Sorted/ music:/music && ssh music python3 /music/sort.py /mnt/Music"
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,13 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: devops-actions/actionlint@f9ec6b423d04a7f7a9f6872b1a16fd8313a7db62
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Install shell tooling
+        run: sudo apt-get update && sudo apt-get install -y emacs-nox shellcheck
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh .bash_profile .config/bash/git-sync.sh
+          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh .bash_profile .config/bash/git-sync.sh
           shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh .bash_profile .config/bash/git-sync.sh
+      - name: Verify bash.org and .bashrc are tangled in sync
+        run: |
+          set -euo pipefail
+          emacs -Q --batch \
+            --eval "(require 'org)" \
+            --eval "(org-babel-tangle-file \"bash.org\")"
+          git diff --exit-code -- .bashrc
       - name: Run Home Manager updater recovery tests
         run: bash tests/home-manager-updater.sh
       - name: Run GPT TODO bidirectional sync tests

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -32,11 +32,17 @@ jobs:
         with:
           name: nix-community
 
+      - name: Verify Nix runner
+        run: |
+          set -euo pipefail
+          nix --version
+          nix flake metadata --no-write-lock-file
+
       - name: Update flake inputs in the candidate checkout
         run: nix flake update
 
       - name: Check candidate flake before publishing lockfile
-        run: nix flake check --show-trace
+        run: nix flake check -L --show-trace
 
       - name: Detect lockfile changes
         id: lockfile
@@ -91,7 +97,7 @@ jobs:
           - Commit checked out: \`$GITHUB_SHA\`
           - Time: \`$(date --iso-8601=seconds)\`
 
-          The workflow updates inputs in its checkout, runs \`nix flake check --show-trace\`, and only pushes \`flake.lock\` after that check succeeds. This issue is intentionally reused across failures.
+          The workflow verifies the Nix runner, updates inputs in its checkout, runs \`nix flake check -L --show-trace\`, and only pushes \`flake.lock\` after every declared check succeeds. This issue is intentionally reused across failures.
           EOF
 
           if [[ -n "$number" ]]; then

--- a/bash.org
+++ b/bash.org
@@ -189,7 +189,7 @@ ex ()
       *.gz)        gunzip $1    ;;
       *.tar)       tar xf $1    ;;
       *.tbz2)      tar xjf $1   ;;
-      *.tgz)       tar xzf $1   ;;
+      *.tgz)        tar xzf $1   ;;
       *.zip)       unzip $1     ;;
       *.Z)         uncompress $1;;
       *.7z)        7z x $1      ;;
@@ -470,6 +470,19 @@ SSH forwarding proxy for ai
 alias ai-proxy="ssh -N -L 7860:127.0.0.1:7860 unseen@10.50.50.18"
 #+end_src
 
+Agent Zero SSH forward. Replaces any stale local tmux forward and leaves the tunnel detached.
+#+begin_src sh :tangle .bashrc
+agent-zero-forward() {
+    local session="agent-zero-forward"
+
+    tmux has-session -t "$session" 2>/dev/null &&
+        tmux kill-session -t "$session"
+
+    tmux new-session -d -s "$session" \
+        "ssh -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -N -L 5080:127.0.0.1:5080 unseen@10.50.50.28"
+}
+#+end_src
+
 Rsync new music to music server
 #+begin_src sh :tangle .bashrc
 alias sync-music="rsync --progress -av ~/Music/Sorted/ music:/music && ssh music python3 /music/sort.py /mnt/Music"
@@ -612,4 +625,3 @@ esac
 
 [fn:2] https://taingram.org/blog/emacs-client.html
 [fn:1] https://github.com/labbots/bash-oneliners#terminal
-

--- a/bash.org
+++ b/bash.org
@@ -189,7 +189,7 @@ ex ()
       *.gz)        gunzip $1    ;;
       *.tar)       tar xf $1    ;;
       *.tbz2)      tar xjf $1   ;;
-      *.tgz)        tar xzf $1   ;;
+      *.tgz)       tar xzf $1   ;;
       *.zip)       unzip $1     ;;
       *.Z)         uncompress $1;;
       *.7z)        7z x $1      ;;
@@ -255,7 +255,7 @@ For some reason on non nixos system this is needed
 #     source ~/.nix-profile/etc/profile.d/nix.sh
 #     export NIX_PATH=$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels${NIX_PATH:+:$NIX_PATH}
 # fi
-# #+end_src
+#+end_src
 **** Setup pkg-config
 This is needed for sbcl
 #+begin_src sh :tangle .bashrc
@@ -625,3 +625,4 @@ esac
 
 [fn:2] https://taingram.org/blog/emacs-client.html
 [fn:1] https://github.com/labbots/bash-oneliners#terminal
+

--- a/flake.nix
+++ b/flake.nix
@@ -185,6 +185,8 @@
         prolog-mcp = prologMcp;
         unseen-home = homeConfigurations."unseen@logos".activationPackage;
         unseen-flake-home = homeConfigurations."unseen@flake".activationPackage;
+        unseen-desktop-home = homeConfigurations."unseen@desktop".activationPackage;
+        unseen-hunter02-home = homeConfigurations."unseen@hunter02".activationPackage;
       };
 
       formatter.${system} = pkgs.nixfmt-rfc-style;

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -5,6 +5,7 @@
     inputs.skills.homeManagerModules.claude
     ./base.nix
     ./desktop.nix
+    ./gnome.nix
     ./fonts.nix
     ./emacs.nix
     ./security.nix

--- a/nix/home-manager/mods/gnome.nix
+++ b/nix/home-manager/mods/gnome.nix
@@ -1,0 +1,101 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.gnome;
+  outrunGtkCss = ''
+    @define-color outrun_bg #170c32;
+    @define-color outrun_surface #202146;
+    @define-color outrun_surface_hover #2a2056;
+    @define-color outrun_fg #f3f4f5;
+    @define-color outrun_magenta #ff00a8;
+    @define-color outrun_cyan #00f3ff;
+    @define-color outrun_purple #7c3aed;
+    @define-color outrun_border #92406e;
+
+    window,
+    .background,
+    preferencespage,
+    preferencesgroup,
+    clamp,
+    scrolledwindow,
+    viewport {
+      background-color: @outrun_bg;
+      color: @outrun_fg;
+    }
+
+    list,
+    .boxed-list,
+    .card,
+    .content {
+      background-color: @outrun_surface;
+      color: @outrun_fg;
+    }
+
+    row,
+    list row,
+    .boxed-list row,
+    preferencesgroup row {
+      background-color: @outrun_surface;
+      color: @outrun_fg;
+    }
+
+    row:hover,
+    list row:hover,
+    .boxed-list row:hover {
+      background-color: @outrun_surface_hover;
+    }
+
+    row:selected,
+    list row:selected,
+    .boxed-list row:selected {
+      background-color: @outrun_purple;
+      color: @outrun_fg;
+    }
+
+    headerbar,
+    .titlebar {
+      background-color: @outrun_bg;
+      color: @outrun_fg;
+      border-color: @outrun_border;
+    }
+
+    button,
+    entry,
+    spinbutton,
+    dropdown {
+      background-color: @outrun_surface;
+      color: @outrun_fg;
+      border-color: @outrun_border;
+    }
+
+    button.suggested-action {
+      background-color: @outrun_magenta;
+      color: @outrun_bg;
+    }
+
+    button:focus,
+    entry:focus,
+    row:focus {
+      outline-color: @outrun_cyan;
+    }
+  '';
+in
+{
+  options.gnome.enable = lib.mkEnableOption "GNOME Outrun theming";
+
+  config = lib.mkIf cfg.enable {
+    dconf = {
+      enable = true;
+      settings."org/gnome/desktop/interface" = {
+        color-scheme = "prefer-dark";
+        gtk-theme = "Adwaita-dark";
+      };
+    };
+
+    xdg.configFile."gtk-3.0/gtk.css".text = outrunGtkCss;
+    xdg.configFile."gtk-4.0/gtk.css".text = outrunGtkCss;
+  };
+}

--- a/nix/home-manager/systems/logos/home.nix
+++ b/nix/home-manager/systems/logos/home.nix
@@ -3,6 +3,8 @@
 {
   imports = [ ../desktop/home.nix ];
 
+  gnome.enable = true;
+
   home.username = lib.mkForce "unseen";
   home.homeDirectory = lib.mkForce "/home/unseen";
 }


### PR DESCRIPTION
## What changed

- add a dedicated Home Manager `gnome` module with the Outrun GTK3/GTK4/libadwaita palette and enable it on `logos`
- add `agent-zero-forward` to `bash.org` and keep the tangled `.bashrc` copy in sync; it replaces a stale tmux tunnel and forwards local `5080` to Agent Zero at `unseen@10.50.50.28:5080`
- make CI syntax-check `.bashrc` and re-tangle `bash.org`, failing if the generated file drifts
- make the flake checks evaluate every Home Manager profile, including desktop and hunter02
- make the daily flake updater explicitly verify its Nix runner and emit full build logs/trace from candidate checks

## Why

GNOME/libadwaita surfaces on Ubuntu were escaping the existing dark Outrun styling, the generated bashrc had no CI guard against literate-config drift, and the scheduled flake updater was reaching candidate validation but failing before it could publish the updated lockfile. The stronger checks should make the actual failing profile visible instead of silently leaving master stale.
