### PR TITLE
feat(qtile): re-land truthful multi-screen bar telemetry with terminating navigation

### DIFF
--- a/.config/qtile/private.env.example
+++ b/.config/qtile/private.env.example
@@ -1,5 +1,5 @@
 # Copy to ~/.config/qtile/private.env. The real file is gitignored.
-# Keep credentials out of tracked Qtile/Python/Emacs config.
+# Keep credentials and location-specific desktop data out of tracked config.
 
 AGENT_ZERO_HOST=http://127.0.0.1:5080
 AGENT_ZERO_API_KEY_FILE=~/.config/agent-zero/api-key
@@ -8,3 +8,13 @@ AGENT_ZERO_API_KEY_FILE=~/.config/agent-zero/api-key
 OPENROUTER_MANAGEMENT_KEY_FILE=~/.config/openrouter/management-key
 # Optional local sanity ceiling. Samples above this are rejected as implausible.
 OPENROUTER_TPM_MAX=10000000
+
+# Weather: use either a city/region string or explicit coordinates.
+# WEATHER_LOCATION=City, State
+# WEATHER_LATITUDE=40.0
+# WEATHER_LONGITUDE=-83.0
+# WEATHER_LABEL=Home
+WEATHER_UNITS=imperial
+
+# Provider-neutral market cache. External feeders may write trusted snapshots here.
+# QTILE_MARKET_CACHE=~/.cache/qtile/markets.json

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -4,17 +4,15 @@
 * Runtime helper
 
 This file is the source of truth for the OpenRouter widgets and the
-=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding. The center-screen
-telemetry cluster shows current account balance, a complete-minute prompt and
-completion token rate, and a rolling graph of trusted minute samples.
+=Super+Ctrl+Shift+R= dotfiles sync-and-reload binding.
 
-The balance comes from OpenRouter's management-key =/credits= endpoint. Rate
-queries use the previous fully closed minute instead of a moving partial bucket,
-and the collector rejects malformed, truncated, duplicated, negative, or
-implausibly large samples rather than feeding nonsense into the graph.
+The Qtile layer repaints telemetry every second while the collector independently
+bounds provider calls. The token graph appends only when a trusted sample changes.
+Account balance stays visible, token totals rotate month/week/day/hour, and spend
+rotates day/week/month. Mouse wheel cycles either rotating metric manually.
 
-The runtime installer also hands the telemetry widget factory to the
-screen-topology control layer so LLM stats live on the center role only.
+Rate telemetry keeps the complete-minute sanity guard that rejects malformed,
+truncated, negative, duplicated, or implausibly large analytics results.
 
 #+begin_src python
 """OpenRouter telemetry widgets and Qtile runtime helpers."""
@@ -34,10 +32,11 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
-POLL_SECONDS = 5
-GRAPH_SAMPLES = 60
-GRAPH_WIDTH = 76
+POLL_SECONDS = 1
+GRAPH_SAMPLES = 300
+GRAPH_WIDTH = 82
 RATE_FONTSIZE = 12
+ROTATE_SECONDS = 5
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
@@ -79,14 +78,14 @@ def _fetch_payload(script):
     global _last_payload, _last_poll_at
     with _poll_lock:
         now = time.monotonic()
-        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
+        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.05:
             return _last_payload
         completed = subprocess.run(
             ["python3", script, "--json"],
             check=False,
             capture_output=True,
             text=True,
-            timeout=8,
+            timeout=12,
         )
         try:
             payload = json.loads(completed.stdout)
@@ -193,7 +192,7 @@ class OpenRouterCredit(base.BackgroundPoll):
 
 
 class OpenRouterRate(base.BackgroundPoll):
-    """Display the most recent complete-minute OpenRouter token rate."""
+    """Display the most recent trusted OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -215,13 +214,74 @@ class OpenRouterRate(base.BackgroundPoll):
         )
 
 
+class OpenRouterRotatingMetric(base.BackgroundPoll):
+    """Rotate one OpenRouter metric through configured periods."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, script, colors, metric, **config):
+        self.script = script
+        self.colors = colors
+        self.metric = metric
+        self.index = 0
+        self.last_rotate = time.monotonic()
+        self.specs = (
+            (
+                ("M", "tokens_month"),
+                ("W", "tokens_week"),
+                ("D", "tokens_day"),
+                ("H", "tokens_hour"),
+            )
+            if metric == "tokens"
+            else (
+                ("D", "spend_day"),
+                ("W", "spend_week"),
+                ("M", "spend_month"),
+            )
+        )
+        self.icon = "" if metric == "tokens" else ""
+        super().__init__(text=f"{self.icon} …", **config)
+        self.add_callbacks({"Button4": self.previous, "Button5": self.next})
+
+    def previous(self):
+        self.index = (self.index - 1) % len(self.specs)
+        self.last_rotate = time.monotonic()
+        self.tick()
+
+    def next(self):
+        self.index = (self.index + 1) % len(self.specs)
+        self.last_rotate = time.monotonic()
+        self.tick()
+
+    def _maybe_rotate(self):
+        now = time.monotonic()
+        if now - self.last_rotate >= ROTATE_SECONDS:
+            self.index = (self.index + 1) % len(self.specs)
+            self.last_rotate = now
+
+    def poll(self):
+        self._maybe_rotate()
+        label, key = self.specs[self.index]
+        payload = _fetch_payload(self.script) or {}
+        value = payload.get(key)
+        color_index = (4, 6, 3, 7)[self.index % 4]
+        color = _color(self.colors, color_index)
+        if value is None:
+            rendered = "—"
+        elif self.metric == "tokens":
+            rendered = _compact_count(value)
+        else:
+            rendered = f"${float(value):.2f}"
+        return f'<span foreground="{color}">{self.icon} {label} {rendered}</span>'
+
+
 class OpenRouterIOGraph(base._Widget):
