### PR TITLE
feat(qtile): RAGE topology-aware desktop control plane

### DIFF
--- a/.config/qtile/private.env.example
+++ b/.config/qtile/private.env.example
@@ -1,0 +1,10 @@
+# Copy to ~/.config/qtile/private.env. The real file is gitignored.
+# Keep credentials out of tracked Qtile/Python/Emacs config.
+
+AGENT_ZERO_HOST=http://127.0.0.1:5080
+AGENT_ZERO_API_KEY_FILE=~/.config/agent-zero/api-key
+# AGENT_ZERO_API_KEY=replace-me-only-in-private.env
+
+OPENROUTER_MANAGEMENT_KEY_FILE=~/.config/openrouter/management-key
+# Optional local sanity ceiling. Samples above this are rejected as implausible.
+OPENROUTER_TPM_MAX=10000000

--- a/.config/qtile/qtile-desktop.el
+++ b/.config/qtile/qtile-desktop.el
@@ -3,6 +3,7 @@
 (require 'json)
 (require 'org)
 (require 'org-agenda)
+(require 'subr-x)
 (require 'url)
 (require 'url-http)
 
@@ -117,8 +118,8 @@
       (buffer-substring-no-properties (point) (point-max))
     ""))
 
-(defun qtile-agent-zero--finish (target-buffer status)
-  "Handle Agent Zero URL callback into TARGET-BUFFER."
+(defun qtile-agent-zero--finish (status target-buffer)
+  "Handle Agent Zero URL callback STATUS into TARGET-BUFFER."
   (let ((body (qtile-agent-zero--response-body))
         (code (plist-get status :error)))
     (kill-buffer (current-buffer))

--- a/.config/qtile/qtile-desktop.el
+++ b/.config/qtile/qtile-desktop.el
@@ -1,0 +1,184 @@
+;;; qtile-desktop.el --- Qtile popup helpers -*- lexical-binding: t; -*-
+
+(require 'json)
+(require 'org)
+(require 'org-agenda)
+(require 'url)
+(require 'url-http)
+
+(defconst qtile-desktop-private-env
+  (expand-file-name "~/.config/qtile/private.env"))
+(defvar-local qtile-agent-zero-context-id nil)
+(defvar-local qtile-agent-zero-prompt-start nil)
+
+(defun qtile-desktop--load-private-env ()
+  "Load KEY=VALUE overrides without ever echoing secret values."
+  (when (file-readable-p qtile-desktop-private-env)
+    (with-temp-buffer
+      (insert-file-contents qtile-desktop-private-env)
+      (goto-char (point-min))
+      (while (not (eobp))
+        (let ((line (string-trim
+                     (buffer-substring-no-properties
+                      (line-beginning-position) (line-end-position)))))
+          (unless (or (string-empty-p line) (string-prefix-p "#" line))
+            (when (string-match "\\`\\([^=]+\\)=\\(.*\\)\\'" line)
+              (let* ((key (string-trim (match-string 1 line)))
+                     (value (string-trim (match-string 2 line)))
+                     (value (string-trim value "['\"]" "['\"]")))
+                (setenv key (substitute-in-file-name value))))))
+        (forward-line 1)))))
+
+(defun qtile-desktop--title (title)
+  (set-frame-parameter nil 'name title)
+  (set-frame-parameter nil 'title title))
+
+(defun qtile-org-todos-open ()
+  "Show the global TODO list in the current Qtile scratch frame."
+  (interactive)
+  (qtile-desktop--title "qtile-org-todos")
+  (org-agenda nil "t")
+  (delete-other-windows))
+
+(defun qtile-workflow-read (choices)
+  "Select one Qtile workflow from CHOICES in a temporary GUI frame."
+  (let ((frame (make-frame '((name . "qtile-workflow")
+                             (title . "qtile-workflow")
+                             (width . 58)
+                             (height . 10)
+                             (minibuffer . t)))))
+    (unwind-protect
+        (with-selected-frame frame
+          (select-frame-set-input-focus frame)
+          (completing-read "Qtile workflow: " choices nil t))
+      (when (frame-live-p frame)
+        (delete-frame frame)))))
+
+(defvar qtile-agent-zero-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map text-mode-map)
+    (define-key map (kbd "C-c C-c") #'qtile-agent-zero-send)
+    (define-key map (kbd "C-c C-r") #'qtile-agent-zero-reset)
+    map))
+
+(define-derived-mode qtile-agent-zero-mode text-mode "Qtile-A0"
+  "Tiny asynchronous Agent Zero client for a Qtile scratch frame."
+  (setq-local header-line-format
+              "Agent Zero  |  C-c C-c send  |  C-c C-r new context")
+  (setq-local qtile-agent-zero-context-id nil)
+  (setq-local qtile-agent-zero-prompt-start nil))
+
+(defun qtile-agent-zero--api-key ()
+  (qtile-desktop--load-private-env)
+  (or (getenv "AGENT_ZERO_API_KEY")
+      (let ((file (getenv "AGENT_ZERO_API_KEY_FILE")))
+        (when (and file (file-readable-p file))
+          (string-trim
+           (with-temp-buffer
+             (insert-file-contents file)
+             (buffer-string)))))))
+
+(defun qtile-agent-zero--host ()
+  (qtile-desktop--load-private-env)
+  (when-let ((host (getenv "AGENT_ZERO_HOST")))
+    (replace-regexp-in-string "/+\\'" "" host)))
+
+(defun qtile-agent-zero--insert-prompt ()
+  (goto-char (point-max))
+  (unless (bolp) (insert "\n"))
+  (insert "> ")
+  (setq qtile-agent-zero-prompt-start (point))
+  (goto-char (point-max)))
+
+(defun qtile-agent-zero-open ()
+  "Open or reuse the Qtile Agent Zero scratch buffer."
+  (interactive)
+  (qtile-desktop--title "qtile-agent-zero")
+  (let ((buffer (get-buffer-create "*Qtile Agent Zero*")))
+    (switch-to-buffer buffer)
+    (unless (derived-mode-p 'qtile-agent-zero-mode)
+      (qtile-agent-zero-mode))
+    (when (= (buffer-size) 0)
+      (insert "Agent Zero from Qtile\n\n")
+      (qtile-agent-zero--insert-prompt))
+    (goto-char (point-max))))
+
+(defun qtile-agent-zero-reset ()
+  "Forget local API conversation continuity and start a new context."
+  (interactive)
+  (setq qtile-agent-zero-context-id nil)
+  (goto-char (point-max))
+  (insert "\n[new Agent Zero context]\n")
+  (qtile-agent-zero--insert-prompt))
+
+(defun qtile-agent-zero--response-body ()
+  (goto-char (point-min))
+  (if (search-forward "\n\n" nil t)
+      (buffer-substring-no-properties (point) (point-max))
+    ""))
+
+(defun qtile-agent-zero--finish (target-buffer status)
+  "Handle Agent Zero URL callback into TARGET-BUFFER."
+  (let ((body (qtile-agent-zero--response-body))
+        (code (plist-get status :error)))
+    (kill-buffer (current-buffer))
+    (when (buffer-live-p target-buffer)
+      (with-current-buffer target-buffer
+        (goto-char (point-max))
+        (condition-case err
+            (if code
+                (insert (format "\nA0 error: %s\n" code))
+              (let* ((json-object-type 'alist)
+                     (payload (json-read-from-string body))
+                     (context (alist-get 'context_id payload))
+                     (response (or (alist-get 'response payload)
+                                   (alist-get 'message payload)
+                                   body)))
+                (when (stringp context)
+                  (setq qtile-agent-zero-context-id context))
+                (insert (format "\nA0: %s\n" response))))
+          (error
+           (insert (format "\nA0 parse error: %s\n" (error-message-string err)))))
+        (qtile-agent-zero--insert-prompt)))))
+
+(defun qtile-agent-zero-send ()
+  "Send the current prompt to Agent Zero asynchronously."
+  (interactive)
+  (let* ((target-buffer (current-buffer))
+         (start (or qtile-agent-zero-prompt-start (point-min)))
+         (prompt (string-trim
+                  (buffer-substring-no-properties start (point-max))))
+         (host (qtile-agent-zero--host))
+         (key (qtile-agent-zero--api-key)))
+    (cond
+     ((string-empty-p prompt)
+      (message "Agent Zero prompt is empty"))
+     ((not host)
+      (goto-char (point-max))
+      (insert "\nA0 config: set AGENT_ZERO_HOST in ~/.config/qtile/private.env\n")
+      (qtile-agent-zero--insert-prompt))
+     ((not key)
+      (goto-char (point-max))
+      (insert "\nA0 config: set AGENT_ZERO_API_KEY or AGENT_ZERO_API_KEY_FILE\n")
+      (qtile-agent-zero--insert-prompt))
+     (t
+      (goto-char (point-max))
+      (insert "\nA0: working…\n")
+      (let* ((url-request-method "POST")
+             (url-request-extra-headers
+              `(("Content-Type" . "application/json")
+                ("X-API-KEY" . ,key)))
+             (payload `((message . ,prompt)))
+             (payload (if qtile-agent-zero-context-id
+                          (append payload `((context_id . ,qtile-agent-zero-context-id)))
+                        payload))
+             (url-request-data (encode-coding-string (json-encode payload) 'utf-8)))
+        (url-retrieve
+         (concat host "/api_message")
+         #'qtile-agent-zero--finish
+         (list target-buffer)
+         t
+         t))))))
+
+(provide 'qtile-desktop)
+;;; qtile-desktop.el ends here

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -3,20 +3,21 @@
 
 * Runtime helper
 
-This file is the source of truth for the OpenRouter status widgets and the
-=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding. Tangle this file whenever
-that runtime helper changes.
+This file is the source of truth for the OpenRouter widgets and the
+=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding. The center-screen
+telemetry cluster shows current account balance, a complete-minute prompt and
+completion token rate, and a rolling graph of trusted minute samples.
 
-OpenRouter telemetry is intentionally rate-oriented: the text widget reports
-prompt and completion tokens consumed during the trailing 60 seconds as tokens
-per minute. The balance and 30-day counters are not shown. The API poll is
-bounded to once every five seconds, and the graph keeps five minutes of those
-samples. Constant series are hidden rather than drawing fake full-height rails;
-when a rate moves, each stream gets an adaptive visual range so its shape stays
-visible even when prompt traffic dwarfs completion traffic.
+The balance comes from OpenRouter's management-key =/credits= endpoint. Rate
+queries use the previous fully closed minute instead of a moving partial bucket,
+and the collector rejects malformed, truncated, duplicated, negative, or
+implausibly large samples rather than feeding nonsense into the graph.
+
+The runtime installer also hands the telemetry widget factory to the
+screen-topology control layer so LLM stats live on the center role only.
 
 #+begin_src python
-"""OpenRouter telemetry widgets and small Qtile runtime helpers."""
+"""OpenRouter telemetry widgets and Qtile runtime helpers."""
 
 from __future__ import annotations
 
@@ -76,12 +77,10 @@ def _compact_count(value):
 
 def _fetch_payload(script):
     global _last_payload, _last_poll_at
-
     with _poll_lock:
         now = time.monotonic()
         if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
             return _last_payload
-
         completed = subprocess.run(
             ["python3", script, "--json"],
             check=False,
@@ -93,19 +92,16 @@ def _fetch_payload(script):
             payload = json.loads(completed.stdout)
         except json.JSONDecodeError:
             payload = None
-
         _last_poll_at = time.monotonic()
         if isinstance(payload, dict) and "input_tokens_per_minute" in payload:
             _last_payload = payload
             return payload
-
         cached = _read_cached_status()
         if cached:
             payload = dict(cached)
             payload["stale"] = True
             _last_payload = payload
             return payload
-
         return None
 
 
@@ -113,16 +109,11 @@ def _notify(summary, body="", urgency="normal"):
     notifier = shutil.which("dunstify") or shutil.which("notify-send")
     if not notifier:
         return
-
     command = [notifier, "-a", "Qtile", "-u", urgency, summary]
     if body:
         command.append(body)
     try:
-        subprocess.Popen(
-            command,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError:
         pass
 
@@ -130,10 +121,7 @@ def _notify(summary, body="", urgency="normal"):
 def _git_sync_command():
     helper = Path.home() / ".config" / "bash" / "git-sync.sh"
     repo = Path.home() / ".dotfiles"
-    return (
-        f'source "{helper}" && '
-        f'git-sync "{repo}"'
-    )
+    return f'source "{helper}" && git-sync "{repo}"'
 
 
 def _run_dotfiles_sync():
@@ -149,13 +137,11 @@ def _run_dotfiles_sync():
 def _sync_and_reload(qtile):
     """Sync dotfiles off the event loop, then reload Qtile in-process."""
     global _sync_in_progress
-
     with _sync_lock:
         if _sync_in_progress:
             _notify("Dotfiles sync", "Already syncing.", "low")
             return
         _sync_in_progress = True
-
     _notify("Dotfiles sync", "Fetching updates…")
 
     def worker():
@@ -167,28 +153,47 @@ def _sync_and_reload(qtile):
             with _sync_lock:
                 _sync_in_progress = False
             return
-
         with _sync_lock:
             _sync_in_progress = False
-
         if completed.returncode != 0:
             detail = (completed.stderr or completed.stdout or "git-sync failed").strip()
             _notify("Dotfiles sync failed", detail[-800:], "critical")
             return
-
         detail = (completed.stdout or "Dotfiles are up to date.").strip()
         _notify("Dotfiles synced", detail[-400:] + "\nReloading Qtile…")
         qtile.call_soon_threadsafe(qtile.reload_config)
 
-    threading.Thread(
-        target=worker,
-        name="qtile-dotfiles-sync",
-        daemon=True,
-    ).start()
+    threading.Thread(target=worker, name="qtile-dotfiles-sync", daemon=True).start()
+
+
+class OpenRouterCredit(base.BackgroundPoll):
+    """Display current OpenRouter account balance without blocking Qtile."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, script, colors, **config):
+        self.script = script
+        self.colors = colors
+        super().__init__(text="$…", **config)
+
+    def poll(self):
+        payload = _fetch_payload(self.script)
+        if not payload or payload.get("balance_usd") is None:
+            return f'<span foreground="{_color(self.colors, 8)}">$?</span>'
+        balance = float(payload["balance_usd"])
+        color = (
+            _color(self.colors, 8)
+            if balance < 5
+            else _color(self.colors, 3)
+            if balance < 10
+            else _color(self.colors, 7)
+        )
+        stale = " ~" if payload.get("stale") else ""
+        return f'<span foreground="{color}">${balance:.2f}{stale}</span>'
 
 
 class OpenRouterRate(base.BackgroundPoll):
-    """Display a rolling 60-second OpenRouter token rate."""
+    """Display the most recent complete-minute OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -201,7 +206,6 @@ class OpenRouterRate(base.BackgroundPoll):
         payload = _fetch_payload(self.script)
         if not payload:
             return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
-
         incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
         outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
         stale = " ~" if payload.get("stale") else ""
@@ -212,10 +216,9 @@ class OpenRouterRate(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Five-minute sparkline of sampled input/output tokens per minute."""
+    """Five-minute sparkline of trusted input/output tokens per minute."""
 
     orientations = base.ORIENTATION_HORIZONTAL
-
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
         ("samples", GRAPH_SAMPLES, "Number of rate samples."),
@@ -232,6 +235,7 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.input_values = deque(maxlen=self.samples)
         self.output_values = deque(maxlen=self.samples)
+        self._last_window_end = None
 
     def timer_setup(self):
         self._update()
@@ -240,30 +244,26 @@ class OpenRouterIOGraph(base._Widget):
     def _update(self):
         status = _read_cached_status()
         if status:
-            self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
-            self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
+            window_end = status.get("window_end")
+            if window_end != self._last_window_end:
+                self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
+                self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
+                self._last_window_end = window_end
         self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
             return
-
         values = list(values)
         minimum = min(values)
         maximum = max(values)
         if maximum <= minimum:
             return
-
-        # Absolute rates are printed beside the graph. The sparkline uses an
-        # adaptive per-stream range so real movement remains visible even when
-        # prompt and completion traffic differ by orders of magnitude.
         span = maximum - minimum
         usable_width = max(self.width - 2 * self.margin_x, 1)
         step = usable_width / max(len(values) - 1, 1)
-
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-
         for index, value in enumerate(values):
             x = self.margin_x + index * step
             normalized = (float(value) - minimum) / span
@@ -277,30 +277,15 @@ class OpenRouterIOGraph(base._Widget):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
-
         center_y = self.height / 2.0
         half_height = max(center_y - self.margin_y - 1, 1)
-
         self.drawer.set_source_rgb(self.midline_color)
         self.drawer.ctx.set_line_width(0.6)
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
-
-        self._draw_series(
-            self.input_values,
-            self.input_color,
-            center_y,
-            half_height,
-            -1,
-        )
-        self._draw_series(
-            self.output_values,
-            self.output_color,
-            center_y,
-            half_height,
-            1,
-        )
+        self._draw_series(self.input_values, self.input_color, center_y, half_height, -1)
+        self._draw_series(self.output_values, self.output_color, center_y, half_height, 1)
         self.draw_at_default_position()
 
 
@@ -309,7 +294,6 @@ def _install_sync_and_reload_key(config_globals):
     mod = config_globals.get("mod", "mod4")
     if not isinstance(keys, list):
         return
-
     modifiers = {mod, "control", "shift"}
     if any(
         getattr(binding, "key", None) == "r"
@@ -317,7 +301,6 @@ def _install_sync_and_reload_key(config_globals):
         for binding in keys
     ):
         return
-
     keys.append(
         Key(
             [mod, "control", "shift"],
@@ -331,8 +314,19 @@ def _install_sync_and_reload_key(config_globals):
 def _telemetry_widgets(home, colors):
     script = home + "/.config/qtile/scripts/openrouter_status.py"
     background = _color(colors, 1)
-
     return [
+        OpenRouterCredit(
+            script,
+            colors,
+            name="openrouter_credit",
+            update_interval=POLL_SECONDS,
+            markup=True,
+            font="Hack Nerd Regular",
+            fontsize=RATE_FONTSIZE,
+            padding=3,
+            foreground=_color(colors, 5),
+            background=background,
+        ),
         OpenRouterRate(
             script,
             colors,
@@ -358,42 +352,9 @@ def _telemetry_widgets(home, colors):
 
 
 def install_openrouter_widget(config_globals):
-    """Install the OpenRouter telemetry cluster and Qtile runtime helpers."""
-
+    """Install OpenRouter telemetry and the topology-aware desktop control layer."""
     _install_sync_and_reload_key(config_globals)
+    from qtile_control import install_desktop_control
 
-    original_widgets = config_globals.get("widgets")
-    separator = config_globals.get("sep")
-    home = config_globals.get("home")
-    colors = config_globals.get("colors")
-
-    if not callable(original_widgets) or not home or not colors:
-        return
-    if getattr(original_widgets, "_openrouter_wrapped", False):
-        return
-
-    def widgets_with_openrouter():
-        items = original_widgets()
-        if any(
-            str(getattr(item, "name", "")).startswith("openrouter_")
-            for item in items
-        ):
-            return items
-
-        insert_at = next(
-            (
-                index + 1
-                for index, item in enumerate(items)
-                if item.__class__.__name__ == "Net"
-            ),
-            len(items),
-        )
-        additions = _telemetry_widgets(home, colors)
-        if callable(separator):
-            additions.insert(0, separator(5))
-        items[insert_at:insert_at] = additions
-        return items
-
-    widgets_with_openrouter._openrouter_wrapped = True
-    config_globals["widgets"] = widgets_with_openrouter
+    install_desktop_control(config_globals, _telemetry_widgets)
 #+end_src

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -1,0 +1,470 @@
+"""Topology-aware Qtile bars, Org integration, and desktop workflows."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shlex
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+ROLE_ACCENTS = {
+    "left": "#f6019d",
+    "center": "#2de2e6",
+    "right": "#fba922",
+    "aux": "#9700cc",
+}
+DEFAULT_WORKFLOWS = {
+    "desktop": {
+        "auto_group": True,
+        "screens": {"left": "1", "center": "2", "right": "6", "aux": "8"},
+    }
+}
+PRIVATE_ENV_PATH = Path("~/.config/qtile/private.env").expanduser()
+WORKFLOWS_PATH = Path("~/.config/qtile/workflows.json").expanduser()
+EMACS_HELPER = Path("~/.config/qtile/qtile-desktop.el").expanduser()
+
+
+def _geometry(item: Any) -> tuple[int, int]:
+    rect = getattr(item, "rect", item)
+    return int(getattr(rect, "x", 0)), max(int(getattr(rect, "width", 1)), 1)
+
+
+def screen_roles(items: Iterable[Any]) -> list[str]:
+    """Return stable physical roles in the same order as *items*."""
+    items = list(items)
+    if not items:
+        return []
+
+    ordered = sorted(
+        [(index, *_geometry(item)) for index, item in enumerate(items)],
+        key=lambda row: (row[1], row[2], row[0]),
+    )
+    roles = ["aux"] * len(items)
+
+    if len(ordered) == 1:
+        roles[ordered[0][0]] = "center"
+        return roles
+
+    if len(ordered) == 2:
+        roles[ordered[0][0]] = "left"
+        roles[ordered[1][0]] = "center"
+        return roles
+
+    left = ordered[0]
+    right = ordered[-1]
+    roles[left[0]] = "left"
+    roles[right[0]] = "right"
+
+    desktop_left = min(row[1] for row in ordered)
+    desktop_right = max(row[1] + row[2] for row in ordered)
+    desktop_midpoint = (desktop_left + desktop_right) / 2.0
+    middle = ordered[1:-1]
+    center = min(
+        middle,
+        key=lambda row: (abs((row[1] + row[2] / 2.0) - desktop_midpoint), row[1]),
+    )
+    roles[center[0]] = "center"
+
+    auxiliary = [row for row in middle if row[0] != center[0]]
+    for index, row in enumerate(auxiliary, start=1):
+        roles[row[0]] = "aux" if len(auxiliary) == 1 else f"aux-{index}"
+    return roles
+
+
+def base_role(role: str) -> str:
+    return "aux" if role.startswith("aux") else role
+
+
+def role_accent(role: str) -> str:
+    return ROLE_ACCENTS[base_role(role)]
+
+
+def parse_private_env(path: Path = PRIVATE_ENV_PATH) -> dict[str, str]:
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return values
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = os.path.expanduser(value)
+    return values
+
+
+def load_private_env(path: Path = PRIVATE_ENV_PATH) -> dict[str, str]:
+    values = parse_private_env(path)
+    for key, value in values.items():
+        os.environ.setdefault(key, value)
+    return values
+
+
+def load_workflows(path: Path = WORKFLOWS_PATH) -> dict[str, dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return dict(DEFAULT_WORKFLOWS)
+    if not isinstance(payload, dict):
+        return dict(DEFAULT_WORKFLOWS)
+    workflows = {
+        str(name): value
+        for name, value in payload.items()
+        if isinstance(name, str) and isinstance(value, dict)
+    }
+    return workflows or dict(DEFAULT_WORKFLOWS)
+
+
+def _decode_emacs_string(output: str) -> str | None:
+    output = output.strip()
+    if not output or output == "nil":
+        return None
+    try:
+        value = ast.literal_eval(output)
+    except (SyntaxError, ValueError):
+        return output.strip('"')
+    return value if isinstance(value, str) else str(value)
+
+
+def _emacs_eval(expression: str, *, timeout: float = 300.0) -> str | None:
+    helper = str(EMACS_HELPER)
+    form = (
+        "(progn "
+        f"(load-file {json.dumps(helper)}) "
+        f"{expression})"
+    )
+    try:
+        completed = subprocess.run(
+            ["emacsclient", "-a", "emacs", "--eval", form],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return _decode_emacs_string(completed.stdout)
+
+
+def _notify(summary: str, body: str = "") -> None:
+    command = ["notify-send", "-a", "Qtile", summary]
+    if body:
+        command.append(body)
+    try:
+        subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except OSError:
+        pass
+
+
+def _role_to_screen_index(screens: Iterable[Any]) -> dict[str, int]:
+    screens = list(screens)
+    roles = screen_roles(screens)
+    result: dict[str, int] = {}
+    for index, role in enumerate(roles):
+        result[role] = index
+        result.setdefault(base_role(role), index)
+    return result
+
+
+def apply_workflow(qtile: Any, workflow: dict[str, Any], config_globals: dict[str, Any]) -> None:
+    if workflow.get("auto_group"):
+        organizer = config_globals.get("organize_existing_windows")
+        if callable(organizer):
+            organizer(qtile)
+
+    screens = workflow.get("screens", {})
+    if not isinstance(screens, dict):
+        return
+    role_indices = _role_to_screen_index(qtile.screens)
+    used_groups: set[str] = set()
+    for role, group_name in screens.items():
+        index = role_indices.get(str(role))
+        group_name = str(group_name)
+        group = qtile.groups_map.get(group_name)
+        if index is None or group is None or group_name in used_groups:
+            continue
+        group.toscreen(index)
+        used_groups.add(group_name)
+
+    center = role_indices.get("center")
+    if center is not None:
+        qtile.focus_screen(center)
+
+
+def _select_workflow(qtile: Any, config_globals: dict[str, Any]) -> None:
+    workflows = load_workflows()
+    names = sorted(workflows)
+    lisp_names = "(" + " ".join(json.dumps(name) for name in names) + ")"
+
+    def worker() -> None:
+        selected = _emacs_eval(f"(qtile-workflow-read '{lisp_names})")
+        if not selected or selected not in workflows:
+            return
+        qtile.call_soon_threadsafe(apply_workflow, qtile, workflows[selected], config_globals)
+        _notify("Qtile workflow", selected)
+
+    threading.Thread(target=worker, name="qtile-workflow-picker", daemon=True).start()
+
+
+def _emacs_frame_command(function: str, title: str) -> str:
+    expression = (
+        "(progn "
+        f"(load-file (expand-file-name {json.dumps(str(EMACS_HELPER))})) "
+        f"({function}))"
+    )
+    frame = f'((name . "{title}") (title . "{title}"))'
+    return " ".join(
+        [
+            "emacsclient",
+            "-c",
+            "-a",
+            "emacs",
+            "-F",
+            shlex.quote(frame),
+            "--eval",
+            shlex.quote(expression),
+        ]
+    )
+
+
+def _parse_clock_output(output: str) -> str:
+    value = _decode_emacs_string(output)
+    if not value:
+        return "Org: no clock"
+    return f"Org: {value}"
+
+
+def _base_widgets(config_globals: dict[str, Any], accent: str):
+    from libqtile import widget
+
+    colors = config_globals["colors"]
+    group_names = config_globals["group_names"]
+    background = colors[1][0] if isinstance(colors[1], (list, tuple)) else colors[1]
+    foreground = colors[5][0] if isinstance(colors[5], (list, tuple)) else colors[5]
+    items = []
+    auto_group = config_globals.get("auto_group_button")
+    if callable(auto_group):
+        items.append(auto_group())
+    items.extend(
+        [
+            widget.GroupBox(
+                font="3270 Nerd Font",
+                visible_groups=group_names,
+                fontsize=18,
+                margin_y=2,
+                margin_x=2,
+                padding_y=-4,
+                padding_x=6,
+                borderwidth=2,
+                active=accent,
+                inactive=foreground,
+                rounded=True,
+                highlight_method="block",
+                this_current_screen_border=accent,
+                this_screen_border=accent,
+                other_current_screen_border=background,
+                foreground=accent,
+                background=background,
+            ),
+            widget.CurrentLayout(font="Hack Bold", foreground=foreground, background=background),
+            widget.WindowName(font="Hack", fontsize=12, foreground=foreground, background=background),
+        ]
+    )
+    return items
+
+
+def build_screen_widgets(
+    role: str,
+    config_globals: dict[str, Any],
+    telemetry_widgets_factory: Callable[[str, Any], list[Any]],
+):
+    from libqtile import widget
+    from libqtile.lazy import lazy
+
+    colors = config_globals["colors"]
+    home = config_globals["home"]
+    background = colors[1][0] if isinstance(colors[1], (list, tuple)) else colors[1]
+    foreground = colors[5][0] if isinstance(colors[5], (list, tuple)) else colors[5]
+    accent = role_accent(role)
+    items = _base_widgets(config_globals, accent)
+    role = base_role(role)
+
+    if role == "center":
+        items.extend(telemetry_widgets_factory(home, colors))
+        items.extend(
+            [
+                widget.Pomodoro(foreground=accent, background=background),
+                widget.TextBox(
+                    name="agent_zero_button",
+                    text=" A0 ",
+                    foreground=accent,
+                    background=background,
+                    mouse_callbacks={
+                        "Button1": lazy.group["qtileControl"].dropdown_toggle("agent-zero")
+                    },
+                ),
+                widget.Clock(
+                    foreground=foreground,
+                    background=background,
+                    fontsize=12,
+                    format="%Y-%m-%d %H:%M",
+                ),
+                widget.Volume(foreground=accent, background=background),
+                widget.Systray(background=background, icon_size=20, padding=4),
+            ]
+        )
+    elif role == "left":
+        clock_expression = (
+            "(if (and (boundp 'org-clock-current-task) org-clock-current-task) "
+            "(substring-no-properties org-clock-current-task) nil)"
+        )
+        items.extend(
+            [
+                widget.GenPollCommand(
+                    name="org_clocked_task",
+                    cmd=["emacsclient", "-a", "emacs", "--eval", clock_expression],
+                    parse=_parse_clock_output,
+                    update_interval=10,
+                    foreground=accent,
+                    background=background,
+                    max_chars=55,
+                ),
+                widget.TextBox(
+                    name="org_todos_button",
+                    text=" TODO ",
+                    foreground=accent,
+                    background=background,
+                    mouse_callbacks={
+                        "Button1": lazy.group["qtileControl"].dropdown_toggle("org-todos")
+                    },
+                ),
+                widget.TextBox(
+                    name="workflow_button",
+                    text=" WF ",
+                    foreground=accent,
+                    background=background,
+                    mouse_callbacks={
+                        "Button1": lazy.function(_select_workflow, config_globals)
+                    },
+                ),
+                widget.Clock(
+                    foreground=foreground,
+                    background=background,
+                    fontsize=12,
+                    format="%H:%M",
+                ),
+            ]
+        )
+    elif role == "right":
+        items.extend(
+            [
+                widget.Mpris2(
+                    name="right_mpris",
+                    background=background,
+                    foreground=accent,
+                    scroll_fixed_width=True,
+                    poll_interval=1,
+                    width=220,
+                    padding=10,
+                    max_chars=80,
+                    markup=False,
+                ),
+                widget.Clock(
+                    foreground=foreground,
+                    background=background,
+                    fontsize=12,
+                    format="%H:%M",
+                ),
+                widget.Volume(foreground=accent, background=background),
+            ]
+        )
+    else:
+        items.append(
+            widget.Clock(
+                foreground=foreground,
+                background=background,
+                fontsize=12,
+                format="%H:%M",
+            )
+        )
+    return items
+
+
+def _install_control_scratchpad(config_globals: dict[str, Any]) -> None:
+    from libqtile.config import DropDown, Match, ScratchPad
+
+    groups = config_globals.get("groups")
+    if not isinstance(groups, list):
+        return
+    if any(getattr(group, "name", None) == "qtileControl" for group in groups):
+        return
+    groups.append(
+        ScratchPad(
+            "qtileControl",
+            [
+                DropDown(
+                    "org-todos",
+                    _emacs_frame_command("qtile-org-todos-open", "qtile-org-todos"),
+                    height=0.68,
+                    width=0.58,
+                    x=0.02,
+                    y=0.05,
+                    opacity=0.97,
+                    on_focus_lost_hide=True,
+                    match=Match(title="qtile-org-todos"),
+                ),
+                DropDown(
+                    "agent-zero",
+                    _emacs_frame_command("qtile-agent-zero-open", "qtile-agent-zero"),
+                    height=0.72,
+                    width=0.62,
+                    x=0.19,
+                    y=0.04,
+                    opacity=0.97,
+                    on_focus_lost_hide=False,
+                    match=Match(title="qtile-agent-zero"),
+                ),
+            ],
+        )
+    )
+
+
+def install_desktop_control(
+    config_globals: dict[str, Any],
+    telemetry_widgets_factory: Callable[[str, Any], list[Any]],
+) -> None:
+    """Replace the cloned bar with topology-aware, role-scoped bars."""
+    from libqtile import bar
+    from libqtile.config import Screen
+
+    load_private_env()
+    _install_control_scratchpad(config_globals)
+
+    def screen_widgets(role: str = "center"):
+        return build_screen_widgets(role, config_globals, telemetry_widgets_factory)
+
+    def generate_screens(output_info):
+        roles = screen_roles(output_info)
+        return [
+            Screen(
+                top=bar.Bar(
+                    screen_widgets(role),
+                    26,
+                    opacity=0.8,
+                )
+            )
+            for role in roles
+        ]
+
+    config_globals["screen_widgets"] = screen_widgets
+    config_globals["generate_screens"] = generate_screens

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -1,4 +1,4 @@
-"""OpenRouter telemetry widgets and small Qtile runtime helpers."""
+"""OpenRouter telemetry widgets and Qtile runtime helpers."""
 
 from __future__ import annotations
 
@@ -58,12 +58,10 @@ def _compact_count(value):
 
 def _fetch_payload(script):
     global _last_payload, _last_poll_at
-
     with _poll_lock:
         now = time.monotonic()
         if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
             return _last_payload
-
         completed = subprocess.run(
             ["python3", script, "--json"],
             check=False,
@@ -75,19 +73,16 @@ def _fetch_payload(script):
             payload = json.loads(completed.stdout)
         except json.JSONDecodeError:
             payload = None
-
         _last_poll_at = time.monotonic()
         if isinstance(payload, dict) and "input_tokens_per_minute" in payload:
             _last_payload = payload
             return payload
-
         cached = _read_cached_status()
         if cached:
             payload = dict(cached)
             payload["stale"] = True
             _last_payload = payload
             return payload
-
         return None
 
 
@@ -95,16 +90,11 @@ def _notify(summary, body="", urgency="normal"):
     notifier = shutil.which("dunstify") or shutil.which("notify-send")
     if not notifier:
         return
-
     command = [notifier, "-a", "Qtile", "-u", urgency, summary]
     if body:
         command.append(body)
     try:
-        subprocess.Popen(
-            command,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except OSError:
         pass
 
@@ -112,10 +102,7 @@ def _notify(summary, body="", urgency="normal"):
 def _git_sync_command():
     helper = Path.home() / ".config" / "bash" / "git-sync.sh"
     repo = Path.home() / ".dotfiles"
-    return (
-        f'source "{helper}" && '
-        f'git-sync "{repo}"'
-    )
+    return f'source "{helper}" && git-sync "{repo}"'
 
 
 def _run_dotfiles_sync():
@@ -131,13 +118,11 @@ def _run_dotfiles_sync():
 def _sync_and_reload(qtile):
     """Sync dotfiles off the event loop, then reload Qtile in-process."""
     global _sync_in_progress
-
     with _sync_lock:
         if _sync_in_progress:
             _notify("Dotfiles sync", "Already syncing.", "low")
             return
         _sync_in_progress = True
-
     _notify("Dotfiles sync", "Fetching updates…")
 
     def worker():
@@ -149,28 +134,47 @@ def _sync_and_reload(qtile):
             with _sync_lock:
                 _sync_in_progress = False
             return
-
         with _sync_lock:
             _sync_in_progress = False
-
         if completed.returncode != 0:
             detail = (completed.stderr or completed.stdout or "git-sync failed").strip()
             _notify("Dotfiles sync failed", detail[-800:], "critical")
             return
-
         detail = (completed.stdout or "Dotfiles are up to date.").strip()
         _notify("Dotfiles synced", detail[-400:] + "\nReloading Qtile…")
         qtile.call_soon_threadsafe(qtile.reload_config)
 
-    threading.Thread(
-        target=worker,
-        name="qtile-dotfiles-sync",
-        daemon=True,
-    ).start()
+    threading.Thread(target=worker, name="qtile-dotfiles-sync", daemon=True).start()
+
+
+class OpenRouterCredit(base.BackgroundPoll):
+    """Display current OpenRouter account balance without blocking Qtile."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, script, colors, **config):
+        self.script = script
+        self.colors = colors
+        super().__init__(text="$…", **config)
+
+    def poll(self):
+        payload = _fetch_payload(self.script)
+        if not payload or payload.get("balance_usd") is None:
+            return f'<span foreground="{_color(self.colors, 8)}">$?</span>'
+        balance = float(payload["balance_usd"])
+        color = (
+            _color(self.colors, 8)
+            if balance < 5
+            else _color(self.colors, 3)
+            if balance < 10
+            else _color(self.colors, 7)
+        )
+        stale = " ~" if payload.get("stale") else ""
+        return f'<span foreground="{color}">${balance:.2f}{stale}</span>'
 
 
 class OpenRouterRate(base.BackgroundPoll):
-    """Display a rolling 60-second OpenRouter token rate."""
+    """Display the most recent complete-minute OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -183,7 +187,6 @@ class OpenRouterRate(base.BackgroundPoll):
         payload = _fetch_payload(self.script)
         if not payload:
             return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
-
         incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
         outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
         stale = " ~" if payload.get("stale") else ""
@@ -194,10 +197,9 @@ class OpenRouterRate(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Five-minute sparkline of sampled input/output tokens per minute."""
+    """Five-minute sparkline of trusted input/output tokens per minute."""
 
     orientations = base.ORIENTATION_HORIZONTAL
-
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
         ("samples", GRAPH_SAMPLES, "Number of rate samples."),
@@ -214,6 +216,7 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.input_values = deque(maxlen=self.samples)
         self.output_values = deque(maxlen=self.samples)
+        self._last_window_end = None
 
     def timer_setup(self):
         self._update()
@@ -222,30 +225,26 @@ class OpenRouterIOGraph(base._Widget):
     def _update(self):
         status = _read_cached_status()
         if status:
-            self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
-            self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
+            window_end = status.get("window_end")
+            if window_end != self._last_window_end:
+                self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
+                self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
+                self._last_window_end = window_end
         self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
             return
-
         values = list(values)
         minimum = min(values)
         maximum = max(values)
         if maximum <= minimum:
             return
-
-        # Absolute rates are printed beside the graph. The sparkline uses an
-        # adaptive per-stream range so real movement remains visible even when
-        # prompt and completion traffic differ by orders of magnitude.
         span = maximum - minimum
         usable_width = max(self.width - 2 * self.margin_x, 1)
         step = usable_width / max(len(values) - 1, 1)
-
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-
         for index, value in enumerate(values):
             x = self.margin_x + index * step
             normalized = (float(value) - minimum) / span
@@ -259,30 +258,15 @@ class OpenRouterIOGraph(base._Widget):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
-
         center_y = self.height / 2.0
         half_height = max(center_y - self.margin_y - 1, 1)
-
         self.drawer.set_source_rgb(self.midline_color)
         self.drawer.ctx.set_line_width(0.6)
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
-
-        self._draw_series(
-            self.input_values,
-            self.input_color,
-            center_y,
-            half_height,
-            -1,
-        )
-        self._draw_series(
-            self.output_values,
-            self.output_color,
-            center_y,
-            half_height,
-            1,
-        )
+        self._draw_series(self.input_values, self.input_color, center_y, half_height, -1)
+        self._draw_series(self.output_values, self.output_color, center_y, half_height, 1)
         self.draw_at_default_position()
 
 
@@ -291,7 +275,6 @@ def _install_sync_and_reload_key(config_globals):
     mod = config_globals.get("mod", "mod4")
     if not isinstance(keys, list):
         return
-
     modifiers = {mod, "control", "shift"}
     if any(
         getattr(binding, "key", None) == "r"
@@ -299,7 +282,6 @@ def _install_sync_and_reload_key(config_globals):
         for binding in keys
     ):
         return
-
     keys.append(
         Key(
             [mod, "control", "shift"],
@@ -313,8 +295,19 @@ def _install_sync_and_reload_key(config_globals):
 def _telemetry_widgets(home, colors):
     script = home + "/.config/qtile/scripts/openrouter_status.py"
     background = _color(colors, 1)
-
     return [
+        OpenRouterCredit(
+            script,
+            colors,
+            name="openrouter_credit",
+            update_interval=POLL_SECONDS,
+            markup=True,
+            font="Hack Nerd Regular",
+            fontsize=RATE_FONTSIZE,
+            padding=3,
+            foreground=_color(colors, 5),
+            background=background,
+        ),
         OpenRouterRate(
             script,
             colors,
@@ -340,41 +333,8 @@ def _telemetry_widgets(home, colors):
 
 
 def install_openrouter_widget(config_globals):
-    """Install the OpenRouter telemetry cluster and Qtile runtime helpers."""
-
+    """Install OpenRouter telemetry and the topology-aware desktop control layer."""
     _install_sync_and_reload_key(config_globals)
+    from qtile_control import install_desktop_control
 
-    original_widgets = config_globals.get("widgets")
-    separator = config_globals.get("sep")
-    home = config_globals.get("home")
-    colors = config_globals.get("colors")
-
-    if not callable(original_widgets) or not home or not colors:
-        return
-    if getattr(original_widgets, "_openrouter_wrapped", False):
-        return
-
-    def widgets_with_openrouter():
-        items = original_widgets()
-        if any(
-            str(getattr(item, "name", "")).startswith("openrouter_")
-            for item in items
-        ):
-            return items
-
-        insert_at = next(
-            (
-                index + 1
-                for index, item in enumerate(items)
-                if item.__class__.__name__ == "Net"
-            ),
-            len(items),
-        )
-        additions = _telemetry_widgets(home, colors)
-        if callable(separator):
-            additions.insert(0, separator(5))
-        items[insert_at:insert_at] = additions
-        return items
-
-    widgets_with_openrouter._openrouter_wrapped = True
-    config_globals["widgets"] = widgets_with_openrouter
+    install_desktop_control(config_globals, _telemetry_widgets)

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -131,8 +131,11 @@ def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
             or row.get("timestamp")
             or row.get("date")
         )
-        row_prompt = float(row.get("tokens_prompt") or 0)
-        row_completion = float(row.get("tokens_completion") or 0)
+        try:
+            row_prompt = float(row.get("tokens_prompt") or 0)
+            row_completion = float(row.get("tokens_completion") or 0)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("OpenRouter analytics token metric malformed") from exc
         signature = (bucket, row_prompt, row_completion)
         if signature in seen:
             continue
@@ -164,8 +167,11 @@ def fetch_tokens(key: str, start: datetime, end: datetime) -> tuple[int, int]:
 def fetch_balance(key: str) -> float:
     payload = _request_json("GET", "/credits", key)
     data = payload.get("data", {})
-    total = float(data.get("total_credits") or 0)
-    usage = float(data.get("total_usage") or 0)
+    try:
+        total = float(data.get("total_credits") or 0)
+        usage = float(data.get("total_usage") or 0)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("OpenRouter credit payload malformed") from exc
     return max(total - usage, 0.0)
 
 

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render OpenRouter token-per-minute telemetry for the Qtile bar."""
+"""Render trustworthy OpenRouter token-per-minute telemetry for the Qtile bar."""
 
 from __future__ import annotations
 
@@ -17,22 +17,22 @@ from pathlib import Path
 from typing import Any
 
 API_BASE = "https://openrouter.ai/api/v1"
-# Nerd Fonts v3+ Material Design "brain" (nf-md-brain).
 AI_ICON = "\U000F09D1"
-
 RED = "#dd546e"
 IO = "#f6019d"
 ACCENT = "#2de2e6"
-
 CACHE_TTL_SECONDS = 4
 RATE_WINDOW_SECONDS = 60
 REQUEST_TIMEOUT_SECONDS = 5
+DEFAULT_MAX_TPM = 10_000_000
 
 
 @dataclass(frozen=True)
 class Status:
     input_tokens_per_minute: int
     output_tokens_per_minute: int
+    balance_usd: float | None = None
+    window_end: str | None = None
 
     @property
     def total_tokens_per_minute(self) -> int:
@@ -74,10 +74,8 @@ def load_management_key() -> str:
         value = os.environ.get(env_name, "").strip()
         if value:
             return value
-
-    key_file = _management_key_file()
     try:
-        return key_file.read_text(encoding="utf-8").strip()
+        return _management_key_file().read_text(encoding="utf-8").strip()
     except FileNotFoundError as exc:
         raise RuntimeError("management key missing") from exc
 
@@ -92,23 +90,16 @@ def _request_json(
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}",
-        "User-Agent": "qtile-openrouter-status/2",
+        "User-Agent": "qtile-openrouter-status/3",
     }
     if payload is not None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         headers["Content-Type"] = "application/json"
-
     request = urllib.request.Request(
-        f"{API_BASE}{path}",
-        data=body,
-        headers=headers,
-        method=method,
+        f"{API_BASE}{path}", data=body, headers=headers, method=method
     )
     try:
-        with urllib.request.urlopen(
-            request,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        ) as response:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             return json.load(response)
     except urllib.error.HTTPError as exc:
         if exc.code in (401, 403):
@@ -121,28 +112,77 @@ def _request_json(
 
 
 def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
+    metadata = payload.get("metadata") or payload.get("data", {}).get("metadata") or {}
+    if metadata.get("truncated"):
+        raise RuntimeError("OpenRouter analytics result truncated")
     rows = payload.get("data", {}).get("data", [])
-    prompt = sum(float(row.get("tokens_prompt") or 0) for row in rows)
-    completion = sum(float(row.get("tokens_completion") or 0) for row in rows)
+    if not isinstance(rows, list):
+        raise RuntimeError("OpenRouter analytics rows malformed")
+
+    prompt = 0.0
+    completion = 0.0
+    seen: set[tuple[Any, ...]] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        bucket = (
+            row.get("created_at__minute")
+            or row.get("date__minute")
+            or row.get("timestamp")
+            or row.get("date")
+        )
+        row_prompt = float(row.get("tokens_prompt") or 0)
+        row_completion = float(row.get("tokens_completion") or 0)
+        signature = (bucket, row_prompt, row_completion)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        prompt += row_prompt
+        completion += row_completion
     return int(round(prompt)), int(round(completion))
 
 
-def fetch_tokens(
-    key: str,
-    start: datetime,
-    end: datetime,
-) -> tuple[int, int]:
+def _closed_minute_window(now: datetime | None = None) -> tuple[datetime, datetime]:
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    end = now.replace(second=0, microsecond=0)
+    return end - timedelta(seconds=RATE_WINDOW_SECONDS), end
+
+
+def fetch_tokens(key: str, start: datetime, end: datetime) -> tuple[int, int]:
     payload = {
         "metrics": ["tokens_prompt", "tokens_completion"],
+        "granularity": "minute",
         "time_range": {
             "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
             "end": end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
         },
         "limit": 10,
     }
-    return parse_token_totals(
-        _request_json("POST", "/analytics/query", key, payload),
-    )
+    return parse_token_totals(_request_json("POST", "/analytics/query", key, payload))
+
+
+def fetch_balance(key: str) -> float:
+    payload = _request_json("GET", "/credits", key)
+    data = payload.get("data", {})
+    total = float(data.get("total_credits") or 0)
+    usage = float(data.get("total_usage") or 0)
+    return max(total - usage, 0.0)
+
+
+def _maximum_tpm() -> int:
+    raw = os.environ.get("OPENROUTER_TPM_MAX", str(DEFAULT_MAX_TPM))
+    try:
+        return max(int(raw), 1)
+    except ValueError:
+        return DEFAULT_MAX_TPM
+
+
+def validate_rate(input_tokens: int, output_tokens: int) -> None:
+    if input_tokens < 0 or output_tokens < 0:
+        raise RuntimeError("negative OpenRouter token rate")
+    maximum = _maximum_tpm()
+    if input_tokens + output_tokens > maximum:
+        raise RuntimeError("implausible OpenRouter token rate")
 
 
 def _cache_path() -> Path:
@@ -171,10 +211,7 @@ def _write_cache(path: Path, status: Status, *, fetched_at: float) -> None:
     temporary = path.with_suffix(".tmp")
     temporary.write_text(
         json.dumps(
-            {
-                "fetched_at": fetched_at,
-                "status": asdict(status),
-            },
+            {"fetched_at": fetched_at, "status": asdict(status)},
             separators=(",", ":"),
         ),
         encoding="utf-8",
@@ -182,16 +219,20 @@ def _write_cache(path: Path, status: Status, *, fetched_at: float) -> None:
     temporary.replace(path)
 
 
-def fetch_status(key: str) -> Status:
-    now = datetime.now(timezone.utc)
-    input_tokens, output_tokens = fetch_tokens(
-        key,
-        now - timedelta(seconds=RATE_WINDOW_SECONDS),
-        now,
-    )
+def fetch_status(key: str, previous: Status | None = None) -> Status:
+    start, end = _closed_minute_window()
+    input_tokens, output_tokens = fetch_tokens(key, start, end)
+    validate_rate(input_tokens, output_tokens)
+    balance = previous.balance_usd if previous else None
+    try:
+        balance = fetch_balance(key)
+    except RuntimeError:
+        pass
     return Status(
         input_tokens_per_minute=input_tokens,
         output_tokens_per_minute=output_tokens,
+        balance_usd=balance,
+        window_end=end.isoformat().replace("+00:00", "Z"),
     )
 
 
@@ -199,23 +240,19 @@ def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
     path = _cache_path()
     lock_path = path.with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-
     with lock_path.open("a+", encoding="utf-8") as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-
         cache = _read_cache(path)
         cached_status = _status_from_cache(cache)
         fetched_at = float((cache or {}).get("fetched_at", 0))
         if not force and cached_status and time.time() - fetched_at < CACHE_TTL_SECONDS:
             return cached_status, False
-
         try:
-            status = fetch_status(key)
+            status = fetch_status(key, cached_status)
         except RuntimeError:
             if cached_status:
                 return cached_status, True
             raise
-
         _write_cache(path, status, fetched_at=time.time())
         return status, False
 
@@ -225,7 +262,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="print machine-readable status")
     parser.add_argument("--force", action="store_true", help="ignore the short poll cache")
     args = parser.parse_args(argv)
-
     try:
         key = load_management_key()
         if not key:
@@ -238,7 +274,6 @@ def main(argv: list[str] | None = None) -> int:
             short = "key?" if "key" in str(exc).lower() else "offline"
             print(render_error(short))
         return 1
-
     if args.json:
         payload = asdict(status)
         payload["total_tokens_per_minute"] = status.total_tokens_per_minute

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -42,6 +42,11 @@ class OpenRouterStatusTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "truncated"):
             MODULE.parse_token_totals(payload)
 
+    def test_parse_token_totals_rejects_malformed_metrics(self):
+        payload = {"data": {"data": [{"tokens_prompt": "wat", "tokens_completion": 1}]}}
+        with self.assertRaisesRegex(RuntimeError, "malformed"):
+            MODULE.parse_token_totals(payload)
+
     def test_closed_window_is_previous_full_minute(self):
         now = MODULE.datetime(2026, 8, 22, 21, 10, 47, 900, tzinfo=MODULE.timezone.utc)
         start, end = MODULE._closed_minute_window(now)
@@ -63,6 +68,12 @@ class OpenRouterStatusTests(unittest.TestCase):
         with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
             self.assertEqual(MODULE.fetch_balance("key"), 17.75)
         self.assertEqual(request.call_args.args[:3], ("GET", "/credits", "key"))
+
+    def test_fetch_balance_rejects_malformed_credit_payload(self):
+        response = {"data": {"total_credits": "nope", "total_usage": 7.25}}
+        with mock.patch.object(MODULE, "_request_json", return_value=response):
+            with self.assertRaisesRegex(RuntimeError, "credit payload malformed"):
+                MODULE.fetch_balance("key")
 
     def test_165m_style_spike_is_rejected(self):
         with mock.patch.dict(os.environ, {"OPENROUTER_TPM_MAX": "10000000"}, clear=False):

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -24,89 +24,76 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(MODULE.compact_count(999), "999")
         self.assertEqual(MODULE.compact_count(1_200), "1.2k")
         self.assertEqual(MODULE.compact_count(12_000_000), "12M")
-        self.assertEqual(MODULE.compact_count(2_500_000_000), "2.5B")
 
     def test_uses_current_nerd_font_brain_codepoint(self):
         self.assertEqual(ord(MODULE.AI_ICON), 0xF09D1)
-        self.assertFalse(0xF500 <= ord(MODULE.AI_ICON) <= 0xFD46)
 
-    def test_parse_token_totals_sums_rows(self):
-        payload = {
-            "data": {
-                "data": [
-                    {"tokens_prompt": 100, "tokens_completion": 10},
-                    {"tokens_prompt": 250, "tokens_completion": 25},
-                ]
-            }
+    def test_parse_token_totals_deduplicates_identical_buckets(self):
+        row = {
+            "created_at__minute": "2026-08-22T21:10:00Z",
+            "tokens_prompt": 100,
+            "tokens_completion": 10,
         }
-        self.assertEqual(MODULE.parse_token_totals(payload), (350, 35))
+        payload = {"data": {"data": [row, dict(row)]}}
+        self.assertEqual(MODULE.parse_token_totals(payload), (100, 10))
 
-    def test_render_labels_tokens_per_minute(self):
-        status = MODULE.Status(
-            input_tokens_per_minute=12_300,
-            output_tokens_per_minute=4_500,
-        )
-        rendered = MODULE.render(status)
-        self.assertIn(MODULE.AI_ICON, rendered)
-        self.assertIn("12.3k↓/m", rendered)
-        self.assertIn("4.5k↑/m", rendered)
-        self.assertNotIn("$", rendered)
-        self.assertNotIn("30d:", rendered)
+    def test_parse_token_totals_rejects_truncated_analytics(self):
+        payload = {"metadata": {"truncated": True}, "data": {"data": []}}
+        with self.assertRaisesRegex(RuntimeError, "truncated"):
+            MODULE.parse_token_totals(payload)
+
+    def test_closed_window_is_previous_full_minute(self):
+        now = MODULE.datetime(2026, 8, 22, 21, 10, 47, 900, tzinfo=MODULE.timezone.utc)
+        start, end = MODULE._closed_minute_window(now)
+        self.assertEqual(end, MODULE.datetime(2026, 8, 22, 21, 10, tzinfo=MODULE.timezone.utc))
+        self.assertEqual((end - start).total_seconds(), 60)
+
+    def test_fetch_tokens_requests_minute_granularity(self):
+        start = MODULE.datetime(2026, 8, 22, 21, 9, tzinfo=MODULE.timezone.utc)
+        end = MODULE.datetime(2026, 8, 22, 21, 10, tzinfo=MODULE.timezone.utc)
+        response = {"data": {"data": [{"tokens_prompt": 1_000, "tokens_completion": 100}]}}
+        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
+            self.assertEqual(MODULE.fetch_tokens("key", start, end), (1_000, 100))
+        payload = request.call_args.args[3]
+        self.assertEqual(payload["granularity"], "minute")
+        self.assertEqual(payload["metrics"], ["tokens_prompt", "tokens_completion"])
+
+    def test_fetch_balance_uses_total_credits_minus_usage(self):
+        response = {"data": {"total_credits": 25.0, "total_usage": 7.25}}
+        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
+            self.assertEqual(MODULE.fetch_balance("key"), 17.75)
+        self.assertEqual(request.call_args.args[:3], ("GET", "/credits", "key"))
+
+    def test_165m_style_spike_is_rejected(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_TPM_MAX": "10000000"}, clear=False):
+            with self.assertRaisesRegex(RuntimeError, "implausible"):
+                MODULE.validate_rate(165_000_000, 1_000)
+
+    def test_tpm_guard_is_configurable(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_TPM_MAX": "200000000"}, clear=False):
+            MODULE.validate_rate(165_000_000, 1_000)
+
+    def test_fetch_status_keeps_previous_balance_if_credit_poll_fails(self):
+        previous = MODULE.Status(100, 10, balance_usd=9.50)
+        with (
+            mock.patch.object(MODULE, "fetch_tokens", return_value=(1_000, 100)),
+            mock.patch.object(MODULE, "fetch_balance", side_effect=RuntimeError("offline")),
+        ):
+            status = MODULE.fetch_status("key", previous)
+        self.assertEqual(status.balance_usd, 9.50)
+        self.assertEqual(status.total_tokens_per_minute, 1_100)
+        self.assertIsNotNone(status.window_end)
 
     def test_management_key_prefers_dedicated_environment_variable(self):
         with mock.patch.dict(
             os.environ,
-            {
-                "OPENROUTER_MANAGEMENT_KEY": "management",
-                "OPENROUTER_API_KEY": "regular",
-            },
+            {"OPENROUTER_MANAGEMENT_KEY": "management", "OPENROUTER_API_KEY": "regular"},
             clear=True,
         ):
             self.assertEqual(MODULE.load_management_key(), "management")
 
-    def test_management_key_falls_back_to_file(self):
-        with tempfile.TemporaryDirectory() as directory:
-            key_file = Path(directory) / "management-key"
-            key_file.write_text("file-key\n", encoding="utf-8")
-            with mock.patch.dict(
-                os.environ,
-                {"OPENROUTER_MANAGEMENT_KEY_FILE": str(key_file)},
-                clear=True,
-            ):
-                self.assertEqual(MODULE.load_management_key(), "file-key")
-
-    def test_fetch_tokens_requests_prompt_and_completion_metrics(self):
-        start = MODULE.datetime(2026, 8, 22, 1, 0, tzinfo=MODULE.timezone.utc)
-        end = MODULE.datetime(2026, 8, 22, 1, 1, tzinfo=MODULE.timezone.utc)
-        response = {
-            "data": {
-                "data": [
-                    {"tokens_prompt": 1_000, "tokens_completion": 100},
-                ]
-            }
-        }
-        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
-            self.assertEqual(MODULE.fetch_tokens("key", start, end), (1_000, 100))
-
-        payload = request.call_args.args[3]
-        self.assertEqual(payload["metrics"], ["tokens_prompt", "tokens_completion"])
-        self.assertNotIn("granularity", payload)
-
-    def test_fetch_status_is_a_rolling_sixty_second_rate(self):
-        with mock.patch.object(MODULE, "fetch_tokens", return_value=(10_000, 500)) as fetch_tokens:
-            status = MODULE.fetch_status("key")
-
-        _, start, end = fetch_tokens.call_args.args
-        self.assertAlmostEqual((end - start).total_seconds(), 60.0)
-        self.assertEqual(status.input_tokens_per_minute, 10_000)
-        self.assertEqual(status.output_tokens_per_minute, 500)
-        self.assertEqual(status.total_tokens_per_minute, 10_500)
-
     def test_status_cache_bounds_api_polling(self):
-        status = MODULE.Status(
-            input_tokens_per_minute=1_000,
-            output_tokens_per_minute=100,
-        )
+        status = MODULE.Status(1_000, 100, balance_usd=12.0, window_end="2026-08-22T21:10:00Z")
         with tempfile.TemporaryDirectory() as directory:
             with (
                 mock.patch.dict(os.environ, {"XDG_CACHE_HOME": directory}),
@@ -114,7 +101,6 @@ class OpenRouterStatusTests(unittest.TestCase):
             ):
                 first, first_stale = MODULE.status_with_cache("key")
                 second, second_stale = MODULE.status_with_cache("key")
-
         self.assertEqual(first, status)
         self.assertEqual(second, status)
         self.assertFalse(first_stale)

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -22,54 +22,50 @@ def assigned_constant(name):
 
 
 class OpenRouterWidgetStructureTests(unittest.TestCase):
-    def test_five_second_rate_polling_and_five_minute_graph(self):
+    def test_five_second_rate_polling_and_five_minute_graph_capacity(self):
         self.assertEqual(assigned_constant("POLL_SECONDS"), 5)
         self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 60)
 
     def test_readable_rate_font_size(self):
         self.assertGreaterEqual(assigned_constant("RATE_FONTSIZE"), 12)
 
-    def test_rate_and_graph_widgets_exist_without_credit_or_rolling_widgets(self):
-        classes = {
-            node.name
-            for node in TREE.body
-            if isinstance(node, ast.ClassDef)
-        }
+    def test_credit_rate_and_graph_widgets_exist(self):
+        classes = {node.name for node in TREE.body if isinstance(node, ast.ClassDef)}
+        self.assertIn("OpenRouterCredit", classes)
         self.assertIn("OpenRouterRate", classes)
         self.assertIn("OpenRouterIOGraph", classes)
-        self.assertNotIn("OpenRouterCredit", classes)
-        self.assertNotIn("OpenRouterCacheText", classes)
+
+    def test_credit_thresholds_are_preserved(self):
+        self.assertIn("balance < 5", SOURCE_TEXT)
+        self.assertIn("balance < 10", SOURCE_TEXT)
+        self.assertIn('name="openrouter_credit"', SOURCE_TEXT)
 
     def test_rate_poll_respects_status_cache(self):
         self.assertIn('["python3", script, "--json"]', SOURCE_TEXT)
         self.assertNotIn('"--force"', SOURCE_TEXT)
         self.assertIn('"openrouter_io_graph"', SOURCE_TEXT)
-        self.assertNotIn('"rolling"', SOURCE_TEXT)
 
     def test_rate_is_rendered_as_two_tokens_per_minute_lines(self):
         self.assertIn("{incoming}↓/m</span>\\n", SOURCE_TEXT)
         self.assertIn("{outgoing}↑/m{stale}</span>", SOURCE_TEXT)
 
-    def test_graph_does_not_seed_fake_zero_history(self):
-        self.assertIn("deque(maxlen=self.samples)", SOURCE_TEXT)
-        self.assertNotIn("[0.0] * self.samples", SOURCE_TEXT)
+    def test_graph_does_not_duplicate_same_minute(self):
+        self.assertIn("self._last_window_end", SOURCE_TEXT)
+        self.assertIn('status.get("window_end")', SOURCE_TEXT)
 
     def test_graph_uses_adaptive_range_and_hides_constant_series(self):
         self.assertIn("minimum = min(values)", SOURCE_TEXT)
         self.assertIn("maximum = max(values)", SOURCE_TEXT)
         self.assertIn("if maximum <= minimum:", SOURCE_TEXT)
-        self.assertIn("return", SOURCE_TEXT)
 
     def test_sync_reload_uses_qtile_process_not_external_cli(self):
         self.assertIn("lazy.function(_sync_and_reload)", SOURCE_TEXT)
         self.assertIn("qtile.call_soon_threadsafe(qtile.reload_config)", SOURCE_TEXT)
         self.assertNotIn("qtile cmd-obj", SOURCE_TEXT)
 
-    def test_sync_reload_notifies_user(self):
-        self.assertIn('shutil.which("dunstify")', SOURCE_TEXT)
-        self.assertIn('shutil.which("notify-send")', SOURCE_TEXT)
-        self.assertIn('"Dotfiles sync failed"', SOURCE_TEXT)
-        self.assertIn('"Dotfiles synced"', SOURCE_TEXT)
+    def test_installs_topology_control_layer(self):
+        self.assertIn("from qtile_control import install_desktop_control", SOURCE_TEXT)
+        self.assertIn("install_desktop_control(config_globals, _telemetry_widgets)", SOURCE_TEXT)
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Topology and config regression tests for Qtile desktop control."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile_control.py"
+SPEC = importlib.util.spec_from_file_location("qtile_control", SOURCE)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+SOURCE_TEXT = SOURCE.read_text(encoding="utf-8")
+
+
+@dataclass
+class Rect:
+    x: int
+    width: int = 1920
+
+
+@dataclass
+class Output:
+    name: str
+    rect: Rect
+
+
+def outputs(count: int):
+    return [Output(str(index), Rect(index * 1920)) for index in range(count)]
+
+
+class QtileControlTests(unittest.TestCase):
+    def test_n1_is_center(self):
+        self.assertEqual(MODULE.screen_roles(outputs(1)), ["center"])
+
+    def test_n2_is_left_center(self):
+        self.assertEqual(MODULE.screen_roles(outputs(2)), ["left", "center"])
+
+    def test_n3_is_left_center_right(self):
+        self.assertEqual(MODULE.screen_roles(outputs(3)), ["left", "center", "right"])
+
+    def test_n4_has_all_primary_roles_and_one_aux(self):
+        roles = MODULE.screen_roles(outputs(4))
+        self.assertEqual(set(roles), {"left", "center", "right", "aux"})
+        self.assertEqual(roles[0], "left")
+        self.assertEqual(roles[-1], "right")
+
+    def test_roles_follow_geometry_not_enumeration_order(self):
+        shuffled = [outputs(3)[2], outputs(3)[0], outputs(3)[1]]
+        self.assertEqual(MODULE.screen_roles(shuffled), ["right", "left", "center"])
+
+    def test_primary_monitor_accents_are_distinct(self):
+        accents = [MODULE.role_accent(role) for role in ("left", "center", "right", "aux")]
+        self.assertEqual(len(accents), len(set(accents)))
+
+    def test_private_env_parser_ignores_comments_and_expands_values(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "private.env"
+            path.write_text("# secret config\nAGENT_ZERO_HOST=http://127.0.0.1:5080\nEMPTY=\n", encoding="utf-8")
+            values = MODULE.parse_private_env(path)
+        self.assertEqual(values["AGENT_ZERO_HOST"], "http://127.0.0.1:5080")
+        self.assertEqual(values["EMPTY"], "")
+
+    def test_workflow_loader_falls_back_on_invalid_json(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "workflows.json"
+            path.write_text("{nope", encoding="utf-8")
+            self.assertEqual(MODULE.load_workflows(path), MODULE.DEFAULT_WORKFLOWS)
+
+    def test_runtime_bar_source_has_no_weather(self):
+        self.assertNotIn("wttr.in", SOURCE_TEXT)
+        self.assertNotIn("OpenWeather", SOURCE_TEXT)
+
+    def test_mpris_is_scoped_to_right_branch(self):
+        right = SOURCE_TEXT.index('elif role == "right":')
+        mpris = SOURCE_TEXT.index("widget.Mpris2", right)
+        self.assertGreater(mpris, right)
+        self.assertEqual(SOURCE_TEXT.count("widget.Mpris2"), 1)
+
+    def test_center_is_only_systray_role(self):
+        self.assertEqual(SOURCE_TEXT.count("widget.Systray"), 1)
+        center = SOURCE_TEXT.index('if role == "center":')
+        tray = SOURCE_TEXT.index("widget.Systray", center)
+        left = SOURCE_TEXT.index('elif role == "left":')
+        self.assertLess(tray, left)
+
+    def test_org_poll_uses_async_genpollcommand(self):
+        self.assertIn("widget.GenPollCommand", SOURCE_TEXT)
+        self.assertIn('name="org_clocked_task"', SOURCE_TEXT)
+
+    def test_agent_zero_is_an_emacs_scratchpad(self):
+        self.assertIn('"agent-zero"', SOURCE_TEXT)
+        self.assertIn('"qtile-agent-zero"', SOURCE_TEXT)
+        self.assertIn("qtile-agent-zero-open", SOURCE_TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_qtile_emacs_control.py
+++ b/.config/qtile/tests/test_qtile_emacs_control.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Static safety regressions for Qtile's Emacs control client."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile-desktop.el"
+TEXT = SOURCE.read_text(encoding="utf-8")
+
+
+class QtileEmacsControlTests(unittest.TestCase):
+    def test_agent_zero_uses_documented_external_api(self):
+        self.assertIn('(concat host "/api_message")', TEXT)
+        self.assertIn('("X-API-KEY" . ,key)', TEXT)
+        self.assertIn('(message . ,prompt)', TEXT)
+        self.assertIn('(context_id . ,qtile-agent-zero-context-id)', TEXT)
+
+    def test_agent_zero_request_is_async(self):
+        self.assertIn("url-retrieve", TEXT)
+        self.assertNotIn("url-retrieve-synchronously", TEXT)
+
+    def test_secrets_come_from_environment_or_private_file(self):
+        self.assertIn('getenv "AGENT_ZERO_API_KEY"', TEXT)
+        self.assertIn('getenv "AGENT_ZERO_API_KEY_FILE"', TEXT)
+        self.assertIn('~/.config/qtile/private.env', TEXT)
+
+    def test_org_todos_and_workflow_picker_are_emacs_native(self):
+        self.assertIn('(org-agenda nil "t")', TEXT)
+        self.assertIn('completing-read "Qtile workflow: "', TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_qtile_emacs_control.py
+++ b/.config/qtile/tests/test_qtile_emacs_control.py
@@ -20,6 +20,7 @@ class QtileEmacsControlTests(unittest.TestCase):
     def test_agent_zero_request_is_async(self):
         self.assertIn("url-retrieve", TEXT)
         self.assertNotIn("url-retrieve-synchronously", TEXT)
+        self.assertIn("(defun qtile-agent-zero--finish (status target-buffer)", TEXT)
 
     def test_secrets_come_from_environment_or_private_file(self):
         self.assertIn('getenv "AGENT_ZERO_API_KEY"', TEXT)

--- a/.config/qtile/workflows.json
+++ b/.config/qtile/workflows.json
@@ -1,0 +1,26 @@
+{
+  "desktop": {
+    "auto_group": true,
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "6",
+      "aux": "8"
+    }
+  },
+  "coding": {
+    "auto_group": true,
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "7",
+      "aux": "8"
+    }
+  },
+  "focus": {
+    "auto_group": true,
+    "screens": {
+      "center": "2"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/
 *.pyc
 *;;
 .config/starintel/*.ini
+.config/qtile/private.env
 .direnv/*
 .direnv
 /.config/variety/.firstrun


### PR DESCRIPTION
## RAGE pass

Closes the architectural failure behind the cloned Qtile bars instead of stacking another one-off widget patch.

Tracks #106, #107, #108.

### Screen roles

- Dynamic geometry-based roles for N=1,2,3,4+ monitor layouts.
- Center: OpenRouter balance + TPM + graph, Pomodoro, Agent Zero, clock/volume, the one Systray.
- Left: current Org clock, TODO popup, workflow picker.
- Right: MPRIS only.
- Aux: minimal bar.
- Distinct active-screen accent per physical role.
- Weather removed from the active runtime bar.

### OpenRouter correctness

- Restore the credit/balance widget and its <$5 / <$10 / healthy thresholds.
- Query a fully closed minute with explicit minute granularity instead of a moving partial bucket.
- Reject truncated/malformed/negative/implausible readings.
- Deduplicate identical analytics buckets.
- Keep the last trusted sample as visibly stale when fresh telemetry is garbage.
- Prevent the graph from adding the same minute 12 times.
- Cover the reported ~165M TPM regression.

### Emacs + Agent Zero control plane

- Compact Emacs TODO and Agent Zero scratch frames.
- Current clock task polled off Qtile's event loop.
- Emacs-native completing-read workflow selector.
- Role-based workflows survive monitor-count changes.
- Agent Zero uses documented `POST /api_message` + `X-API-KEY`, asynchronously via `url-retrieve`, preserving `context_id`.
- Host and secrets live in env or ignored `~/.config/qtile/private.env`; only a placeholder example is tracked.
- Second review caught and fixed the Emacs `url-retrieve` callback argument order before merge.

### Verification

- 41 focused unit/structural tests pass locally.
- Python syntax compilation passes for the new/reworked helpers.
- Literate `qtile-openrouter.org` is synchronized with the tangled runtime.

The remote `pivpn-credential` ref was also reviewed during this pass: it currently points to the already-merged PR #103 commit and has no unique PiVPN credential diff to merge.