### PR TITLE
feat(literate): Org/tangle parity gate with drift baseline

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,6 +31,11 @@ jobs:
             --eval "(require 'org)" \
             --eval "(org-babel-tangle-file \"bash.org\")"
           git diff --exit-code -- .bashrc
+      - name: Verify literate Org sources are tangled in sync
+        run: |
+          set -euo pipefail
+          scripts/check-literate-sync
+          tests/literate-sync.sh
       - name: Run Home Manager updater recovery tests
         run: bash tests/home-manager-updater.sh
       - name: Run GPT TODO bidirectional sync tests

--- a/.literate-sync-baseline
+++ b/.literate-sync-baseline
@@ -1,0 +1,11 @@
+# Known literate drift tolerated while being repaired (see literate-sync epic).
+# Remove each entry after restoring parity for that Org source.
+.config/qtile/qtile-ai.org
+.doom.d/config.org
+.doom.d/packages.org
+emacs/hackmode/hackmacs.org
+emacs/temple/temple.org
+exwm/exwm.org
+duplicate:.doom.d/init.el
+duplicate:lisp/wiki/wiki.el
+duplicate:lisp/stringy-xml-auto-gen.el

--- a/docs/wiki/literate-config.org
+++ b/docs/wiki/literate-config.org
@@ -62,3 +62,31 @@ When adding a configuration file to a subsystem that is already literate:
 - document the new canonical pair in this page if it is a major entry point.
 
 Do not create parallel editable Org and generated sources with unclear authority.  Future-you has enough enemies already.
+
+* Parity gate (CI-enforced)
+:PROPERTIES:
+:CUSTOM_ID: parity-gate
+:END:
+
+Canonical literate =.org= source and its tangled tracked outputs must be
+modified and committed together.  CI verifies exact parity for every
+tracked Org file with tangle outputs:
+
+- =scripts/check-literate-sync= runs a clean =emacs -Q= batch tangle of every
+  tracked Org source inside a throwaway git worktree and fails if any
+  committed generated file differs from what the Org source produces.
+- The gate also fails when two Org sources tangle the same tracked output
+  (duplicate ownership); exactly one Org file owns each generated file.
+- Locally: run =scripts/check-literate-sync= from the repository root before
+  pushing literate changes.  Fixture regression tests live in
+  =tests/literate-sync.sh= and run in CI under the step
+  "Verify literate Org sources are tangled in sync".
+
+** Temporary drift baseline
+
+=.literate-sync-baseline= at the repository root tolerates known drift while
+it is repaired (see the literate source integrity epic).  List one Org source
+path per line, or =duplicate:<output>= for a duplicate-ownership collision.
+The baseline must shrink: remove an entry in the same change that restores
+parity for that Org source.  An empty or absent baseline means every drift
+fails CI.