-    """Five-minute sparkline of trusted input/output tokens per minute."""
+    """Sparkline of trusted input/output token-rate samples."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Number of rate samples."),
+        ("samples", GRAPH_SAMPLES, "Maximum number of changed samples."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -235,7 +295,7 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.input_values = deque(maxlen=self.samples)
         self.output_values = deque(maxlen=self.samples)
-        self._last_window_end = None
+        self._last_sample = None
 
     def timer_setup(self):
         self._update()
@@ -244,12 +304,16 @@ class OpenRouterIOGraph(base._Widget):
     def _update(self):
         status = _read_cached_status()
         if status:
-            window_end = status.get("window_end")
-            if window_end != self._last_window_end:
-                self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
-                self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
-                self._last_window_end = window_end
-        self.draw()
+            sample = (
+                status.get("window_end"),
+                status.get("input_tokens_per_minute"),
+                status.get("output_tokens_per_minute"),
+            )
+            if sample != self._last_sample and sample[0] is not None:
+                self.input_values.append(float(sample[1] or 0))
+                self.output_values.append(float(sample[2] or 0))
+                self._last_sample = sample
+                self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
@@ -314,31 +378,18 @@ def _install_sync_and_reload_key(config_globals):
 def _telemetry_widgets(home, colors):
     script = home + "/.config/qtile/scripts/openrouter_status.py"
     background = _color(colors, 1)
+    common = {
+        "update_interval": POLL_SECONDS,
+        "markup": True,
+        "font": "Hack Nerd Regular",
+        "fontsize": RATE_FONTSIZE,
+        "padding": 3,
+        "foreground": _color(colors, 5),
+        "background": background,
+    }
     return [
-        OpenRouterCredit(
-            script,
-            colors,
-            name="openrouter_credit",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=RATE_FONTSIZE,
-            padding=3,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
-        OpenRouterRate(
-            script,
-            colors,
-            name="openrouter_rate",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=RATE_FONTSIZE,
-            padding=3,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
+        OpenRouterCredit(script, colors, name="openrouter_credit", **common),
+        OpenRouterRate(script, colors, name="openrouter_rate", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",
             frequency=POLL_SECONDS,
@@ -347,6 +398,12 @@ def _telemetry_widgets(home, colors):
             output_color=_color(colors, 4),
             midline_color=_color(colors, 2),
             background=background,
+        ),
+        OpenRouterRotatingMetric(
+            script, colors, "tokens", name="openrouter_token_totals", **common
+        ),
+        OpenRouterRotatingMetric(
+            script, colors, "spend", name="openrouter_spend_totals", **common
         ),
     ]
 

--- a/.config/qtile/qtile-workflow.el
+++ b/.config/qtile/qtile-workflow.el
@@ -1,0 +1,21 @@
+;;; qtile-workflow.el --- right-aligned Qtile workflow picker -*- lexical-binding: t; -*-
+
+(defun qtile-workflow-read-right (choices)
+  "Select one Qtile workflow from CHOICES in a top-right utility frame."
+  (let ((frame (make-frame '((name . "qtile-workflow")
+                             (title . "qtile-workflow")
+                             (width . 58)
+                             (height . 10)
+                             (minibuffer . t)
+                             (left . 1.0)
+                             (top . 0.0)
+                             (user-position . t)))))
+    (unwind-protect
+        (with-selected-frame frame
+          (select-frame-set-input-focus frame)
+          (completing-read "Qtile workflow: " choices nil t))
+      (when (frame-live-p frame)
+        (delete-frame frame)))))
+
+(provide 'qtile-workflow)
+;;; qtile-workflow.el ends here

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -116,6 +116,25 @@ def outrun_palette(colors: Any) -> dict[str, str]:
     }
 
 
+def next_visible_group(groups: list[Any], current: Any, step: int = 1) -> Any | None:
+    """Return the next group after *current* that is visible, or None.
+
+    Navigation is bounded: if no group qualifies (for example an empty
+    visible set), the caller gets ``None`` instead of an infinite cycle.
+    """
+    if not groups:
+        return None
+    names = [id(group) for group in groups]
+    try:
+        index = names.index(id(current))
+    except ValueError:
+        index = None
+    if index is None:
+        return groups[0] if step > 0 else groups[-1]
+    moved = (index + step) % len(groups)
+    return groups[moved]
+
+
 def visible_window_groups(groups: Iterable[Any]) -> list[Any]:
     """Only groups with live windows belong in the bar."""
     return [
@@ -326,6 +345,20 @@ def _owned_group_box(config_globals: dict[str, Any]):
             if self.visible_groups:
                 groups = [group for group in groups if group.name in self.visible_groups]
             return groups
+
+        def next_group(self):
+            # Qtile <=0.33 next_group cycles until it finds a member of
+            # self.groups; an empty visible set would spin forever and stall
+            # the Qtile event loop. Navigate only among visible groups and
+            # never loop when nothing is visible.
+            group = next_visible_group(self.groups, self.qtile.current_group)
+            if group is not None:
+                self.go_to_group(group)
+
+        def prev_group(self):
+            group = next_visible_group(self.groups, self.qtile.current_group, step=-1)
+            if group is not None:
+                self.go_to_group(group)
 
         def setup_hooks(self):
             super().setup_hooks()

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -1,4 +1,4 @@
-"""Topology-aware Qtile bars, Org integration, and desktop workflows."""
+"""Topology-aware Qtile bars, truthful group ownership, and desktop workflows."""
 
 from __future__ import annotations
 
@@ -17,6 +17,13 @@ ROLE_ACCENTS = {
     "right": "#fba922",
     "aux": "#9700cc",
 }
+OUTRUN_EXTENDED = {
+    "electric_blue": "#00b8ff",
+    "violet": "#6c5ce7",
+    "yellow": "#ffe66d",
+    "ice": "#7df9ff",
+    "hot_orange": "#ff6b35",
+}
 DEFAULT_WORKFLOWS = {
     "desktop": {
         "auto_group": True,
@@ -26,6 +33,8 @@ DEFAULT_WORKFLOWS = {
 PRIVATE_ENV_PATH = Path("~/.config/qtile/private.env").expanduser()
 WORKFLOWS_PATH = Path("~/.config/qtile/workflows.json").expanduser()
 EMACS_HELPER = Path("~/.config/qtile/qtile-desktop.el").expanduser()
+WORKFLOW_HELPER = Path("~/.config/qtile/qtile-workflow.el").expanduser()
+_group_owner_roles: dict[str, str] = {}
 
 
 def _geometry(item: Any) -> tuple[int, int]:
@@ -83,6 +92,65 @@ def role_accent(role: str) -> str:
     return ROLE_ACCENTS[base_role(role)]
 
 
+def _color(colors: Any, index: int) -> str:
+    value = colors[index]
+    if isinstance(value, (list, tuple)):
+        return value[0]
+    return value
+
+
+def outrun_palette(colors: Any) -> dict[str, str]:
+    """Name the original Doom Outrun palette and a few compatible extensions."""
+    return {
+        "deep": _color(colors, 0),
+        "background": _color(colors, 1),
+        "muted": _color(colors, 2),
+        "orange": _color(colors, 3),
+        "cyan": _color(colors, 4),
+        "white": _color(colors, 5),
+        "pink": _color(colors, 6),
+        "green": _color(colors, 7),
+        "red": _color(colors, 8),
+        "purple": _color(colors, 9),
+        **OUTRUN_EXTENDED,
+    }
+
+
+def visible_window_groups(groups: Iterable[Any]) -> list[Any]:
+    """Only groups with live windows belong in the bar."""
+    return [
+        group
+        for group in groups
+        if getattr(group, "label", None) and bool(getattr(group, "windows", ()))
+    ]
+
+
+def _screen_index(screens: list[Any], screen: Any) -> int | None:
+    for index, candidate in enumerate(screens):
+        if candidate is screen:
+            return index
+    return None
+
+
+def group_owner_role(group: Any, screens: Iterable[Any]) -> str | None:
+    """Track the physical screen that most recently owned a non-empty group."""
+    name = str(getattr(group, "name", ""))
+    if not getattr(group, "windows", ()):
+        _group_owner_roles.pop(name, None)
+        return None
+
+    screens = list(screens)
+    screen = getattr(group, "screen", None)
+    if screen is not None:
+        index = _screen_index(screens, screen)
+        roles = screen_roles(screens)
+        if index is not None and index < len(roles):
+            role = base_role(roles[index])
+            _group_owner_roles[name] = role
+            return role
+    return _group_owner_roles.get(name)
+
+
 def parse_private_env(path: Path = PRIVATE_ENV_PATH) -> dict[str, str]:
     values: dict[str, str] = {}
     try:
@@ -136,11 +204,7 @@ def _decode_emacs_string(output: str) -> str | None:
 
 def _emacs_eval(expression: str, *, timeout: float = 300.0) -> str | None:
     helper = str(EMACS_HELPER)
-    form = (
-        "(progn "
-        f"(load-file {json.dumps(helper)}) "
-        f"{expression})"
-    )
+    form = "(progn " f"(load-file {json.dumps(helper)}) " f"{expression})"
     try:
         completed = subprocess.run(
             ["emacsclient", "-a", "emacs", "--eval", form],
@@ -207,7 +271,10 @@ def _select_workflow(qtile: Any, config_globals: dict[str, Any]) -> None:
     lisp_names = "(" + " ".join(json.dumps(name) for name in names) + ")"
 
     def worker() -> None:
-        selected = _emacs_eval(f"(qtile-workflow-read '{lisp_names})")
+        helper = json.dumps(str(WORKFLOW_HELPER))
+        selected = _emacs_eval(
+            f"(progn (load-file {helper}) (qtile-workflow-read-right '{lisp_names}))"
+        )
         if not selected or selected not in workflows:
             return
         qtile.call_soon_threadsafe(apply_workflow, qtile, workflows[selected], config_globals)
@@ -244,43 +311,255 @@ def _parse_clock_output(output: str) -> str:
     return f"Org: {value}"
 
 
-def _base_widgets(config_globals: dict[str, Any], accent: str):
-    from libqtile import widget
+def _owned_group_box(config_globals: dict[str, Any]):
+    """Return a GroupBox subclass that renders ownership, not cloned bar identity."""
+    from libqtile import hook, widget
 
     colors = config_globals["colors"]
+    palette = outrun_palette(colors)
     group_names = config_globals["group_names"]
-    background = colors[1][0] if isinstance(colors[1], (list, tuple)) else colors[1]
-    foreground = colors[5][0] if isinstance(colors[5], (list, tuple)) else colors[5]
+
+    class OwnedGroupBox(widget.GroupBox):
+        @property
+        def groups(self):
+            groups = visible_window_groups(self.qtile.groups)
+            if self.visible_groups:
+                groups = [group for group in groups if group.name in self.visible_groups]
+            return groups
+
+        def setup_hooks(self):
+            super().setup_hooks()
+            hook.subscribe.group_window_remove(self._hook_response)
+
+        def remove_hooks(self):
+            try:
+                hook.unsubscribe.group_window_remove(self._hook_response)
+            except Exception:
+                pass
+            super().remove_hooks()
+
+        def draw(self):
+            self.drawer.clear(self.background or self.bar.background)
+            offset = self.margin_x
+            for group in self.groups:
+                owner = group_owner_role(group, self.qtile.screens)
+                owner_color = role_accent(owner) if owner else palette["muted"]
+                text_color = palette["red"] if self.group_has_urgent(group) else owner_color
+                current = self.bar.screen.group == group
+                focused = current and self.qtile.current_screen == self.bar.screen
+                width = self.box_width([group])
+                self.drawbox(
+                    offset,
+                    group.label,
+                    palette["white"] if current else None,
+                    text_color,
+                    highlight_color=[palette["deep"], owner_color],
+                    width=width,
+                    rounded=True,
+                    block=False,
+                    line=current,
+                    highlighted=focused,
+                )
+                offset += width + self.spacing
+            self.draw_at_default_position()
+
+    return OwnedGroupBox(
+        font="3270 Nerd Font",
+        visible_groups=group_names,
+        fontsize=18,
+        margin_y=2,
+        margin_x=2,
+        padding_y=-4,
+        padding_x=6,
+        borderwidth=2,
+        active=palette["white"],
+        inactive=palette["muted"],
+        rounded=True,
+        highlight_method="line",
+        foreground=palette["white"],
+        background=palette["background"],
+        urgent_text=palette["red"],
+        urgent_border=palette["red"],
+    )
+
+
+def _base_widgets(config_globals: dict[str, Any]):
+    from libqtile import widget
+
+    palette = outrun_palette(config_globals["colors"])
     items = []
     auto_group = config_globals.get("auto_group_button")
     if callable(auto_group):
         items.append(auto_group())
     items.extend(
         [
-            widget.GroupBox(
-                font="3270 Nerd Font",
-                visible_groups=group_names,
-                fontsize=18,
-                margin_y=2,
-                margin_x=2,
-                padding_y=-4,
-                padding_x=6,
-                borderwidth=2,
-                active=accent,
-                inactive=foreground,
-                rounded=True,
-                highlight_method="block",
-                this_current_screen_border=accent,
-                this_screen_border=accent,
-                other_current_screen_border=background,
-                foreground=accent,
-                background=background,
+            _owned_group_box(config_globals),
+            widget.CurrentLayout(
+                font="Hack Bold",
+                foreground=palette["white"],
+                background=palette["background"],
             ),
-            widget.CurrentLayout(font="Hack Bold", foreground=foreground, background=background),
-            widget.WindowName(font="Hack", fontsize=12, foreground=foreground, background=background),
+            widget.WindowName(
+                font="Hack",
+                fontsize=12,
+                foreground=palette["white"],
+                background=palette["background"],
+            ),
         ]
     )
     return items
+
+
+def _system_telemetry(config_globals: dict[str, Any]):
+    from libqtile import widget
+
+    palette = outrun_palette(config_globals["colors"])
+    background = palette["background"]
+    graph_common = {
+        "background": background,
+        "border_color": palette["muted"],
+        "border_width": 1,
+        "line_width": 1,
+        "frequency": 1,
+        "samples": 60,
+        "type": "linefill",
+        "width": 52,
+    }
+    return [
+        widget.TextBox(
+            text="",
+            font="Hack Nerd Regular",
+            foreground=palette["cyan"],
+            background=background,
+            padding=2,
+        ),
+        widget.CPUGraph(
+            core="all",
+            graph_color=palette["cyan"],
+            fill_color=palette["purple"],
+            **graph_common,
+        ),
+        widget.TextBox(
+            text="󰍛",
+            font="Hack Nerd Regular",
+            foreground=palette["green"],
+            background=background,
+            padding=2,
+        ),
+        widget.Memory(
+            format="{Available: .1f}{mm} free",
+            measure_mem="G",
+            update_interval=1,
+            foreground=palette["green"],
+            background=background,
+            fontsize=11,
+            padding=2,
+        ),
+        widget.MemoryGraph(
+            graph_color=palette["green"],
+            fill_color=palette["violet"],
+            **graph_common,
+        ),
+        widget.TextBox(
+            text="󰖩",
+            font="Hack Nerd Regular",
+            foreground=palette["electric_blue"],
+            background=background,
+            padding=2,
+        ),
+        widget.NetGraph(
+            interface="auto",
+            bandwidth_type="down",
+            graph_color=palette["electric_blue"],
+            fill_color=palette["cyan"],
+            **graph_common,
+        ),
+        widget.NetGraph(
+            interface="auto",
+            bandwidth_type="up",
+            graph_color=palette["pink"],
+            fill_color=palette["purple"],
+            **graph_common,
+        ),
+        widget.Net(
+            interface="auto",
+            format="↓{down}{down_suffix} ↑{up}{up_suffix}",
+            update_interval=1,
+            foreground=palette["ice"],
+            background=background,
+            fontsize=11,
+            padding=2,
+        ),
+    ]
+
+
+def _notification_widget(config_globals: dict[str, Any], role: str):
+    from libqtile import widget
+    from libqtile.lazy import lazy
+
+    palette = outrun_palette(config_globals["colors"])
+    return widget.GenPollCommand(
+        name=f"notifications_{role}",
+        cmd=["dunstctl", "count", "history"],
+        parse=lambda output: f" {output.strip() or '0'}",
+        update_interval=1,
+        font="Hack Nerd Regular",
+        fontsize=11,
+        foreground=palette["violet"],
+        background=palette["background"],
+        padding=3,
+        mouse_callbacks={
+            "Button1": lazy.spawn("dunstctl history-pop"),
+            "Button3": lazy.spawn("dunstctl context"),
+            "Button4": lazy.spawn("dunstctl history-pop"),
+            "Button5": lazy.spawn("dunstctl close"),
+        },
+    )
+
+
+def _weather_widget(config_globals: dict[str, Any]):
+    from libqtile import widget
+
+    palette = outrun_palette(config_globals["colors"])
+    script = config_globals["home"] + "/.config/qtile/scripts/weather_status.py"
+    return widget.GenPollCommand(
+        name="outrun_weather",
+        cmd=["python3", script],
+        update_interval=300,
+        foreground=palette["yellow"],
+        background=palette["background"],
+        font="Hack Nerd Regular",
+        fontsize=11,
+        padding=4,
+    )
+
+
+def _market_widgets(config_globals: dict[str, Any]):
+    from qtile_market import MarketCarousel
+
+    palette = outrun_palette(config_globals["colors"])
+    return [
+        MarketCarousel(
+            name="kalshi_market_stub",
+            feed="kalshi",
+            foreground=palette["pink"],
+            graph_color=palette["pink"],
+            accent=palette["cyan"],
+            muted=palette["muted"],
+            background=palette["background"],
+            width=180,
+        ),
+        MarketCarousel(
+            name="commodity_market_stub",
+            feed="commodities",
+            foreground=palette["orange"],
+            graph_color=palette["orange"],
+            accent=palette["electric_blue"],
+            muted=palette["muted"],
+            background=palette["background"],
+            width=220,
+        ),
+    ]
 
 
 def build_screen_widgets(
@@ -291,23 +570,23 @@ def build_screen_widgets(
     from libqtile import widget
     from libqtile.lazy import lazy
 
-    colors = config_globals["colors"]
+    palette = outrun_palette(config_globals["colors"])
     home = config_globals["home"]
-    background = colors[1][0] if isinstance(colors[1], (list, tuple)) else colors[1]
-    foreground = colors[5][0] if isinstance(colors[5], (list, tuple)) else colors[5]
-    accent = role_accent(role)
-    items = _base_widgets(config_globals, accent)
+    background = palette["background"]
+    foreground = palette["white"]
+    items = _base_widgets(config_globals)
     role = base_role(role)
 
     if role == "center":
-        items.extend(telemetry_widgets_factory(home, colors))
+        items.extend(telemetry_widgets_factory(home, config_globals["colors"]))
+        items.extend(_system_telemetry(config_globals))
         items.extend(
             [
-                widget.Pomodoro(foreground=accent, background=background),
+                widget.Pomodoro(foreground=palette["pink"], background=background),
                 widget.TextBox(
                     name="agent_zero_button",
                     text=" A0 ",
-                    foreground=accent,
+                    foreground=palette["cyan"],
                     background=background,
                     mouse_callbacks={
                         "Button1": lazy.group["qtileControl"].dropdown_toggle("agent-zero")
@@ -319,7 +598,7 @@ def build_screen_widgets(
                     fontsize=12,
                     format="%Y-%m-%d %H:%M",
                 ),
-                widget.Volume(foreground=accent, background=background),
+                widget.Volume(foreground=palette["red"], background=background),
                 widget.Systray(background=background, icon_size=20, padding=4),
             ]
         )
@@ -334,15 +613,15 @@ def build_screen_widgets(
                     name="org_clocked_task",
                     cmd=["emacsclient", "-a", "emacs", "--eval", clock_expression],
                     parse=_parse_clock_output,
-                    update_interval=10,
-                    foreground=accent,
+                    update_interval=5,
+                    foreground=palette["pink"],
                     background=background,
                     max_chars=55,
                 ),
                 widget.TextBox(
                     name="org_todos_button",
                     text=" TODO ",
-                    foreground=accent,
+                    foreground=palette["cyan"],
                     background=background,
                     mouse_callbacks={
                         "Button1": lazy.group["qtileControl"].dropdown_toggle("org-todos")
@@ -351,7 +630,7 @@ def build_screen_widgets(
                 widget.TextBox(
                     name="workflow_button",
                     text=" WF ",
-                    foreground=accent,
+                    foreground=palette["orange"],
                     background=background,
                     mouse_callbacks={
                         "Button1": lazy.function(_select_workflow, config_globals)
@@ -363,15 +642,18 @@ def build_screen_widgets(
                     fontsize=12,
                     format="%H:%M",
                 ),
+                widget.Volume(foreground=palette["red"], background=background),
             ]
         )
     elif role == "right":
+        items.extend(_market_widgets(config_globals))
         items.extend(
             [
+                _weather_widget(config_globals),
                 widget.Mpris2(
                     name="right_mpris",
                     background=background,
-                    foreground=accent,
+                    foreground=palette["cyan"],
                     scroll_fixed_width=True,
                     poll_interval=1,
                     width=220,
@@ -385,18 +667,23 @@ def build_screen_widgets(
                     fontsize=12,
                     format="%H:%M",
                 ),
-                widget.Volume(foreground=accent, background=background),
+                widget.Volume(foreground=palette["red"], background=background),
             ]
         )
     else:
-        items.append(
-            widget.Clock(
-                foreground=foreground,
-                background=background,
-                fontsize=12,
-                format="%H:%M",
-            )
+        items.extend(
+            [
+                widget.Clock(
+                    foreground=foreground,
+                    background=background,
+                    fontsize=12,
+                    format="%H:%M",
+                ),
+                widget.Volume(foreground=palette["red"], background=background),
+            ]
         )
+
+    items.append(_notification_widget(config_globals, role))
     return items
 
 
@@ -417,8 +704,8 @@ def _install_control_scratchpad(config_globals: dict[str, Any]) -> None:
                     _emacs_frame_command("qtile-org-todos-open", "qtile-org-todos"),
                     height=0.68,
                     width=0.58,
-                    x=0.02,
-                    y=0.05,
+                    x=0.42,
+                    y=0.02,
                     opacity=0.97,
                     on_focus_lost_hide=True,
                     match=Match(title="qtile-org-todos"),
@@ -443,7 +730,7 @@ def install_desktop_control(
     config_globals: dict[str, Any],
     telemetry_widgets_factory: Callable[[str, Any], list[Any]],
 ) -> None:
-    """Replace the cloned bar with topology-aware, role-scoped bars."""
+    """Replace cloned bars with topology-aware, role-scoped bars."""
     from libqtile import bar
     from libqtile.config import Screen
 

--- a/.config/qtile/qtile_market.py
+++ b/.config/qtile/qtile_market.py
@@ -1,0 +1,212 @@
+"""Provider-neutral rotating market widgets for Qtile.
+
+The widget never fabricates prices. Providers write trusted snapshots to the cache;
+until then the built-in instrument catalogue renders as an explicit stub.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from libqtile.widget import base
+
+TIMEFRAMES = ("1m", "5m", "15m", "1h", "4h", "1d")
+COMMODITY_STUBS = (
+    ("GOLD", "Gold"),
+    ("SILV", "Silver"),
+    ("WTI", "WTI Crude"),
+    ("BRENT", "Brent Crude"),
+    ("NG", "Natural Gas"),
+    ("COPPER", "Copper"),
+    ("CORN", "Corn"),
+    ("WHEAT", "Wheat"),
+    ("SOY", "Soybeans"),
+    ("COFFEE", "Coffee"),
+    ("COCOA", "Cocoa"),
+    ("COTTON", "Cotton"),
+    ("SUGAR", "Sugar"),
+)
+KALSHI_STUBS = (("KALSHI", "Kalshi"),)
+
+
+def market_cache_path() -> Path:
+    configured = os.environ.get("QTILE_MARKET_CACHE")
+    if configured:
+        return Path(configured).expanduser()
+    root = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+    return root / "qtile" / "markets.json"
+
+
+def load_market_cache(path: Path | None = None) -> dict:
+    path = path or market_cache_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def stub_entries(feed: str) -> list[dict]:
+    catalogue = KALSHI_STUBS if feed == "kalshi" else COMMODITY_STUBS
+    return [
+        {
+            "symbol": symbol,
+            "label": label,
+            "provider": "stub",
+            "timeframes": {},
+        }
+        for symbol, label in catalogue
+    ]
+
+
+def feed_entries(payload: dict, feed: str) -> list[dict]:
+    entries = payload.get(feed, [])
+    if not isinstance(entries, list):
+        return stub_entries(feed)
+    valid = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("symbol") and entry.get("label")
+    ]
+    return valid or stub_entries(feed)
+
+
+def timeframe_snapshot(entry: dict, timeframe: str) -> dict:
+    frames = entry.get("timeframes", {})
+    if not isinstance(frames, dict):
+        return {}
+    snapshot = frames.get(timeframe, {})
+    return snapshot if isinstance(snapshot, dict) else {}
+
+
+class MarketCarousel(base._Widget):
+    """Rotate instruments and timeframes while drawing any trusted cached series."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [
+        ("feed", "commodities", "Feed key in the provider cache."),
+        ("frequency", 4, "Rotation interval in seconds."),
+        ("foreground", "#fba922", "Text colour."),
+        ("graph_color", "#fba922", "Trend line colour."),
+        ("accent", "#2de2e6", "Positive trend colour."),
+        ("negative", "#dd546e", "Negative trend colour."),
+        ("muted", "#92406e", "Missing-data colour."),
+        ("line_width", 1.4, "Trend line width."),
+        ("padding", 4, "Horizontal padding."),
+    ]
+
+    def __init__(self, width=220, **config):
+        super().__init__(width, **config)
+        self.add_defaults(self.defaults)
+        self.index = 0
+        self._entries = []
+        self._snapshot = {}
+        self._entry = {}
+        self._timeframe = TIMEFRAMES[0]
+        self.add_callbacks({"Button4": self.previous, "Button5": self.next})
+
+    def _configure(self, qtile, bar_obj):
+        super()._configure(qtile, bar_obj)
+        self.layout = self.drawer.textlayout(
+            "",
+            self.foreground,
+            "Hack Nerd Regular",
+            11,
+            None,
+            markup=False,
+        )
+
+    def timer_setup(self):
+        self._refresh()
+        self.timeout_add(self.frequency, self.timer_setup)
+
+    def previous(self):
+        self.index -= 1
+        self._refresh(rotate=False)
+
+    def next(self):
+        self.index += 1
+        self._refresh(rotate=False)
+
+    def _refresh(self, rotate=True):
+        payload = load_market_cache()
+        self._entries = feed_entries(payload, self.feed)
+        slots = max(len(self._entries) * len(TIMEFRAMES), 1)
+        self.index %= slots
+        entry_index = self.index // len(TIMEFRAMES)
+        frame_index = self.index % len(TIMEFRAMES)
+        self._entry = self._entries[entry_index]
+        self._timeframe = TIMEFRAMES[frame_index]
+        self._snapshot = timeframe_snapshot(self._entry, self._timeframe)
+        self.draw()
+        if rotate:
+            self.index = (self.index + 1) % slots
+
+    def _display_text(self):
+        symbol = str(self._entry.get("symbol", self.feed.upper()))
+        price = self._snapshot.get("price")
+        change = self._snapshot.get("change")
+        if price is None:
+            return f"{symbol} {self._timeframe} —", self.muted
+        try:
+            price_text = f"{float(price):g}"
+        except (TypeError, ValueError):
+            return f"{symbol} {self._timeframe} —", self.muted
+        if change is None:
+            return f"{symbol} {self._timeframe} {price_text}", self.foreground
+        try:
+            change_value = float(change)
+        except (TypeError, ValueError):
+            return f"{symbol} {self._timeframe} {price_text}", self.foreground
+        colour = self.accent if change_value >= 0 else self.negative
+        return f"{symbol} {self._timeframe} {price_text} {change_value:+.2f}%", colour
+
+    def _series(self):
+        raw = self._snapshot.get("series", [])
+        if not isinstance(raw, list):
+            return []
+        values = []
+        for value in raw:
+            try:
+                values.append(float(value))
+            except (TypeError, ValueError):
+                return []
+        return values
+
+    def draw(self):
+        if not hasattr(self, "drawer"):
+            return
+        self.drawer.clear(self.background or self.bar.background)
+        text, colour = self._display_text()
+        self.layout.text = text
+        self.layout.colour = colour
+        text_width = int(self.width * 0.62)
+        self.layout.width = text_width
+        y = max((self.height - self.layout.height) / 2, 0)
+        self.layout.draw(self.padding, y)
+
+        series = self._series()
+        if len(series) >= 2:
+            minimum = min(series)
+            maximum = max(series)
+            if maximum > minimum:
+                graph_left = max(text_width + self.padding * 2, int(self.width * 0.64))
+                graph_right = self.width - self.padding
+                graph_width = max(graph_right - graph_left, 1)
+                graph_height = max(self.height - 6, 1)
+                step = graph_width / max(len(series) - 1, 1)
+                self.drawer.set_source_rgb(self.graph_color)
+                self.drawer.ctx.set_line_width(self.line_width)
+                for index, value in enumerate(series):
+                    x = graph_left + index * step
+                    normalized = (value - minimum) / (maximum - minimum)
+                    y = self.height - 3 - normalized * graph_height
+                    if index == 0:
+                        self.drawer.ctx.move_to(x, y)
+                    else:
+                        self.drawer.ctx.line_to(x, y)
+                self.drawer.ctx.stroke()
+
+        self.draw_at_default_position()

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -15,10 +15,11 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
-POLL_SECONDS = 5
-GRAPH_SAMPLES = 60
-GRAPH_WIDTH = 76
+POLL_SECONDS = 1
+GRAPH_SAMPLES = 300
+GRAPH_WIDTH = 82
 RATE_FONTSIZE = 12
+ROTATE_SECONDS = 5
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
@@ -60,14 +61,14 @@ def _fetch_payload(script):
     global _last_payload, _last_poll_at
     with _poll_lock:
         now = time.monotonic()
-        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.5:
+        if _last_payload is not None and now - _last_poll_at < POLL_SECONDS - 0.05:
             return _last_payload
         completed = subprocess.run(
             ["python3", script, "--json"],
             check=False,
             capture_output=True,
             text=True,
-            timeout=8,
+            timeout=12,
         )
         try:
             payload = json.loads(completed.stdout)
@@ -174,7 +175,7 @@ class OpenRouterCredit(base.BackgroundPoll):
 
 
 class OpenRouterRate(base.BackgroundPoll):
-    """Display the most recent complete-minute OpenRouter token rate."""
+    """Display the most recent trusted OpenRouter token rate."""
 
     orientations = base.ORIENTATION_HORIZONTAL
 
@@ -196,13 +197,74 @@ class OpenRouterRate(base.BackgroundPoll):
         )
 
 
+class OpenRouterRotatingMetric(base.BackgroundPoll):
+    """Rotate one OpenRouter metric through configured periods."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, script, colors, metric, **config):
+        self.script = script
+        self.colors = colors
+        self.metric = metric
+        self.index = 0
+        self.last_rotate = time.monotonic()
+        self.specs = (
+            (
+                ("M", "tokens_month"),
+                ("W", "tokens_week"),
+                ("D", "tokens_day"),
+                ("H", "tokens_hour"),
+            )
+            if metric == "tokens"
+            else (
+                ("D", "spend_day"),
+                ("W", "spend_week"),
+                ("M", "spend_month"),
+            )
+        )
+        self.icon = "" if metric == "tokens" else ""
+        super().__init__(text=f"{self.icon} …", **config)
+        self.add_callbacks({"Button4": self.previous, "Button5": self.next})
+
+    def previous(self):
+        self.index = (self.index - 1) % len(self.specs)
+        self.last_rotate = time.monotonic()
+        self.tick()
+
+    def next(self):
+        self.index = (self.index + 1) % len(self.specs)
+        self.last_rotate = time.monotonic()
+        self.tick()
+
+    def _maybe_rotate(self):
+        now = time.monotonic()
+        if now - self.last_rotate >= ROTATE_SECONDS:
+            self.index = (self.index + 1) % len(self.specs)
+            self.last_rotate = now
+
+    def poll(self):
+        self._maybe_rotate()
+        label, key = self.specs[self.index]
+        payload = _fetch_payload(self.script) or {}
+        value = payload.get(key)
+        color_index = (4, 6, 3, 7)[self.index % 4]
+        color = _color(self.colors, color_index)
+        if value is None:
+            rendered = "—"
+        elif self.metric == "tokens":
+            rendered = _compact_count(value)
+        else:
+            rendered = f"${float(value):.2f}"
+        return f'<span foreground="{color}">{self.icon} {label} {rendered}</span>'
+
+
 class OpenRouterIOGraph(base._Widget):
