### PR TITLE
feat(gnome): keep OSK from covering terminals

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,6 +28,10 @@ jobs:
         run: bash tests/home-manager-updater.sh
       - name: Run GPT TODO bidirectional sync tests
         run: bash tests/gpt-todos-sync.sh
+      - name: Check GNOME tablet extension
+        run: |
+          node --check nix/home-manager/mods/gnome-tablet/extension.js
+          python3 -m json.tool nix/home-manager/mods/gnome-tablet/metadata.json >/dev/null
       - name: Check Qtile Python helpers
         run: >-
           python3 -m py_compile
@@ -73,3 +77,5 @@ jobs:
         run: nix eval --raw '.#homeConfigurations."unseen@desktop".activationPackage.drvPath'
       - name: Evaluate flake Home Manager configuration
         run: nix eval --raw '.#homeConfigurations."unseen@flake".activationPackage.drvPath'
+      - name: Evaluate logos Home Manager configuration
+        run: nix eval --raw '.#homeConfigurations."unseen@logos".activationPackage.drvPath'

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -5,6 +5,7 @@
     inputs.skills.homeManagerModules.claude
     ./base.nix
     ./desktop.nix
+    ./gnome-tablet.nix
     ./fonts.nix
     ./emacs.nix
     ./security.nix

--- a/nix/home-manager/mods/gnome-tablet.nix
+++ b/nix/home-manager/mods/gnome-tablet.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.desktop.gnomeTablet;
+  uuid = "osk-terminal-avoid@lost-rob0t";
+  extensionDir = ".local/share/gnome-shell/extensions/${uuid}";
+in
+{
+  options.desktop.gnomeTablet.enable = lib.mkEnableOption
+    "GNOME tablet-mode helpers";
+
+  config = lib.mkIf cfg.enable {
+    home.file."${extensionDir}/extension.js".source = ./gnome-tablet/extension.js;
+    home.file."${extensionDir}/metadata.json".source = ./gnome-tablet/metadata.json;
+
+    home.activation.enableGnomeTabletExtension =
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        gsettings_bin=${pkgs.glib}/bin/gsettings
+        uuid='${uuid}'
+
+        current="$($gsettings_bin get org.gnome.shell enabled-extensions 2>/dev/null || true)"
+        case "$current" in
+          *"$uuid"*)
+            ;;
+          ""|"[]"|"@as []")
+            $gsettings_bin set org.gnome.shell enabled-extensions "['$uuid']" || true
+            ;;
+          \[*\])
+            next="''${current%]}"
+            $gsettings_bin set org.gnome.shell enabled-extensions "$next, '$uuid']" || true
+            ;;
+        esac
+
+        if command -v gnome-extensions >/dev/null 2>&1; then
+          gnome-extensions enable "$uuid" >/dev/null 2>&1 || true
+        fi
+      '';
+  };
+}