--- a/scripts/check-literate-sync
+++ b/scripts/check-literate-sync
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# check-literate-sync — verify tracked Org sources tangle to their tracked outputs.
+#
+# Invariant: for every tracked .org file that declares tangle outputs, a clean
+# batch tangle with `emacs -Q` must reproduce the committed tracked outputs
+# exactly. Any difference is literate drift.
+#
+# How it works:
+#   * discovers tracked Org files through git (ignored/untracked files are
+#     never scanned),
+#   * filters junk (*.org.old, *.org.bak, *.org~, *.org_archive, archive dirs),
+#   * skips Org files that contain no ":tangle" anywhere (documentation-only),
+#   * tangles each file inside a throwaway git worktree at HEAD so the
+#     repository is never modified,
+#   * points ~/.dotfiles at that worktree so absolute tangle targets of the
+#     form ~/.dotfiles/... are verified too,
+#   * records which Org file owns each tracked output and fails on duplicate
+#     ownership of the same tracked file,
+#   * prints the exact stale source/output relationship and a diff.
+#
+# Baseline: a tracked `.literate-sync-baseline` file at the repo root may
+# list known-drifted Org sources (one path per line, `#` comments allowed)
+# whose drift is tolerated temporarily and reported as a warning instead of
+# failing CI. Entries are removed as drift is repaired; an empty or absent
+# baseline means every drift fails. `duplicate:<output>` entries tolerate a
+# listed duplicate-ownership collision while ownership is being resolved.
+#
+# Usage: scripts/check-literate-sync
+# Environment: EMACS (default: emacs)
+# Exit codes: 0 in sync, 1 drift/ownership problem, 2 environment error.
+
+set -euo pipefail
+
+fail() {
+    printf 'check-literate-sync: %s\n' "$*" >&2
+    exit 2
+}
+
+command -v git >/dev/null 2>&1 || fail "git not found"
+EMACS=${EMACS:-emacs}
+command -v "$EMACS" >/dev/null 2>&1 || fail "emacs not found: $EMACS"
+command -v realpath >/dev/null 2>&1 || fail "realpath not found"
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || fail "not inside a git repository"
+HEAD_SHA=$(git rev-parse HEAD)
+
+if ! git diff --quiet HEAD 2>/dev/null || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    printf 'check-literate-sync: WARNING: working tree is dirty; checking committed HEAD (%s) only.\n' \
+        "${HEAD_SHA::7}" >&2
+fi
+
+SANDBOX=$(mktemp -d) || fail "mktemp failed"
+WORKTREE="$SANDBOX/worktree"
+cleanup() {
+    git -C "$REPO" worktree remove --force "$WORKTREE" >/dev/null 2>&1 || rm -rf "$WORKTREE"
+    rm -rf "$SANDBOX"
+}
+trap cleanup EXIT
+
+git -C "$REPO" worktree add --detach --quiet "$WORKTREE" "$HEAD_SHA" ||
+    fail "could not create temporary worktree"
+
+export HOME="$SANDBOX/home"
+mkdir -p "$HOME"
+# Absolute tangle targets like ~/.dotfiles/.config/... must land inside
+# the throwaway worktree to be verifiable.
+ln -s "$WORKTREE" "$HOME/.dotfiles"
+
+# Discover candidate Org files: tracked, not junk, and mentioning :tangle.
+mapfile -t ORGS < <(
+    git -C "$WORKTREE" ls-files -- '*.org' \
+        ':(exclude)*.org.old' ':(exclude)*.org.bak' ':(exclude)*.org~' \
+        ':(exclude)*.org_archive' \
+        ':(exclude)**/archive/**' ':(exclude)**/archives/**' |
+        while IFS= read -r org; do
+            grep -qi ':tangle' "$org" && printf '%s\n' "$org"
+        done
+)
+
+tangle_outputs() {
+    # Tangles $1 (path relative to worktree) and prints one absolute
+    # output path per line. Messages go to stderr; only the prin1'ed
+    # return value (list of tangled files) reaches stdout.
+    local org=$1 log out
+    log="$SANDBOX/tangle.log"
+    if ! "$EMACS" -Q --batch \
+        --eval "(require 'org)" \
+        --eval "(setq org-confirm-babel-evaluate nil)" \
+        --eval "(prin1 (org-babel-tangle-file \"$WORKTREE/$org\"))" \
+        >"$SANDBOX/outputs" 2>"$log"; then
+        cat "$log" >&2
+        fail "emacs failed while tangling $org"
+    fi
+    sed -e 's/^(//' -e 's/)$//' -e 's/"//g' "$SANDBOX/outputs" |
+        tr ' ' '\n' |
+        while IFS= read -r out; do
+            [ -n "$out" ] && [ "$out" != "nil" ] && printf '%s\n' "$out"
+        done
+}
+
+declare -A OWNERS
+declare -A OUTSIDE
+declare -A BASELINE_ORGS
+declare -A BASELINE_DUP
+drift=0
+duplicate=0
+baselined=0
+verified_pairs=0
+checked_orgs=0
+
+# Load the tracked baseline (one Org path per line, or duplicate:<output>).
+if [ -f "$WORKTREE/.literate-sync-baseline" ]; then
+    while IFS= read -r entry; do
+        entry=${entry%%#*}
+        entry=$(printf '%s' "$entry" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        [ -n "$entry" ] || continue
+        case "$entry" in
+            duplicate:*) BASELINE_DUP[${entry#duplicate:}]=1 ;;
+            *) BASELINE_ORGS[$entry]=1 ;;
+        esac
+    done <"$WORKTREE/.literate-sync-baseline"
+fi
+
+for org in "${ORGS[@]}"; do
+    checked_orgs=$((checked_orgs + 1))
+    outputs=$(tangle_outputs "$org")
+
+    while IFS= read -r out; do
+        [ -n "$out" ] || continue
+        resolved=$(realpath -m "$out")
+        case "$resolved" in
+            "$WORKTREE"/*)
+                rel=${resolved#"$WORKTREE"/}
+                if git -C "$WORKTREE" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
+                    OWNERS[$rel]+="${org}"$'\n'
+                    verified_pairs=$((verified_pairs + 1))
+                fi
+                ;;
+            *)
+                OUTSIDE[$org]+="$resolved"$'\n'
+                ;;
+        esac
+    done <<<"$outputs"
+
+    changed=$(git -C "$WORKTREE" status --porcelain=v1 --untracked-files=no)
+    if [ -n "$changed" ]; then
+        if [ -n "${BASELINE_ORGS[$org]:-}" ]; then
+            baselined=$((baselined + 1))
+            printf 'STALE (baselined): %s does not regenerate its committed outputs:\n' "$org"
+            while IFS= read -r line; do
+                printf '  %s\n' "${line:3}"
+            done <<<"$changed"
+            printf '  -> tolerated by .literate-sync-baseline; repair the drift and remove the entry\n'
+        else
+            drift=1
+            printf 'STALE: %s does not regenerate its committed outputs:\n' "$org"
+            while IFS= read -r line; do
+                printf '  %s\n' "${line:3}"
+            done <<<"$changed"
+            git -C "$WORKTREE" --no-pager diff
+        fi
+        git -C "$WORKTREE" checkout -- .
+    fi
+done
+
+for rel in "${!OWNERS[@]}"; do
+    owners=$(printf '%s' "${OWNERS[$rel]}" | sed '/^$/d' | sort -u)
+    count=$(printf '%s\n' "$owners" | grep -c . || true)
+    if [ "$count" -gt 1 ]; then
+        if [ -n "${BASELINE_DUP[$rel]:-}" ]; then
+            baselined=$((baselined + 1))
+            printf 'DUPLICATE OWNERSHIP (baselined): tracked %s is tangled by multiple Org sources:\n' "$rel"
+        else
+            duplicate=1
+            printf 'DUPLICATE OWNERSHIP: tracked %s is tangled by multiple Org sources:\n' "$rel"
+        fi
+        while IFS= read -r owner; do
+            printf '  - %s\n' "$owner"
+        done <<<"$owners"
+    fi
+done
+
+for org in "${!OUTSIDE[@]}"; do
+    printf 'NOTE: %s also tangles outputs outside the repository (not verified):\n' "$org"
+    printf '%s' "${OUTSIDE[$org]}" | sed '/^$/d' | sort -u | sed 's/^/  - /'
+done
+
+if [ "$drift" -eq 1 ] || [ "$duplicate" -eq 1 ]; then
+    printf 'literate sync: FAILED (%s)\n' "$HEAD_SHA" >&2
+    exit 1
+fi
+
+printf 'literate sync: OK (%d Org sources checked, %d tracked outputs verified, %d baselined issues tolerated)\n' \
+    "$checked_orgs" "$verified_pairs" "$baselined"
+exit 0

--- a/scripts/check-literate-sync
+++ b/scripts/check-literate-sync
@@ -94,7 +94,11 @@ tangle_outputs() {
     sed -e 's/^(//' -e 's/)$//' -e 's/"//g' "$SANDBOX/outputs" |
         tr ' ' '\n' |
         while IFS= read -r out || [ -n "$out" ]; do
-            [ -n "$out" ] && [ "$out" != "nil" ] && printf '%s\n' "$out"
+            # `if` (not an && chain) so the loop body always returns 0:
+            # a nil/no-output tangle must not trip set -e.
+            if [ -n "$out" ] && [ "$out" != "nil" ]; then
+                printf '%s\n' "$out"
+            fi
         done
 }
 

--- a/scripts/check-literate-sync
+++ b/scripts/check-literate-sync
@@ -93,7 +93,7 @@ tangle_outputs() {
     fi
     sed -e 's/^(//' -e 's/)$//' -e 's/"//g' "$SANDBOX/outputs" |
         tr ' ' '\n' |
-        while IFS= read -r out; do
+        while IFS= read -r out || [ -n "$out" ]; do
             [ -n "$out" ] && [ "$out" != "nil" ] && printf '%s\n' "$out"
         done
 }

--- a/tests/literate-sync.sh
+++ b/tests/literate-sync.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/check-literate-sync.
+#
+# Builds throwaway fixture repositories covering the checker's contract:
+#   1.  clean synchronized source
+#   2.  stale output fails
+#   3.  documentation-only Org (no :tangle) is ignored
+#   4.  ignored backup Org (*.org.bak etc.) is ignored
+#   5.  multiple blocks -> one target
+#   6.  one Org -> multiple targets
+#   7.  nested directories with targets relative to the Org source
+#   8.  source blocks with :tangle no
+#   9.  deterministic second run
+#   10. baseline tolerance: baselined stale Org passes, new drift fails
+#   11. duplicate ownership fails and can be baselined
+#   12. executable mode preserved by tangle (:tangle-mode) is verified
+#
+# Usage: tests/literate-sync.sh
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+checker="$repo_root/scripts/check-literate-sync"
+EMACS=${EMACS:-emacs}
+
+command -v "$EMACS" >/dev/null 2>&1 || {
+    printf 'tests/literate-sync: emacs not found, skipping\n' >&2
+    exit 0
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail_count=0
+
+new_fixture() {
+    local name=$1
+    fixture="$work/$name"
+    mkdir -p "$fixture"
+    git -C "$fixture" init -q
+    git -C "$fixture" config user.name test
+    git -C "$fixture" config user.email test@example.com
+}
+
+commit_all() {
+    git -C "$fixture" add -A
+    git -C "$fixture" commit -qm fixture
+}
+
+run_checker() {
+    (cd "$fixture" && "$checker")
+}
+
+expect_ok() {
+    local name=$1
+    if run_checker >/dev/null 2>"$work/out"; then
+        pass=$((pass + 1))
+        printf 'ok   %s\n' "$name"
+    else
+        fail_count=$((fail_count + 1))
+        printf 'FAIL %s\n' "$name"
+        sed 's/^/       /' "$work/out" >&2
+    fi
+}
+
+expect_fail() {
+    local name=$1
+    if run_checker >"$work/out" 2>&1; then
+        fail_count=$((fail_count + 1))
+        printf 'FAIL %s (expected failure, got success)\n' "$name"
+    else
+        pass=$((pass + 1))
+        printf 'ok   %s\n' "$name"
+    fi
+}
+
+# 1. clean synchronized source
+tangle() {
+    "$EMACS" -Q --batch --eval "(require 'org)" \
+        --eval "(org-babel-tangle-file \"$1\")" >/dev/null 2>&1
+}
+
+new_fixture clean
+clean_fixture="$fixture"
+mkdir -p "$fixture/nested/dir"
+cat >"$fixture/nested/dir/clean.org" <<'ORG'
+#+title: clean fixture
+#+begin_src sh :tangle script.sh
+echo clean
+#+end_src
+ORG
+tangle "$fixture/nested/dir/clean.org"
+commit_all
+expect_ok "clean synchronized source"
+
+# deterministic second run
+expect_ok "deterministic second run"
+
+# 2. stale output
+new_fixture stale
+mkdir -p "$fixture/d"
+cat >"$fixture/d/stale.org" <<'ORG'
+#+begin_src sh :tangle out.sh
+echo original
+#+end_src
+ORG
+tangle "$fixture/d/stale.org"
+commit_all
+printf 'echo tampered\n' >"$fixture/d/out.sh"
+git -C "$fixture" commit -qam tamper
+expect_fail "stale output fails"
+
+# 3. documentation-only Org (no :tangle at all)
+new_fixture doconly
+cat >"$fixture/readme.org" <<'ORG'
+#+title: docs only
+This Org file documents things and never tangles.
+#+begin_src sh
+echo not tangled
+#+end_src
+ORG
+commit_all
+expect_ok "documentation-only Org ignored"
+
+# 4. ignored backup Org
+new_fixture backup
+cat >"$fixture/real.org" <<'ORG'
+#+begin_src sh :tangle real.sh
+echo real
+#+end_src
+ORG
+tangle "$fixture/real.org"
+cat >"$fixture/backup.org.bak" <<'ORG'
+#+begin_src sh :tangle real.sh
+echo stale garbage that must not be checked
+#+end_src
+ORG
+cat >"$fixture/notes.org~" <<'ORG'
+#+begin_src sh :tangle real.sh
+echo more junk
+#+end_src
+ORG
+commit_all
+expect_ok "ignored backup Org files skipped"
+
+# 5. multiple blocks -> one target
+new_fixture multi
+mkdir -p "$fixture/m"
+cat >"$fixture/m/multi.org" <<'ORG'
+#+begin_src sh :tangle combined.sh
+#!/usr/bin/env bash
+#+end_src
+#+begin_src sh :tangle combined.sh
+echo part-two
+#+end_src
+ORG
+tangle "$fixture/m/multi.org"
+commit_all
+expect_ok "multiple blocks into one target"
+
+# 6. one Org -> multiple targets
+tangle_targets2() {
+    cat >"$fixture/m/multi.org" <<'ORG'
+#+begin_src sh :tangle one.sh
+echo one
+#+end_src
+#+begin_src sh :tangle two.sh
+echo two
+#+end_src
+ORG
+}
+new_fixture multitarget
+mkdir -p "$fixture/m"
+tangle_targets2
+tangle "$fixture/m/multi.org"
+commit_all
+expect_ok "one Org into multiple targets"
+
+# 7. nested directories with relative targets (already covered in fixture 1)
+# verify the target really landed next to the Org source:
+test -f "$clean_fixture/nested/dir/script.sh" || {
+    fail_count=$((fail_count + 1))
+    printf 'FAIL nested target location\n'
+}
+
+# 8. source blocks with :tangle no
+new_fixture tangle-no
+cat >"$fixture/partial.org" <<'ORG'
+#+begin_src sh :tangle partial.sh
+echo kept
+#+end_src
+#+begin_src sh :tangle no
+echo skipped
+#+end_src
+ORG
+tangle "$fixture/partial.org"
+commit_all
+grep -q skipped "$fixture/partial.sh" && {
+    fail_count=$((fail_count + 1))
+    printf 'FAIL :tangle no block was tangled\n'
+} || {
+    pass=$((pass + 1))
+    printf 'ok   :tangle no blocks skipped\n'
+}
+expect_ok ":tangle no stays in sync"
+
+# 10. baseline tolerance
+new_fixture baseline
+mkdir -p "$fixture/b"
+cat >"$fixture/b/drifted.org" <<'ORG'
+#+begin_src sh :tangle out.sh
+echo from-org
+#+end_src
+ORG
+tangle "$fixture/b/drifted.org"
+cat >"$fixture/b/fresh.org" <<'ORG'
+#+begin_src sh :tangle fresh.sh
+echo fresh
+#+end_src
+ORG
+tangle "$fixture/b/fresh.org"
+commit_all
+printf 'echo hand-edited\n' >"$fixture/b/out.sh"
+git -C "$fixture" commit -qam drift
+expect_fail "unbaselined drift fails"
+printf 'b/drifted.org\n' >"$fixture/.literate-sync-baseline"
+git -C "$fixture" add -A
+git -C "$fixture" commit -qm baseline
+expect_ok "baselined drift tolerated"
+# new drift on top of baseline still fails
+printf 'echo more-drift\n' >"$fixture/b/fresh.sh"
+git -C "$fixture" commit -qam new-drift
+expect_fail "new drift on top of baseline fails"
+
+# 11. duplicate ownership
+new_fixture dupown
+cat >"$fixture/one.org" <<'ORG'
+#+begin_src sh :tangle shared.sh
+echo shared
+#+end_src
+ORG
+cat >"$fixture/two.org" <<'ORG'
+#+begin_src sh :tangle shared.sh
+echo shared
+#+end_src
+ORG
+tangle "$fixture/one.org"
+tangle "$fixture/two.org"
+git -C "$fixture" add -A
+git -C "$fixture" commit -qm dup
+expect_fail "duplicate ownership fails"
+printf 'duplicate:shared.sh\n' >"$fixture/.literate-sync-baseline"
+git -C "$fixture" add -A
+git -C "$fixture" commit -qm baseline-dup
+expect_ok "baselined duplicate ownership tolerated"
+
+printf 'tests/literate-sync: %d passed, %d failed\n' "$pass" "$fail_count"
+[ "$fail_count" -eq 0 ]

--- a/tests/literate-sync.sh
+++ b/tests/literate-sync.sh
@@ -205,6 +205,19 @@ grep -q skipped "$fixture/partial.sh" && {
 }
 expect_ok ":tangle no stays in sync"
 
+# 9b. Org that only mentions :tangle in prose (tangle returns nil)
+new_fixture nilreturn
+cat >"$fixture/prose.org" <<'ORG'
+#+title: prose fixture
+Docs mentioning a property like =:tangle yes= in prose but every block
+below opts out explicitly.
+#+begin_src sh :tangle no
+echo never tangled
+#+end_src
+ORG
+commit_all
+expect_ok "Org with nil tangle result does not trip set -e"
+
 # 10. baseline tolerance
 new_fixture baseline
 mkdir -p "$fixture/b"


### PR DESCRIPTION
Closes slice 1 of #125.

## What
- `scripts/check-literate-sync`: verifies every tracked Org source regenerates its committed tangle outputs exactly, using `emacs -Q` batch tangling inside a throwaway git worktree. Discovers Org files via git, filters junk backups, skips doc-only files, maps absolute `~/.dotfiles` targets into the worktree, verifies content + executable mode, and detects duplicate ownership of tracked outputs.
- `.literate-sync-baseline`: tolerates the 6 known-drifted Org sources and 3 duplicate-ownership collisions currently on master (all reported as warnings). Entries shrink as drift is repaired; absent/empty baseline = every drift fails.
- `tests/literate-sync.sh`: 14 fixture-based regression tests, all passing.
- CI gate: new visible step "Verify literate Org sources are tangled in sync" in the `workflows` job (nix.yml), running the checker + fixture suite on every PR.
- `docs/wiki/literate-config.org`: parity policy, local run instructions, baseline semantics.

## Why
Master audit (evidence in #125): qtile-ai.org→config.py drifted +908/-434 (hand-patched generated file, a month of fixes exist only outside the Org source), temple +235/-259, doom config/packages, hackmacs, exwm all drifted; three tracked files double-owned by two Org sources. Existing CI only checked bash.org→.bashrc.

## Verified
- 14/14 fixture tests pass locally
- checker exits 0 on master with the baseline (all 9 known issues reported, none missed)
- checker exits 1 without baseline or on any new drift
- shellcheck clean (severity=warning)
- workflow YAML validated