-    """Five-minute sparkline of trusted input/output tokens per minute."""
+    """Sparkline of trusted input/output token-rate samples."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Number of rate samples."),
+        ("samples", GRAPH_SAMPLES, "Maximum number of changed samples."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -216,7 +278,7 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.input_values = deque(maxlen=self.samples)
         self.output_values = deque(maxlen=self.samples)
-        self._last_window_end = None
+        self._last_sample = None
 
     def timer_setup(self):
         self._update()
@@ -225,12 +287,16 @@ class OpenRouterIOGraph(base._Widget):
     def _update(self):
         status = _read_cached_status()
         if status:
-            window_end = status.get("window_end")
-            if window_end != self._last_window_end:
-                self.input_values.append(float(status.get("input_tokens_per_minute", 0)))
-                self.output_values.append(float(status.get("output_tokens_per_minute", 0)))
-                self._last_window_end = window_end
-        self.draw()
+            sample = (
+                status.get("window_end"),
+                status.get("input_tokens_per_minute"),
+                status.get("output_tokens_per_minute"),
+            )
+            if sample != self._last_sample and sample[0] is not None:
+                self.input_values.append(float(sample[1] or 0))
+                self.output_values.append(float(sample[2] or 0))
+                self._last_sample = sample
+                self.draw()
 
     def _draw_series(self, values, color, center_y, half_height, direction):
         if len(values) < 2:
@@ -295,31 +361,18 @@ def _install_sync_and_reload_key(config_globals):
 def _telemetry_widgets(home, colors):
     script = home + "/.config/qtile/scripts/openrouter_status.py"
     background = _color(colors, 1)
+    common = {
+        "update_interval": POLL_SECONDS,
+        "markup": True,
+        "font": "Hack Nerd Regular",
+        "fontsize": RATE_FONTSIZE,
+        "padding": 3,
+        "foreground": _color(colors, 5),
+        "background": background,
+    }
     return [
-        OpenRouterCredit(
-            script,
-            colors,
-            name="openrouter_credit",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=RATE_FONTSIZE,
-            padding=3,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
-        OpenRouterRate(
-            script,
-            colors,
-            name="openrouter_rate",
-            update_interval=POLL_SECONDS,
-            markup=True,
-            font="Hack Nerd Regular",
-            fontsize=RATE_FONTSIZE,
-            padding=3,
-            foreground=_color(colors, 5),
-            background=background,
-        ),
+        OpenRouterCredit(script, colors, name="openrouter_credit", **common),
+        OpenRouterRate(script, colors, name="openrouter_rate", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",
             frequency=POLL_SECONDS,
@@ -328,6 +381,12 @@ def _telemetry_widgets(home, colors):
             output_color=_color(colors, 4),
             midline_color=_color(colors, 2),
             background=background,
+        ),
+        OpenRouterRotatingMetric(
+            script, colors, "tokens", name="openrouter_token_totals", **common
+        ),
+        OpenRouterRotatingMetric(
+            script, colors, "spend", name="openrouter_spend_totals", **common
         ),
     ]
 

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Render trustworthy OpenRouter token-per-minute telemetry for the Qtile bar."""
+"""Collect trustworthy OpenRouter rate, balance, token, and spend telemetry."""
 
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import fcntl
 import json
 import os