--- a/nix/home-manager/mods/gnome-tablet/extension.js
+++ b/nix/home-manager/mods/gnome-tablet/extension.js
@@ -1,0 +1,169 @@
+import GLib from 'gi://GLib';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const SETTLE_DELAY_MS = 220;
+const TERMINAL_RE = /(terminal|ptyxis|kgx|console|alacritty|kitty|foot|wezterm|xterm|urxvt|tilix|terminator|konsole)/i;
+
+function isTerminal(window) {
+    if (!window)
+        return false;
+
+    const values = [
+        window.get_wm_class?.(),
+        window.get_wm_class_instance?.(),
+    ];
+
+    return values.some(value => value && TERMINAL_RE.test(value));
+}
+
+export default class OskTerminalAvoidance extends Extension {
+    enable() {
+        this._keyboardActor = null;
+        this._originalAnimateWindow = null;
+        this._originalAffectsStruts = false;
+        this._settleId = 0;
+
+        this._keyboardVisibilityId = Main.keyboard.connect(
+            'visibility-changed', () => this._sync());
+        this._focusWindowId = global.display.connect(
+            'notify::focus-window', () => this._sync());
+        this._keyboardChildId = Main.layoutManager.keyboardBox.connect(
+            'child-added', () => this._syncActor());
+
+        this._syncActor();
+        this._sync();
+    }
+
+    disable() {
+        this._cancelSettle();
+
+        if (this._keyboardVisibilityId)
+            Main.keyboard.disconnect(this._keyboardVisibilityId);
+        if (this._focusWindowId)
+            global.display.disconnect(this._focusWindowId);
+        if (this._keyboardChildId)
+            Main.layoutManager.keyboardBox.disconnect(this._keyboardChildId);
+
+        this._keyboardVisibilityId = 0;
+        this._focusWindowId = 0;
+        this._keyboardChildId = 0;
+
+        this._restoreActor();
+    }
+
+    _syncActor() {
+        const actor = Main.keyboard.keyboardActor;
+        if (actor === this._keyboardActor)
+            return;
+
+        this._restoreActor();
+        if (!actor)
+            return;
+
+        this._keyboardActor = actor;
+        this._patchWindowAvoidance(actor);
+
+        const actorData = this._getActorData(actor);
+        if (actorData)
+            this._originalAffectsStruts = actorData.affectsStruts;
+    }
+
+    _patchWindowAvoidance(actor) {
+        if (typeof actor._animateWindow !== 'function')
+            return;
+
+        this._originalAnimateWindow = actor._animateWindow;
+        const original = this._originalAnimateWindow;
+
+        actor._animateWindow = function (window, show) {
+            if (isTerminal(window))
+                return;
+
+            return original.call(this, window, show);
+        };
+    }
+
+    _restoreActor() {
+        if (!this._keyboardActor)
+            return;
+
+        const actorData = this._getActorData(this._keyboardActor);
+        if (actorData) {
+            actorData.affectsStruts = this._originalAffectsStruts;
+            Main.layoutManager._queueUpdateRegions?.();
+        }
+
+        if (this._originalAnimateWindow)
+            this._keyboardActor._animateWindow = this._originalAnimateWindow;
+
+        this._keyboardActor = null;
+        this._originalAnimateWindow = null;
+        this._originalAffectsStruts = false;
+    }
+
+    _sync() {
+        this._syncActor();
+
+        const terminalFocused = isTerminal(global.display.focus_window);
+        const reserve = Boolean(
+            this._keyboardActor && Main.keyboard.visible && terminalFocused);
+
+        this._setReserveSpace(reserve);
+
+        if (reserve)
+            this._scheduleSettledUpdate();
+        else
+            this._cancelSettle();
+    }
+
+    _setReserveSpace(enabled) {
+        if (!this._keyboardActor)
+            return;
+
+        const actorData = this._getActorData(this._keyboardActor);
+        if (!actorData)
+            return;
+
+        const desired = enabled ? true : this._originalAffectsStruts;
+        if (actorData.affectsStruts === desired)
+            return;
+
+        actorData.affectsStruts = desired;
+        Main.layoutManager._queueUpdateRegions?.();
+    }
+
+    _getActorData(actor) {
+        const layout = Main.layoutManager;
+        if (!layout?._trackedActors || typeof layout._findActor !== 'function')
+            return null;
+
+        const index = layout._findActor(actor);
+        if (index < 0)
+            return null;
+
+        return layout._trackedActors[index];
+    }
+
+    _scheduleSettledUpdate() {
+        this._cancelSettle();
+        this._settleId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT,
+            SETTLE_DELAY_MS,
+            () => {
+                this._settleId = 0;
+                if (Main.keyboard.visible && isTerminal(global.display.focus_window))
+                    Main.layoutManager._queueUpdateRegions?.();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _cancelSettle() {
+        if (!this._settleId)
+            return;
+
+        GLib.source_remove(this._settleId);
+        this._settleId = 0;
+    }
+}

--- a/nix/home-manager/mods/gnome-tablet/metadata.json
+++ b/nix/home-manager/mods/gnome-tablet/metadata.json
@@ -1,0 +1,6 @@
+{
+  "uuid": "osk-terminal-avoid@lost-rob0t",
+  "name": "OSK Terminal Avoidance",
+  "description": "Keeps GNOME's on-screen keyboard from covering terminal windows.",
+  "shell-version": ["45", "46", "47", "48", "49", "50"]
+}

--- a/nix/home-manager/systems/logos/home.nix
+++ b/nix/home-manager/systems/logos/home.nix
@@ -3,6 +3,8 @@
 {
   imports = [ ../desktop/home.nix ];
 
+  desktop.gnomeTablet.enable = true;
+
   home.username = lib.mkForce "unseen";
   home.homeDirectory = lib.mkForce "/home/unseen";
 }


### PR DESCRIPTION
## What

- add a small GNOME Shell extension for tablet mode
- when the GNOME OSK is visible and a terminal is focused, reserve the keyboard area as workspace instead of letting it cover the terminal
- suppress GNOME's built-in whole-window upward translation for terminal windows so maximized terminals resize against the OSK work area
- leave non-terminal apps on GNOME's normal OSK behavior
- install and enable the extension through Home Manager without replacing existing enabled extensions
- enable it for `unseen@logos`

## Verification

- JS syntax and extension metadata validation in CI
- `unseen@logos` Home Manager evaluation added to CI
- GNOME 46/current shell internals checked for `keyboardActor`, chrome tracking, strut updates, and keyboard window animation hooks

A real tablet-session smoke test is still required because CI does not run a GNOME Shell compositor.