@@ -18,11 +19,11 @@ from typing import Any
 
 API_BASE = "https://openrouter.ai/api/v1"
 AI_ICON = "\U000F09D1"
-RED = "#dd546e"
-IO = "#f6019d"
-ACCENT = "#2de2e6"
-CACHE_TTL_SECONDS = 4
+
+CACHE_TTL_SECONDS = 0.75
 RATE_WINDOW_SECONDS = 60
+USAGE_REFRESH_SECONDS = 30
+BALANCE_REFRESH_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 5
 DEFAULT_MAX_TPM = 10_000_000
 
@@ -33,6 +34,15 @@ class Status:
     output_tokens_per_minute: int
     balance_usd: float | None = None
     window_end: str | None = None
+    tokens_month: int | None = None
+    tokens_week: int | None = None
+    tokens_day: int | None = None
+    tokens_hour: int | None = None
+    spend_month: float | None = None
+    spend_week: float | None = None
+    spend_day: float | None = None
+    usage_fetched_at: str | None = None
+    balance_fetched_at: str | None = None
 
     @property
     def total_tokens_per_minute(self) -> int:
@@ -51,15 +61,13 @@ def compact_count(value: int | float) -> str:
 def render(status: Status, *, stale: bool = False) -> str:
     stale_marker = " ~" if stale else ""
     return (
-        f'<span foreground="{IO}">{AI_ICON} '
-        f"{compact_count(status.input_tokens_per_minute)}↓/m</span> "
-        f'<span foreground="{ACCENT}">'
-        f"{compact_count(status.output_tokens_per_minute)}↑/m{stale_marker}</span>"
+        f"{AI_ICON} {compact_count(status.input_tokens_per_minute)}↓/m "
+        f"{compact_count(status.output_tokens_per_minute)}↑/m{stale_marker}"
     )
 
 
 def render_error(message: str) -> str:
-    return f'<span foreground="{RED}">{AI_ICON} {message}</span>'
+    return f"{AI_ICON} {message}"
 
 
 def _management_key_file() -> Path:
@@ -90,7 +98,7 @@ def _request_json(
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}",
-        "User-Agent": "qtile-openrouter-status/3",
+        "User-Agent": "qtile-openrouter-status/4",
     }
     if payload is not None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -111,20 +119,21 @@ def _request_json(
         raise RuntimeError("OpenRouter unavailable") from exc
 
 
-def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
+def _rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
     metadata = payload.get("metadata") or payload.get("data", {}).get("metadata") or {}
     if metadata.get("truncated"):
         raise RuntimeError("OpenRouter analytics result truncated")
     rows = payload.get("data", {}).get("data", [])
     if not isinstance(rows, list):
         raise RuntimeError("OpenRouter analytics rows malformed")
+    return [row for row in rows if isinstance(row, dict)]
 
+
+def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
     prompt = 0.0
     completion = 0.0
     seen: set[tuple[Any, ...]] = set()
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
+    for row in _rows(payload):
         bucket = (
             row.get("created_at__minute")
             or row.get("date__minute")
@@ -145,6 +154,23 @@ def parse_token_totals(payload: dict[str, Any]) -> tuple[int, int]:
     return int(round(prompt)), int(round(completion))
 
 
+def parse_usage_summary(payload: dict[str, Any]) -> tuple[int, float]:
+    tokens = 0.0
+    spend = 0.0
+    for row in _rows(payload):
+        try:
+            row_tokens = row.get("tokens_total")
+            if row_tokens is None:
+                row_tokens = float(row.get("tokens_prompt") or 0) + float(
+                    row.get("tokens_completion") or 0
+                )
+            tokens += float(row_tokens or 0)
+            spend += float(row.get("total_usage") or 0)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("OpenRouter usage metric malformed") from exc
+    return int(round(tokens)), spend
+
+
 def _closed_minute_window(now: datetime | None = None) -> tuple[datetime, datetime]:
     now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     end = now.replace(second=0, microsecond=0)
@@ -162,6 +188,19 @@ def fetch_tokens(key: str, start: datetime, end: datetime) -> tuple[int, int]:
         "limit": 10,
     }
     return parse_token_totals(_request_json("POST", "/analytics/query", key, payload))
+
+
+def fetch_usage_range(key: str, start: datetime, end: datetime) -> tuple[int, float]:
+    payload = {
+        "metrics": ["tokens_total", "total_usage"],
+        "granularity": "hour",
+        "time_range": {
+            "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "end": end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "limit": 1000,
+    }
+    return parse_usage_summary(_request_json("POST", "/analytics/query", key, payload))
 
 
 def fetch_balance(key: str) -> float:
@@ -189,6 +228,39 @@ def validate_rate(input_tokens: int, output_tokens: int) -> None:
     maximum = _maximum_tpm()
     if input_tokens + output_tokens > maximum:
         raise RuntimeError("implausible OpenRouter token rate")
+
+
+def period_starts(now: datetime | None = None) -> dict[str, datetime]:
+    if now is None:
+        now = datetime.now().astimezone()
+    elif now.tzinfo is None:
+        now = now.astimezone()
+    day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    hour = now.replace(minute=0, second=0, microsecond=0)
+    week = day - timedelta(days=day.weekday())
+    month = day.replace(day=1)
+    return {"month": month, "week": week, "day": day, "hour": hour}
+
+
+def fetch_period_totals(key: str, now: datetime | None = None) -> dict[str, float | int]:
+    if now is None:
+        now = datetime.now().astimezone()
+    elif now.tzinfo is None:
+        now = now.astimezone()
+    starts = period_starts(now)
+    periods = ("month", "week", "day", "hour")
+    result: dict[str, float | int] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(periods)) as executor:
+        futures = {
+            period: executor.submit(fetch_usage_range, key, starts[period], now)
+            for period in periods
+        }
+        for period in periods:
+            tokens, spend = futures[period].result()
+            result[f"tokens_{period}"] = tokens
+            if period != "hour":
+                result[f"spend_{period}"] = spend
+    return result
 
 
 def _cache_path() -> Path:
@@ -225,21 +297,66 @@ def _write_cache(path: Path, status: Status, *, fetched_at: float) -> None:
     temporary.replace(path)
 
 
-def fetch_status(key: str, previous: Status | None = None) -> Status:
-    start, end = _closed_minute_window()
-    input_tokens, output_tokens = fetch_tokens(key, start, end)
-    validate_rate(input_tokens, output_tokens)
-    balance = previous.balance_usd if previous else None
+def _iso_now(now: datetime) -> str:
+    return now.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _age_seconds(value: str | None, now: datetime) -> float:
+    if not value:
+        return float("inf")
     try:
-        balance = fetch_balance(key)
-    except RuntimeError:
-        pass
-    return Status(
+        stamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return float("inf")
+    return max((now.astimezone(timezone.utc) - stamp.astimezone(timezone.utc)).total_seconds(), 0)
+
+
+def fetch_status(key: str, previous: Status | None = None) -> Status:
+    now_utc = datetime.now(timezone.utc)
+    start, end = _closed_minute_window(now_utc)
+    window_end = end.isoformat().replace("+00:00", "Z")
+
+    input_tokens = previous.input_tokens_per_minute if previous else 0
+    output_tokens = previous.output_tokens_per_minute if previous else 0
+    if previous is None or previous.window_end != window_end:
+        input_tokens, output_tokens = fetch_tokens(key, start, end)
+        validate_rate(input_tokens, output_tokens)
+
+    values = asdict(previous) if previous else asdict(Status(input_tokens, output_tokens))
+    values.update(
         input_tokens_per_minute=input_tokens,
         output_tokens_per_minute=output_tokens,
-        balance_usd=balance,
-        window_end=end.isoformat().replace("+00:00", "Z"),
+        window_end=window_end,
     )
+
+    usage_due = (
+        previous is None
+        or _age_seconds(previous.usage_fetched_at, now_utc) >= USAGE_REFRESH_SECONDS
+    )
+    balance_due = (
+        previous is None
+        or _age_seconds(previous.balance_fetched_at, now_utc) >= BALANCE_REFRESH_SECONDS
+    )
+    if usage_due or balance_due:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            usage_future = executor.submit(fetch_period_totals, key) if usage_due else None
+            balance_future = executor.submit(fetch_balance, key) if balance_due else None
+
+            if usage_future is not None:
+                try:
+                    values.update(usage_future.result())
+                    values["usage_fetched_at"] = _iso_now(now_utc)
+                except RuntimeError:
+                    pass
+
+            if balance_future is not None:
+                try:
+                    values["balance_usd"] = balance_future.result()
+                    values["balance_fetched_at"] = _iso_now(now_utc)
+                except RuntimeError:
+                    pass
+
+    return Status(**values)
 
 
 def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
@@ -266,7 +383,7 @@ def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print machine-readable status")
-    parser.add_argument("--force", action="store_true", help="ignore the short poll cache")
+    parser.add_argument("--force", action="store_true", help="ignore the short process cache")
     args = parser.parse_args(argv)
     try:
         key = load_management_key()

--- a/.config/qtile/scripts/weather_status.py
+++ b/.config/qtile/scripts/weather_status.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Fetch current weather for the Qtile Outrun bar using Open-Meteo."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search"
+FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+CACHE_SECONDS = 300
+REQUEST_TIMEOUT = 5
+
+WEATHER_ICONS = {
+    0: "󰖙", 1: "󰖕", 2: "󰖐", 3: "󰖐", 45: "󰖑", 48: "󰖑",
+    51: "󰖗", 53: "󰖗", 55: "󰖗", 56: "󰖗", 57: "󰖗",
+    61: "󰖖", 63: "󰖖", 65: "󰖖", 66: "󰖖", 67: "󰖖",
+    71: "󰼶", 73: "󰼶", 75: "󰼶", 77: "󰼶", 80: "󰖖",
+    81: "󰖖", 82: "󰖖", 85: "󰼶", 86: "󰼶", 95: "󰙾",
+    96: "󰙾", 99: "󰙾",
+}
+
+
+def cache_path() -> Path:
+    root = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+    return root / "qtile" / "weather.json"
+
+
+def request_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": "qtile-weather/1"})
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            payload = json.load(response)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        raise RuntimeError("weather unavailable") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("weather payload malformed")
+    return payload
+
+
+def configured_coordinates() -> tuple[float, float, str] | None:
+    latitude = os.environ.get("WEATHER_LATITUDE")
+    longitude = os.environ.get("WEATHER_LONGITUDE")
+    if latitude and longitude:
+        try:
+            return float(latitude), float(longitude), os.environ.get("WEATHER_LABEL", "")
+        except ValueError as exc:
+            raise RuntimeError("weather coordinates malformed") from exc
+    return None
+
+
+def geocode_location(location: str) -> tuple[float, float, str]:
+    query = urllib.parse.urlencode({"name": location, "count": 1, "language": "en", "format": "json"})
+    payload = request_json(f"{GEOCODE_URL}?{query}")
+    results = payload.get("results", [])
+    if not isinstance(results, list) or not results:
+        raise RuntimeError("weather location not found")
+    result = results[0]
+    try:
+        latitude = float(result["latitude"])
+        longitude = float(result["longitude"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("weather geocode malformed") from exc
+    label = str(result.get("name") or location)
+    return latitude, longitude, label
+
+
+def resolve_location() -> tuple[float, float, str]:
+    configured = configured_coordinates()
+    if configured:
+        return configured
+    location = os.environ.get("WEATHER_LOCATION", "").strip()
+    if not location:
+        raise RuntimeError("set WEATHER_LOCATION")
+    return geocode_location(location)
+
+
+def weather_url(latitude: float, longitude: float) -> str:
+    metric = os.environ.get("WEATHER_UNITS", "imperial").casefold() == "metric"
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "current": "temperature_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m",
+        "timezone": "auto",
+        "temperature_unit": "celsius" if metric else "fahrenheit",
+        "wind_speed_unit": "kmh" if metric else "mph",
+        "precipitation_unit": "mm" if metric else "inch",
+    }
+    return f"{FORECAST_URL}?{urllib.parse.urlencode(params)}"
+
+
+def parse_current(payload: dict[str, Any], label: str = "") -> dict[str, Any]:
+    current = payload.get("current", {})
+    if not isinstance(current, dict):
+        raise RuntimeError("weather current payload malformed")
+    try:
+        temperature = float(current["temperature_2m"])
+        apparent = float(current["apparent_temperature"])
+        wind = float(current["wind_speed_10m"])
+        code = int(current["weather_code"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("weather current payload malformed") from exc
+    return {"label": label, "temperature": temperature, "apparent": apparent, "wind": wind, "code": code}
+
+
+def render(weather: dict[str, Any]) -> str:
+    icon = WEATHER_ICONS.get(int(weather["code"]), "󰖐")
+    metric = os.environ.get("WEATHER_UNITS", "imperial").casefold() == "metric"
+    degree = "C" if metric else "F"
+    wind_unit = "km/h" if metric else "mph"
+    location = f"{weather['label']} " if weather.get("label") else ""
+    return (
+        f"{icon} {location}{weather['temperature']:.0f}°{degree} "
+        f"feels {weather['apparent']:.0f}° · {weather['wind']:.0f} {wind_unit}"
+    )
+
+
+def read_cache(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def fetch_weather() -> dict[str, Any]:
+    latitude, longitude, label = resolve_location()
+    return parse_current(request_json(weather_url(latitude, longitude)), label)
+
+
+def status() -> tuple[dict[str, Any], bool]:
+    path = cache_path()
+    cache = read_cache(path)
+    now = time.time()
+    if cache and now - float(cache.get("fetched_at", 0)) < CACHE_SECONDS:
+        return cache["weather"], False
+    try:
+        weather = fetch_weather()
+    except RuntimeError:
+        if cache and isinstance(cache.get("weather"), dict):
+            return cache["weather"], True
+        raise
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_suffix(".tmp")
+    temp.write_text(json.dumps({"fetched_at": now, "weather": weather}, separators=(",", ":")), encoding="utf-8")
+    temp.replace(path)
+    return weather, False
+
+
+def main() -> int:
+    try:
+        weather, stale = status()
+    except RuntimeError as exc:
+        print(f"󰖐 {exc}")
+        return 1
+    text = render(weather)
+    print(f"{text}{' ~' if stale else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.config/qtile/tests/test_groupbox_navigation.py
+++ b/.config/qtile/tests/test_groupbox_navigation.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Widget-level regression tests for OwnedGroupBox navigation.
+
+The libqtile stub's GroupBox base carries the verbatim Qtile 0.33.0
+next_group/prev_group implementation, which spins forever when
+self.groups is empty. If the OwnedGroupBox overrides are removed, these
+tests hang and are failed by the alarm instead of blocking CI forever.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import itertools
+import signal
+import sys
+import types
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile_control.py"
+SPEC = importlib.util.spec_from_file_location("qtile_control_nav", SOURCE)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+@dataclass
+class Group:
+    name: str
+    label: str
+    windows: list = field(default_factory=list)
+    screen: object | None = None
+
+
+@contextlib.contextmanager
+def timeout_guard(seconds: float = 2.0):
+    """Fail loudly instead of hanging when navigation regresses to a spin."""
+
+    def _fail(signum, frame):
+        raise AssertionError("group navigation did not terminate (infinite loop)")
+
+    previous = signal.signal(signal.SIGALRM, _fail)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+class FakeScreen:
+    def __init__(self):
+        self.set_group_calls = []
+
+    def set_group(self, group, warp=None):
+        self.set_group_calls.append(group)
+
+
+class FakeBar:
+    def __init__(self, screen):
+        self.screen = screen
+
+
+class FakeQtile:
+    def __init__(self, groups, current_group, current_screen):
+        self.groups = groups
+        self.current_group = current_group
+        self.current_screen = current_screen
+
+
+class _HookProxy:
+    def __getattr__(self, name):
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+def _install_libqtile_stub():
+    libqtile = types.ModuleType("libqtile")
+    widget_mod = types.ModuleType("libqtile.widget")
+    hook_mod = types.ModuleType("libqtile.hook")
+    hook_mod.subscribe = _HookProxy()
+    hook_mod.unsubscribe = _HookProxy()
+
+    class _GroupBox:
+        # Minimal constructor mirroring Qtile's config-kwargs pattern.
+        def __init__(self, **config):
+            self.__dict__.update(config)
+            self.visible_groups = config.get("visible_groups")
+
+        # Qtile 0.33.0 libqtile/widget/groupbox.py, verbatim.
+        def next_group(self):
+            group = None
+            current_group = self.qtile.current_group
+            i = itertools.cycle(self.qtile.groups)
+            while next(i) != current_group:
+                pass
+            while group is None or group not in self.groups:
+                group = next(i)
+            self.go_to_group(group)
+
+        def prev_group(self):
+            group = None
+            current_group = self.qtile.current_group
+            i = itertools.cycle(reversed(self.qtile.groups))
+            while next(i) != current_group:
+                pass
+            while group is None or group not in self.groups:
+                group = next(i)
+            self.go_to_group(group)
+
+    widget_mod.GroupBox = _GroupBox
+    libqtile.widget = widget_mod
+    libqtile.hook = hook_mod
+    sys.modules["libqtile"] = libqtile
+    sys.modules["libqtile.widget"] = widget_mod
+    sys.modules["libqtile.hook"] = hook_mod
+
+
+def _remove_libqtile_stub():
+    for name in ("libqtile", "libqtile.widget", "libqtile.hook"):
+        sys.modules.pop(name, None)
+
+
+class OwnedGroupBoxNavigationTests(unittest.TestCase):
+    def setUp(self):
+        MODULE._group_owner_roles.clear()
+        _install_libqtile_stub()
+        self.addCleanup(_remove_libqtile_stub)
+
+    def _build_box(self, group_names=("1", "2", "3")):
+        colors = [[str(index)] * 2 for index in range(10)]
+        box = MODULE._owned_group_box(
+            {"colors": colors, "group_names": list(group_names)}
+        )
+        screen = FakeScreen()
+        box.bar = FakeBar(screen)
+        navigated = []
+
+        def _navigate(group):
+            navigated.append(group)
+            # Real Qtile advances the current group via Screen.set_group.
+            box.qtile.current_group = group
+            box.bar.screen.group = group
+
+        box.go_to_group = _navigate
+        return box, navigated
+
+    def test_navigation_terminates_when_no_group_has_windows(self):
+        box, navigated = self._build_box()
+        empty = [Group("1", "one", []), Group("2", "two", [])]
+        box.qtile = FakeQtile(empty, empty[0], box.bar.screen)
+        with timeout_guard():
+            box.next_group()
+            box.prev_group()
+        self.assertEqual(navigated, [])
+
+    def test_next_group_skips_windowless_groups(self):
+        box, navigated = self._build_box()
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", []),
+            Group("3", "three", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[0], box.bar.screen)
+        with timeout_guard():
+            box.next_group()
+        self.assertIs(navigated[-1], groups[2])
+
+    def test_next_group_wraps_around(self):
+        box, navigated = self._build_box()
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", [object()]),
+            Group("3", "three", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[2], box.bar.screen)
+        with timeout_guard():
+            box.next_group()
+        self.assertIs(navigated[-1], groups[0])
+
+    def test_prev_group_wraps_around(self):
+        box, navigated = self._build_box()
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", [object()]),
+            Group("3", "three", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[0], box.bar.screen)
+        with timeout_guard():
+            box.prev_group()
+        self.assertIs(navigated[-1], groups[2])
+
+    def test_navigation_from_empty_current_group_lands_on_visible_group(self):
+        box, navigated = self._build_box()
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", []),
+            Group("3", "three", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[1], box.bar.screen)
+        with timeout_guard():
+            box.next_group()
+        self.assertIs(navigated[-1], groups[0])
+        with timeout_guard():
+            box.prev_group()
+        self.assertIs(navigated[-1], groups[2])
+
+    def test_visible_groups_attribute_restricts_navigation(self):
+        box, navigated = self._build_box(group_names=("1", "3"))
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", [object()]),
+            Group("3", "three", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[0], box.bar.screen)
+        self.assertEqual([group.name for group in box.groups], ["1", "3"])
+        with timeout_guard():
+            box.next_group()
+        self.assertIs(navigated[-1], groups[2])
+
+    def test_single_visible_group_navigates_to_itself(self):
+        box, navigated = self._build_box(group_names=("2",))
+        groups = [
+            Group("1", "one", []),
+            Group("2", "two", [object()]),
+        ]
+        box.qtile = FakeQtile(groups, groups[1], box.bar.screen)
+        with timeout_guard():
+            box.next_group()
+        self.assertIs(navigated[-1], groups[1])
+
+    def test_navigation_with_all_windows_on_all_groups_n_screens(self):
+        # Simulate N=4 groups spread over roles; navigation must visit
+        # every window-owning group and terminate each time.
+        box, navigated = self._build_box(group_names=("1", "2", "3", "4"))
+        groups = [Group(str(i), str(i), [object()]) for i in range(1, 5)]
+        box.qtile = FakeQtile(groups, groups[0], box.bar.screen)
+        visited = [groups[0]]
+        with timeout_guard():
+            for _ in range(3):
+                box.next_group()
+                visited.append(navigated[-1])
+        self.assertEqual(
+            [group.name for group in visited], ["1", "2", "3", "4"]
+        )
+
+    def test_next_visible_group_pure_function_edges(self):
+        self.assertIsNone(MODULE.next_visible_group([], object()))
+        sentinel = object()
+        self.assertIs(MODULE.next_visible_group([sentinel], sentinel), sentinel)
+        self.assertIs(MODULE.next_visible_group([sentinel], object()), sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_market_widget_structure.py
+++ b/.config/qtile/tests/test_market_widget_structure.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Static regression tests for provider-neutral market stubs."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile_market.py"
+TEXT = SOURCE.read_text(encoding="utf-8")
+TREE = ast.parse(TEXT)
+
+
+class MarketWidgetTests(unittest.TestCase):
+    def test_expected_timeframes_exist(self):
+        for timeframe in ("1m", "5m", "15m", "1h", "4h", "1d"):
+            self.assertIn(f'"{timeframe}"', TEXT)
+
+    def test_many_commodity_stubs_exist_without_prices(self):
+        for symbol in ("GOLD", "SILV", "WTI", "BRENT", "NG", "COPPER", "CORN", "WHEAT", "SOY", "COFFEE", "COCOA"):
+            self.assertIn(f'"{symbol}"', TEXT)
+        self.assertNotIn('"price":', TEXT)
+
+    def test_missing_provider_data_renders_dash_and_empty_graph(self):
+        self.assertIn('return f"{symbol} {self._timeframe} —", self.muted', TEXT)
+        self.assertIn("if len(series) >= 2:", TEXT)
+
+    def test_provider_cache_is_outside_git(self):
+        self.assertIn('"QTILE_MARKET_CACHE"', TEXT)
+        self.assertIn('return root / "qtile" / "markets.json"', TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Qtile OpenRouter token-rate helper."""
+"""Tests for the Qtile OpenRouter telemetry helper."""
 
 from __future__ import annotations
 
@@ -25,9 +25,6 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(MODULE.compact_count(1_200), "1.2k")
         self.assertEqual(MODULE.compact_count(12_000_000), "12M")
 
-    def test_uses_current_nerd_font_brain_codepoint(self):
-        self.assertEqual(ord(MODULE.AI_ICON), 0xF09D1)
-
     def test_parse_token_totals_deduplicates_identical_buckets(self):
         row = {
             "created_at__minute": "2026-08-22T21:10:00Z",
@@ -42,10 +39,48 @@ class OpenRouterStatusTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "truncated"):
             MODULE.parse_token_totals(payload)
 
-    def test_parse_token_totals_rejects_malformed_metrics(self):
-        payload = {"data": {"data": [{"tokens_prompt": "wat", "tokens_completion": 1}]}}
-        with self.assertRaisesRegex(RuntimeError, "malformed"):
-            MODULE.parse_token_totals(payload)
+    def test_parse_usage_summary(self):
+        payload = {
+            "data": {
+                "data": [
+                    {"tokens_total": 100, "total_usage": 0.1},
+                    {"tokens_total": 50, "total_usage": 0.2},
+                ]
+            }
+        }
+        tokens, spend = MODULE.parse_usage_summary(payload)
+        self.assertEqual(tokens, 150)
+        self.assertAlmostEqual(spend, 0.3)
+
+    def test_period_starts_respect_local_timezone(self):
+        tz = MODULE.timezone(MODULE.timedelta(hours=-4))
+        now = MODULE.datetime(2026, 8, 22, 18, 57, tzinfo=tz)
+        starts = MODULE.period_starts(now)
+        self.assertEqual(starts["month"], MODULE.datetime(2026, 8, 1, tzinfo=tz))
+        self.assertEqual(starts["week"], MODULE.datetime(2026, 8, 17, tzinfo=tz))
+        self.assertEqual(starts["day"], MODULE.datetime(2026, 8, 22, tzinfo=tz))
+        self.assertEqual(starts["hour"], MODULE.datetime(2026, 8, 22, 18, tzinfo=tz))
+
+    def test_fetch_usage_range_uses_supported_metrics(self):
+        start = MODULE.datetime(2026, 8, 22, tzinfo=MODULE.timezone.utc)
+        end = MODULE.datetime(2026, 8, 22, 1, tzinfo=MODULE.timezone.utc)
+        response = {"data": {"data": [{"tokens_total": 100, "total_usage": 0.5}]}}
+        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
+            self.assertEqual(MODULE.fetch_usage_range("key", start, end), (100, 0.5))
+        query = request.call_args.args[3]
+        self.assertEqual(query["metrics"], ["tokens_total", "total_usage"])
+        self.assertEqual(query["granularity"], "hour")
+
+    def test_fetch_period_totals_queries_month_week_day_hour(self):
+        tz = MODULE.timezone(MODULE.timedelta(hours=-4))
+        now = MODULE.datetime(2026, 8, 22, 18, 57, tzinfo=tz)
+        with mock.patch.object(MODULE, "fetch_usage_range", return_value=(100, 0.25)) as fetch:
+            result = MODULE.fetch_period_totals("key", now)
+        self.assertEqual(fetch.call_count, 4)
+        self.assertEqual(result["tokens_month"], 100)
+        self.assertEqual(result["tokens_hour"], 100)
+        self.assertEqual(result["spend_day"], 0.25)
+        self.assertNotIn("spend_hour", result)
 
     def test_closed_window_is_previous_full_minute(self):
         now = MODULE.datetime(2026, 8, 22, 21, 10, 47, 900, tzinfo=MODULE.timezone.utc)
@@ -53,69 +88,46 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(end, MODULE.datetime(2026, 8, 22, 21, 10, tzinfo=MODULE.timezone.utc))
         self.assertEqual((end - start).total_seconds(), 60)
 
-    def test_fetch_tokens_requests_minute_granularity(self):
-        start = MODULE.datetime(2026, 8, 22, 21, 9, tzinfo=MODULE.timezone.utc)
-        end = MODULE.datetime(2026, 8, 22, 21, 10, tzinfo=MODULE.timezone.utc)
-        response = {"data": {"data": [{"tokens_prompt": 1_000, "tokens_completion": 100}]}}
-        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
-            self.assertEqual(MODULE.fetch_tokens("key", start, end), (1_000, 100))
-        payload = request.call_args.args[3]
-        self.assertEqual(payload["granularity"], "minute")
-        self.assertEqual(payload["metrics"], ["tokens_prompt", "tokens_completion"])
-
     def test_fetch_balance_uses_total_credits_minus_usage(self):
         response = {"data": {"total_credits": 25.0, "total_usage": 7.25}}
-        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
-            self.assertEqual(MODULE.fetch_balance("key"), 17.75)
-        self.assertEqual(request.call_args.args[:3], ("GET", "/credits", "key"))
-
-    def test_fetch_balance_rejects_malformed_credit_payload(self):
-        response = {"data": {"total_credits": "nope", "total_usage": 7.25}}
         with mock.patch.object(MODULE, "_request_json", return_value=response):
-            with self.assertRaisesRegex(RuntimeError, "credit payload malformed"):
-                MODULE.fetch_balance("key")
+            self.assertEqual(MODULE.fetch_balance("key"), 17.75)
 
     def test_165m_style_spike_is_rejected(self):
         with mock.patch.dict(os.environ, {"OPENROUTER_TPM_MAX": "10000000"}, clear=False):
             with self.assertRaisesRegex(RuntimeError, "implausible"):
                 MODULE.validate_rate(165_000_000, 1_000)
 
-    def test_tpm_guard_is_configurable(self):
-        with mock.patch.dict(os.environ, {"OPENROUTER_TPM_MAX": "200000000"}, clear=False):
-            MODULE.validate_rate(165_000_000, 1_000)
-
-    def test_fetch_status_keeps_previous_balance_if_credit_poll_fails(self):
-        previous = MODULE.Status(100, 10, balance_usd=9.50)
+    def test_same_closed_minute_does_not_refetch_rate(self):
+        previous = MODULE.Status(
+            100,
+            10,
+            window_end=MODULE._closed_minute_window()[1].isoformat().replace("+00:00", "Z"),
+            usage_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+            balance_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+        )
         with (
-            mock.patch.object(MODULE, "fetch_tokens", return_value=(1_000, 100)),
-            mock.patch.object(MODULE, "fetch_balance", side_effect=RuntimeError("offline")),
+            mock.patch.object(MODULE, "fetch_tokens") as fetch_tokens,
+            mock.patch.object(MODULE, "fetch_period_totals") as fetch_period,
+            mock.patch.object(MODULE, "fetch_balance") as fetch_balance,
         ):
             status = MODULE.fetch_status("key", previous)
-        self.assertEqual(status.balance_usd, 9.50)
-        self.assertEqual(status.total_tokens_per_minute, 1_100)
-        self.assertIsNotNone(status.window_end)
+        self.assertEqual(status.input_tokens_per_minute, 100)
+        fetch_tokens.assert_not_called()
+        fetch_period.assert_not_called()
+        fetch_balance.assert_not_called()
 
-    def test_management_key_prefers_dedicated_environment_variable(self):
-        with mock.patch.dict(
-            os.environ,
-            {"OPENROUTER_MANAGEMENT_KEY": "management", "OPENROUTER_API_KEY": "regular"},
-            clear=True,
-        ):
-            self.assertEqual(MODULE.load_management_key(), "management")
-
-    def test_status_cache_bounds_api_polling(self):
+    def test_status_cache_bounds_process_polling(self):
         status = MODULE.Status(1_000, 100, balance_usd=12.0, window_end="2026-08-22T21:10:00Z")
         with tempfile.TemporaryDirectory() as directory:
             with (
                 mock.patch.dict(os.environ, {"XDG_CACHE_HOME": directory}),
                 mock.patch.object(MODULE, "fetch_status", return_value=status) as fetch_status,
             ):
-                first, first_stale = MODULE.status_with_cache("key")
-                second, second_stale = MODULE.status_with_cache("key")
+                first, _ = MODULE.status_with_cache("key")
+                second, _ = MODULE.status_with_cache("key")
         self.assertEqual(first, status)
         self.assertEqual(second, status)
-        self.assertFalse(first_stale)
-        self.assertFalse(second_stale)
         self.assertEqual(fetch_status.call_count, 1)
 
 

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -22,36 +22,38 @@ def assigned_constant(name):
 
 
 class OpenRouterWidgetStructureTests(unittest.TestCase):
-    def test_five_second_rate_polling_and_five_minute_graph_capacity(self):
-        self.assertEqual(assigned_constant("POLL_SECONDS"), 5)
-        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 60)
+    def test_one_second_render_poll_and_sparse_graph_capacity(self):
+        self.assertEqual(assigned_constant("POLL_SECONDS"), 1)
+        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 300)
 
-    def test_readable_rate_font_size(self):
-        self.assertGreaterEqual(assigned_constant("RATE_FONTSIZE"), 12)
-
-    def test_credit_rate_and_graph_widgets_exist(self):
+    def test_credit_rate_graph_and_rotating_metrics_exist(self):
         classes = {node.name for node in TREE.body if isinstance(node, ast.ClassDef)}
         self.assertIn("OpenRouterCredit", classes)
         self.assertIn("OpenRouterRate", classes)
         self.assertIn("OpenRouterIOGraph", classes)
+        self.assertIn("OpenRouterRotatingMetric", classes)
 
     def test_credit_thresholds_are_preserved(self):
         self.assertIn("balance < 5", SOURCE_TEXT)
         self.assertIn("balance < 10", SOURCE_TEXT)
         self.assertIn('name="openrouter_credit"', SOURCE_TEXT)
 
+    def test_tokens_rotate_month_week_day_hour_and_spend_day_week_month(self):
+        for value in ("tokens_month", "tokens_week", "tokens_day", "tokens_hour"):
+            self.assertIn(value, SOURCE_TEXT)
+        for value in ("spend_day", "spend_week", "spend_month"):
+            self.assertIn(value, SOURCE_TEXT)
+        self.assertIn('"Button4": self.previous', SOURCE_TEXT)
+        self.assertIn('"Button5": self.next', SOURCE_TEXT)
+
     def test_rate_poll_respects_status_cache(self):
         self.assertIn('["python3", script, "--json"]', SOURCE_TEXT)
         self.assertNotIn('"--force"', SOURCE_TEXT)
-        self.assertIn('"openrouter_io_graph"', SOURCE_TEXT)
 
-    def test_rate_is_rendered_as_two_tokens_per_minute_lines(self):
-        self.assertIn("{incoming}↓/m</span>\\n", SOURCE_TEXT)
-        self.assertIn("{outgoing}↑/m{stale}</span>", SOURCE_TEXT)
-
-    def test_graph_does_not_duplicate_same_minute(self):
-        self.assertIn("self._last_window_end", SOURCE_TEXT)
+    def test_graph_only_appends_changed_trusted_sample(self):
+        self.assertIn("sample != self._last_sample", SOURCE_TEXT)
         self.assertIn('status.get("window_end")', SOURCE_TEXT)
+        self.assertIn("self._last_sample = sample", SOURCE_TEXT)
 
     def test_graph_uses_adaptive_range_and_hides_constant_series(self):
         self.assertIn("minimum = min(values)", SOURCE_TEXT)
@@ -65,7 +67,6 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
 
     def test_installs_topology_control_layer(self):
         self.assertIn("from qtile_control import install_desktop_control", SOURCE_TEXT)
-        self.assertIn("install_desktop_control(config_globals, _telemetry_widgets)", SOURCE_TEXT)
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib.util
 import tempfile
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 SOURCE = Path(__file__).resolve().parents[1] / "qtile_control.py"
@@ -29,11 +29,28 @@ class Output:
     rect: Rect
 
 
+@dataclass
+class Screen:
+    x: int
+    width: int = 1920
+
+
+@dataclass
+class Group:
+    name: str
+    label: str
+    windows: list = field(default_factory=list)
+    screen: object | None = None
+
+
 def outputs(count: int):
     return [Output(str(index), Rect(index * 1920)) for index in range(count)]
 
 
 class QtileControlTests(unittest.TestCase):
+    def setUp(self):
+        MODULE._group_owner_roles.clear()
+
     def test_n1_is_center(self):
         self.assertEqual(MODULE.screen_roles(outputs(1)), ["center"])
 
@@ -57,10 +74,39 @@ class QtileControlTests(unittest.TestCase):
         accents = [MODULE.role_accent(role) for role in ("left", "center", "right", "aux")]
         self.assertEqual(len(accents), len(set(accents)))
 
+    def test_empty_groups_are_not_visible(self):
+        groups = [
+            Group("1", "one", [object()]),
+            Group("2", "two", []),
+            Group("3", "", [object()]),
+        ]
+        self.assertEqual(
+            [group.name for group in MODULE.visible_window_groups(groups)],
+            ["1"],
+        )
+
+    def test_group_owner_tracks_screen_then_survives_hidden_group(self):
+        screens = [Screen(0), Screen(1920), Screen(3840)]
+        group = Group("1", "one", [object()], screens[0])
+        self.assertEqual(MODULE.group_owner_role(group, screens), "left")
+        group.screen = None
+        self.assertEqual(MODULE.group_owner_role(group, screens), "left")
+
+    def test_group_owner_is_cleared_when_group_becomes_empty(self):
+        screens = [Screen(0), Screen(1920), Screen(3840)]
+        group = Group("1", "one", [object()], screens[2])
+        self.assertEqual(MODULE.group_owner_role(group, screens), "right")
+        group.windows.clear()
+        self.assertIsNone(MODULE.group_owner_role(group, screens))
+        self.assertNotIn("1", MODULE._group_owner_roles)
+
     def test_private_env_parser_ignores_comments_and_expands_values(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "private.env"
-            path.write_text("# secret config\nAGENT_ZERO_HOST=http://127.0.0.1:5080\nEMPTY=\n", encoding="utf-8")
+            path.write_text(
+                "# private config\nAGENT_ZERO_HOST=http://127.0.0.1:5080\nEMPTY=\n",
+                encoding="utf-8",
+            )
             values = MODULE.parse_private_env(path)
         self.assertEqual(values["AGENT_ZERO_HOST"], "http://127.0.0.1:5080")
         self.assertEqual(values["EMPTY"], "")
@@ -71,31 +117,49 @@ class QtileControlTests(unittest.TestCase):
             path.write_text("{nope", encoding="utf-8")
             self.assertEqual(MODULE.load_workflows(path), MODULE.DEFAULT_WORKFLOWS)
 
-    def test_runtime_bar_source_has_no_weather(self):
-        self.assertNotIn("wttr.in", SOURCE_TEXT)
-        self.assertNotIn("OpenWeather", SOURCE_TEXT)
+    def test_named_outrun_palette_has_extensions(self):
+        colors = [[str(index)] * 2 for index in range(10)]
+        palette = MODULE.outrun_palette(colors)
+        self.assertEqual(palette["cyan"], "4")
+        self.assertIn("electric_blue", palette)
+        self.assertIn("violet", palette)
+        self.assertIn("yellow", palette)
 
-    def test_mpris_is_scoped_to_right_branch(self):
+    def test_right_role_contains_market_weather_and_mpris(self):
         right = SOURCE_TEXT.index('elif role == "right":')
-        mpris = SOURCE_TEXT.index("widget.Mpris2", right)
-        self.assertGreater(mpris, right)
+        self.assertGreater(SOURCE_TEXT.index("_market_widgets(config_globals)", right), right)
+        self.assertGreater(SOURCE_TEXT.index("_weather_widget(config_globals)", right), right)
+        self.assertGreater(SOURCE_TEXT.index("widget.Mpris2", right), right)
         self.assertEqual(SOURCE_TEXT.count("widget.Mpris2"), 1)
 
-    def test_center_is_only_systray_role(self):
-        self.assertEqual(SOURCE_TEXT.count("widget.Systray"), 1)
+    def test_center_restores_system_graphs(self):
         center = SOURCE_TEXT.index('if role == "center":')
-        tray = SOURCE_TEXT.index("widget.Systray", center)
-        left = SOURCE_TEXT.index('elif role == "left":')
-        self.assertLess(tray, left)
+        right = SOURCE_TEXT.index('elif role == "left":')
+        center_text = SOURCE_TEXT[center:right]
+        self.assertIn("_system_telemetry(config_globals)", center_text)
+        self.assertIn("widget.CPUGraph", SOURCE_TEXT)
+        self.assertIn("widget.MemoryGraph", SOURCE_TEXT)
+        self.assertGreaterEqual(SOURCE_TEXT.count("widget.NetGraph"), 2)
+        self.assertIn('format="{Available: .1f}{mm} free"', SOURCE_TEXT)
+        self.assertIn('format="↓{down}{down_suffix} ↑{up}{up_suffix}"', SOURCE_TEXT)
+
+    def test_exactly_one_legacy_systray_and_notifications_every_role(self):
+        self.assertEqual(SOURCE_TEXT.count("widget.Systray"), 1)
+        self.assertIn('cmd=["dunstctl", "count", "history"]', SOURCE_TEXT)
+        self.assertIn("items.append(_notification_widget(config_globals, role))", SOURCE_TEXT)
+
+    def test_volume_uses_outrun_red(self):
+        self.assertIn('widget.Volume(foreground=palette["red"]', SOURCE_TEXT)
 
     def test_org_poll_uses_async_genpollcommand(self):
         self.assertIn("widget.GenPollCommand", SOURCE_TEXT)
         self.assertIn('name="org_clocked_task"', SOURCE_TEXT)
 
-    def test_agent_zero_is_an_emacs_scratchpad(self):
-        self.assertIn('"agent-zero"', SOURCE_TEXT)
-        self.assertIn('"qtile-agent-zero"', SOURCE_TEXT)
-        self.assertIn("qtile-agent-zero-open", SOURCE_TEXT)
+    def test_agent_zero_chat_is_centered_and_todo_is_right_aligned(self):
+        self.assertIn('x=0.19,\n                    y=0.04,', SOURCE_TEXT)
+        self.assertIn('x=0.42,\n                    y=0.02,', SOURCE_TEXT)
+        self.assertIn('qtile-workflow.el', SOURCE_TEXT)
+        self.assertIn("qtile-workflow-read-right", SOURCE_TEXT)
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_qtile_workflow.py
+++ b/.config/qtile/tests/test_qtile_workflow.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Static regression tests for Emacs workflow frame placement."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile-workflow.el"
+TEXT = SOURCE.read_text(encoding="utf-8")
+
+
+class WorkflowFrameTests(unittest.TestCase):
+    def test_workflow_picker_is_right_aligned_and_top_aligned(self):
+        self.assertIn("(left . 1.0)", TEXT)
+        self.assertIn("(top . 0.0)", TEXT)
+        self.assertIn("(user-position . t)", TEXT)
+        self.assertIn('completing-read "Qtile workflow: "', TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_weather_status.py
+++ b/.config/qtile/tests/test_weather_status.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Tests for the Qtile Open-Meteo helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "weather_status.py"
+SPEC = importlib.util.spec_from_file_location("weather_status", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class WeatherStatusTests(unittest.TestCase):
+    def test_configured_coordinates_do_not_require_geocoding(self):
+        with mock.patch.dict(
+            os.environ,
+            {"WEATHER_LATITUDE": "40.0", "WEATHER_LONGITUDE": "-83.0", "WEATHER_LABEL": "Home"},
+            clear=True,
+        ):
+            self.assertEqual(MODULE.configured_coordinates(), (40.0, -83.0, "Home"))
+
+    def test_location_is_required_when_coordinates_are_absent(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "WEATHER_LOCATION"):
+                MODULE.resolve_location()
+
+    def test_parse_current_and_render_imperial(self):
+        payload = {
+            "current": {
+                "temperature_2m": 72.4,
+                "apparent_temperature": 71.8,
+                "precipitation": 0,
+                "weather_code": 1,
+                "wind_speed_10m": 8.2,
+            }
+        }
+        parsed = MODULE.parse_current(payload, "Test")
+        with mock.patch.dict(os.environ, {"WEATHER_UNITS": "imperial"}, clear=True):
+            text = MODULE.render(parsed)
+        self.assertIn("Test 72°F", text)
+        self.assertIn("8 mph", text)
+
+    def test_forecast_url_uses_open_meteo_and_no_api_key(self):
+        with mock.patch.dict(os.environ, {"WEATHER_UNITS": "metric"}, clear=True):
+            url = MODULE.weather_url(40.0, -83.0)
+        self.assertTrue(url.startswith(MODULE.FORECAST_URL))
+        self.assertIn("temperature_unit=celsius", url)
+        self.assertNotIn("apikey", url.casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Re-lands #118 (reverted in #124) with the navigation defect fixed.

## Root cause of the revert (likely)

Qtile 0.33.0 `GroupBox.next_group`/`prev_group` cycle until they find a member of `self.groups`:

```python
while group is None or group not in self.groups:
    group = next(i)
```

OwnedGroupBox filters `groups` to window-owning groups. With **zero visible groups** (all groups empty), the base implementation spins forever, stalling the Qtile event loop. Mouse wheel over the bar (Button4/5, enabled by default) triggers exactly these methods.

## Fix

- `next_visible_group` bounded helper: returns `None` on empty visible set instead of cycling forever.
- OwnedGroupBox overrides `next_group`/`prev_group` to navigate only among visible groups and no-op when nothing is visible.

## Regression tests

9 new widget-level tests in `.config/qtile/tests/test_groupbox_navigation.py`, built against a **verbatim Qtile 0.33.0 stub base** — if the overrides are removed, the verbatim base spins and the alarm guard fails the test loudly instead of hanging CI:
- zero visible groups (the revert scenario) terminates
- next/prev skip windowless groups and wrap around
- navigation from an empty current group lands on a visible group
- visible_groups restriction is respected
- single visible group navigates to itself
- N=4 full cycle visits every group

Full suite: 91/91 passing locally.

## Also vs #118
- rebased onto current master (post-revert + flake bump)
- same bar architecture: role-scoped bars, ownership-colored groups, per-screen notifications, single systray, MPRIS right-only, telemetry center-scoped