### PR TITLE
feat(qtile): persistent OpenRouter graph history and Org-screen sync controls

### DIFF
--- a/.config/qtile/openrouter_history.py
+++ b/.config/qtile/openrouter_history.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Persistent, local OpenRouter telemetry history and graph aggregation."""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+TIMEFRAMES: tuple[tuple[str, int], ...] = (
+    ("1m", 60),
+    ("5m", 5 * 60),
+    ("1h", 60 * 60),
+    ("6h", 6 * 60 * 60),
+    ("12h", 12 * 60 * 60),
+    ("1d", 24 * 60 * 60),
+    ("1w", 7 * 24 * 60 * 60),
+    ("1mo", 30 * 24 * 60 * 60),
+    ("1y", 365 * 24 * 60 * 60),
+)
+TIMEFRAME_SECONDS = dict(TIMEFRAMES)
+
+
+def history_path() -> Path:
+    configured = os.environ.get("OPENROUTER_HISTORY_DB")
+    if configured:
+        return Path(configured).expanduser()
+    root = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    return root / "qtile" / "openrouter-history.sqlite3"
+
+
+def _connect(path: Path | None = None) -> sqlite3.Connection:
+    path = path or history_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path, timeout=2.0)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA busy_timeout=2000")
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS usage_samples (
+            bucket_start INTEGER NOT NULL,
+            bucket_seconds INTEGER NOT NULL CHECK(bucket_seconds > 0),
+            input_tokens INTEGER NOT NULL CHECK(input_tokens >= 0),
+            output_tokens INTEGER NOT NULL CHECK(output_tokens >= 0),
+            spend REAL,
+            source TEXT NOT NULL,
+            PRIMARY KEY (bucket_start, bucket_seconds)
+        );
+        CREATE INDEX IF NOT EXISTS usage_samples_window
+            ON usage_samples(bucket_start, bucket_seconds);
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """
+    )
+    return connection
+
+
+def _epoch(value: datetime | int | float) -> int:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp())
+    return int(value)
+
+
+def upsert_sample(
+    bucket_start: datetime | int | float,
+    bucket_seconds: int,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    spend: float | None = None,
+    source: str = "live",
+    path: Path | None = None,
+) -> None:
+    """Idempotently persist one truthful provider bucket."""
+    start = _epoch(bucket_start)
+    duration = max(int(bucket_seconds), 1)
+    incoming = max(int(input_tokens), 0)
+    outgoing = max(int(output_tokens), 0)
+    with _connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO usage_samples
+                (bucket_start, bucket_seconds, input_tokens, output_tokens, spend, source)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(bucket_start, bucket_seconds) DO UPDATE SET
+                input_tokens=excluded.input_tokens,
+                output_tokens=excluded.output_tokens,
+                spend=COALESCE(excluded.spend, usage_samples.spend),
+                source=excluded.source
+            """,
+            (start, duration, incoming, outgoing, spend, source),
+        )
+
+
+def set_metadata(key: str, value: str, *, path: Path | None = None) -> None:
+    with _connect(path) as connection:
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, value),
+        )
+
+
+def get_metadata(key: str, *, path: Path | None = None) -> str | None:
+    with _connect(path) as connection:
+        row = connection.execute("SELECT value FROM metadata WHERE key=?", (key,)).fetchone()
+    return None if row is None else str(row["value"])
+
+
+def claim_due(key: str, interval_seconds: float, *, path: Path | None = None) -> bool:
+    """Atomically claim periodic work so 1 Hz collectors do not fan it out."""
+    now = time.time()
+    with _connect(path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute("SELECT value FROM metadata WHERE key=?", (key,)).fetchone()
+        try:
+            last = float(row["value"]) if row is not None else 0.0
+        except (TypeError, ValueError):
+            last = 0.0
+        if now - last < interval_seconds:
+            connection.rollback()
+            return False
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, str(now)),
+        )
+        connection.commit()
+    return True
+
+
+def _aligned_end(now: datetime | int | float | None = None) -> int:
+    stamp = _epoch(now or datetime.now(timezone.utc))
+    return stamp - stamp % 60
+
+
+def _overlaps(start: int, end: int, accepted: Iterable[tuple[int, int]]) -> bool:
+    return any(start < other_end and end > other_start for other_start, other_end in accepted)
+
+
+def _window_rows(
+    label: str,
+    *,
+    now: datetime | int | float | None = None,
+    path: Path | None = None,
+) -> tuple[int, int, list[sqlite3.Row]]:
+    duration = TIMEFRAME_SECONDS[label]
+    end = _aligned_end(now)
+    start = end - duration
+    with _connect(path) as connection:
+        rows = connection.execute(
+            """
+            SELECT bucket_start, bucket_seconds, input_tokens, output_tokens, spend, source
+              FROM usage_samples
+             WHERE bucket_start >= ?
+               AND bucket_start + bucket_seconds <= ?
+             ORDER BY bucket_seconds DESC, bucket_start ASC
+            """,
+            (start, end),
+        ).fetchall()
+
+    # Coarser complete provider buckets win where granularities overlap. This
+    # prevents a later hourly backfill from double-counting live minute rows.
+    accepted_intervals: list[tuple[int, int]] = []
+    accepted_rows: list[sqlite3.Row] = []
+    for row in rows:
+        row_start = int(row["bucket_start"])
+        row_end = row_start + int(row["bucket_seconds"])
+        if _overlaps(row_start, row_end, accepted_intervals):
+            continue
+        accepted_intervals.append((row_start, row_end))
+        accepted_rows.append(row)
+    accepted_rows.sort(key=lambda row: int(row["bucket_start"]))
+    return start, end, accepted_rows
+
+
+def query_series(
+    label: str,
+    *,
+    points: int = 82,
+    now: datetime | int | float | None = None,
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Return truthful average token-rate samples for one display range.
+
+    Provider buckets are never interpolated. If the history is coarse, the
+    result intentionally contains fewer points rather than inventing detail.
+    """
+    if label not in TIMEFRAME_SECONDS:
+        raise ValueError(f"unknown OpenRouter history range: {label}")
+    point_limit = max(int(points), 1)
+    start, end, rows = _window_rows(label, now=now, path=path)
+    samples = [
+        {
+            "timestamp": int(row["bucket_start"]) + int(row["bucket_seconds"]) / 2.0,
+            "input": float(row["input_tokens"]) * 60.0 / int(row["bucket_seconds"]),
+            "output": float(row["output_tokens"]) * 60.0 / int(row["bucket_seconds"]),
+            "bucket_seconds": int(row["bucket_seconds"]),
+            "source": str(row["source"]),
+        }
+        for row in rows
+    ]
+
+    if len(samples) > point_limit:
+        chunk_size = int(math.ceil(len(samples) / point_limit))
+        reduced: list[dict[str, Any]] = []
+        for offset in range(0, len(samples), chunk_size):
+            chunk = samples[offset : offset + chunk_size]
+            weights = [max(int(item["bucket_seconds"]), 1) for item in chunk]
+            total_weight = float(sum(weights))
+            reduced.append(
+                {
+                    "timestamp": sum(float(item["timestamp"]) * weight for item, weight in zip(chunk, weights)) / total_weight,
+                    "input": sum(float(item["input"]) * weight for item, weight in zip(chunk, weights)) / total_weight,
+                    "output": sum(float(item["output"]) * weight for item, weight in zip(chunk, weights)) / total_weight,
+                    "bucket_seconds": sum(weights),
+                    "source": "aggregate",
+                }
+            )
+        samples = reduced
+
+    ceiling = max(
+        [float(item["input"]) for item in samples]
+        + [float(item["output"]) for item in samples]
+        + [0.0]
+    )
+    return {
+        "range": label,
+        "start": start,
+        "end": end,
+        "ceiling": ceiling,
+        "samples": samples,
+    }
+
+
+def summary(*, path: Path | None = None) -> dict[str, Any]:
+    with _connect(path) as connection:
+        row = connection.execute(
+            "SELECT COUNT(*) AS rows, MIN(bucket_start) AS oldest, "
+            "MAX(bucket_start + bucket_seconds) AS newest FROM usage_samples"
+        ).fetchone()
+    return {
+        "path": str(path or history_path()),
+        "rows": int(row["rows"] or 0),
+        "oldest": row["oldest"],
+        "newest": row["newest"],
+    }

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -3,16 +3,14 @@
 
 * Runtime helper
 
-This file is the source of truth for the OpenRouter widgets and the
+This file is the source of truth for the OpenRouter Qtile widgets and the
 =Super+Ctrl+Shift+R= dotfiles sync-and-reload binding.
 
-The Qtile layer repaints telemetry every second while the collector independently
-bounds provider calls. The token graph appends only when a trusted sample changes.
-Account balance stays visible, token totals rotate month/week/day/hour, and spend
-rotates day/week/month. Mouse wheel cycles either rotating metric manually.
-
-Rate telemetry keeps the complete-minute sanity guard that rejects malformed,
-truncated, negative, duplicated, or implausibly large analytics results.
+The collector persists trusted provider buckets in a local SQLite history under
+=XDG_STATE_HOME=.  The graph reads that local store and visibly rotates every
+five seconds through =1m → 5m → 1h → 6h → 12h → 1d → 1w → 1mo → 1y=.
+Provider buckets are never interpolated to invent detail.  Input and output use
+one shared scale so their relative magnitude remains truthful.
 
 #+begin_src python
 """OpenRouter telemetry widgets and Qtile runtime helpers."""
@@ -25,24 +23,29 @@ import shutil
 import subprocess
 import threading
 import time
-from collections import deque
 from pathlib import Path
 
 from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
+import openrouter_history
+
 POLL_SECONDS = 1
-GRAPH_SAMPLES = 300
-GRAPH_WIDTH = 82
+GRAPH_SAMPLES = 82
+GRAPH_WIDTH = 96
 RATE_FONTSIZE = 12
 ROTATE_SECONDS = 5
+GRAPH_RANGES = tuple(label for label, _seconds in openrouter_history.TIMEFRAMES)
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
 _last_payload = None
 _sync_lock = threading.Lock()
 _sync_in_progress = False
+_graph_lock = threading.Lock()
+_graph_range_index = 0
+_graph_range_changed_at = time.monotonic()
 
 
 def _color(colors, index):
@@ -99,9 +102,11 @@ def _fetch_payload(script):
         if cached:
             payload = dict(cached)
             payload["stale"] = True
+            if isinstance(payload, dict) and completed.stderr:
+                payload.setdefault("last_error", completed.stderr.strip())
             _last_payload = payload
             return payload
-        return None
+        return payload if isinstance(payload, dict) else None
 
 
 def _notify(summary, body="", urgency="normal"):
@@ -165,6 +170,26 @@ def _sync_and_reload(qtile):
     threading.Thread(target=worker, name="qtile-dotfiles-sync", daemon=True).start()
 
 
+def _rotate_graph_range(now=None):
+    global _graph_range_index, _graph_range_changed_at
+    with _graph_lock:
+        now = time.monotonic() if now is None else float(now)
+        elapsed = now - _graph_range_changed_at
+        if elapsed >= ROTATE_SECONDS:
+            steps = max(int(elapsed // ROTATE_SECONDS), 1)
+            _graph_range_index = (_graph_range_index + steps) % len(GRAPH_RANGES)
+            _graph_range_changed_at += steps * ROTATE_SECONDS
+        return GRAPH_RANGES[_graph_range_index]
+
+
+def _step_graph_range(step):
+    global _graph_range_index, _graph_range_changed_at
+    with _graph_lock:
+        _graph_range_index = (_graph_range_index + int(step)) % len(GRAPH_RANGES)
+        _graph_range_changed_at = time.monotonic()
+        return GRAPH_RANGES[_graph_range_index]
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -203,14 +228,16 @@ class OpenRouterRate(base.BackgroundPoll):
 
     def poll(self):
         payload = _fetch_payload(self.script)
-        if not payload:
-            return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
+        if not payload or payload.get("error"):
+            reason = (payload or {}).get("error", "offline")
+            return f'<span foreground="{_color(self.colors, 8)}">AI {reason}</span>'
         incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
         outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
+        warning = " !" if payload.get("last_error") else ""
         stale = " ~" if payload.get("stale") else ""
         return (
             f'<span foreground="{_color(self.colors, 6)}">{incoming}↓/m</span>\n'
-            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{stale}</span>'
+            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{warning}{stale}</span>'
         )
 
 
@@ -226,18 +253,9 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         self.index = 0
         self.last_rotate = time.monotonic()
         self.specs = (
-            (
-                ("M", "tokens_month"),
-                ("W", "tokens_week"),
-                ("D", "tokens_day"),
-                ("H", "tokens_hour"),
-            )
+            (("M", "tokens_month"), ("W", "tokens_week"), ("D", "tokens_day"), ("H", "tokens_hour"))
             if metric == "tokens"
-            else (
-                ("D", "spend_day"),
-                ("W", "spend_week"),
-                ("M", "spend_month"),
-            )
+            else (("D", "spend_day"), ("W", "spend_week"), ("M", "spend_month"))
         )
         self.icon = "" if metric == "tokens" else ""
         super().__init__(text=f"{self.icon} …", **config)
@@ -267,7 +285,7 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         color_index = (4, 6, 3, 7)[self.index % 4]
         color = _color(self.colors, color_index)
         if value is None:
-            rendered = "—"
+            rendered = "!" if payload.get("usage_error") else "—"
         elif self.metric == "tokens":
             rendered = _compact_count(value)
         else:
@@ -275,13 +293,36 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         return f'<span foreground="{color}">{self.icon} {label} {rendered}</span>'
 
 
+class OpenRouterGraphRange(base.BackgroundPoll):
+    """Visible controller for the persistent graph range."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, colors, **config):
+        self.colors = colors
+        super().__init__(text="󰓅 1m", **config)
+        self.add_callbacks({"Button1": self.next, "Button4": self.previous, "Button5": self.next})
+
+    def previous(self):
+        _step_graph_range(-1)
+        self.tick()
+
+    def next(self):
+        _step_graph_range(1)
+        self.tick()
+
+    def poll(self):
+        label = _rotate_graph_range()
+        return f'<span foreground="{_color(self.colors, 3)}">󰓅 {label}</span>'
+
+
 class OpenRouterIOGraph(base._Widget):
-    """Sparkline of trusted input/output token-rate samples."""
+    """Persistent input/output graph with one truthful shared Y scale."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Maximum number of changed samples."),
+        ("samples", GRAPH_SAMPLES, "Maximum local history points."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -293,47 +334,45 @@ class OpenRouterIOGraph(base._Widget):
     def __init__(self, width=GRAPH_WIDTH, **config):
         super().__init__(width, **config)
         self.add_defaults(self.defaults)
-        self.input_values = deque(maxlen=self.samples)
-        self.output_values = deque(maxlen=self.samples)
-        self._last_sample = None
+        self.series = {"range": "1m", "start": 0, "end": 1, "ceiling": 0, "samples": []}
+        self._last_signature = None
 
     def timer_setup(self):
         self._update()
         self.timeout_add(self.frequency, self.timer_setup)
 
     def _update(self):
-        status = _read_cached_status()
-        if status:
-            sample = (
-                status.get("window_end"),
-                status.get("input_tokens_per_minute"),
-                status.get("output_tokens_per_minute"),
-            )
-            if sample != self._last_sample and sample[0] is not None:
-                self.input_values.append(float(sample[1] or 0))
-                self.output_values.append(float(sample[2] or 0))
-                self._last_sample = sample
-                self.draw()
+        label = _rotate_graph_range()
+        try:
+            series = openrouter_history.query_series(label, points=self.samples)
+        except (OSError, ValueError):
+            return
+        samples = series.get("samples", [])
+        newest = samples[-1].get("timestamp") if samples else None
+        signature = (label, len(samples), newest, series.get("ceiling"))
+        if signature != self._last_signature:
+            self.series = series
+            self._last_signature = signature
+            self.draw()
 
-    def _draw_series(self, values, color, center_y, half_height, direction):
-        if len(values) < 2:
+    def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
+        samples = self.series.get("samples", [])
+        if not samples or ceiling <= 0:
             return
-        values = list(values)
-        minimum = min(values)
-        maximum = max(values)
-        if maximum <= minimum:
-            return
-        span = maximum - minimum
+        start = float(self.series.get("start", 0))
+        end = float(self.series.get("end", start + 1))
+        span = max(end - start, 1.0)
         usable_width = max(self.width - 2 * self.margin_x, 1)
-        step = usable_width / max(len(values) - 1, 1)
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-        for index, value in enumerate(values):
-            x = self.margin_x + index * step
-            normalized = (float(value) - minimum) / span
-            distance = (0.15 + 0.85 * normalized) * half_height
-            y = center_y + direction * distance
-            if index == 0:
+        for index, sample in enumerate(samples):
+            x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
+            normalized = min(max(float(sample.get(key, 0)) / ceiling, 0.0), 1.0)
+            y = center_y + direction * normalized * half_height
+            if len(samples) == 1:
+                self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
+                self.drawer.ctx.line_to(min(self.width - self.margin_x, x + 2), y)
+            elif index == 0:
                 self.drawer.ctx.move_to(x, y)
             else:
                 self.drawer.ctx.line_to(x, y)
@@ -348,8 +387,9 @@ class OpenRouterIOGraph(base._Widget):
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
-        self._draw_series(self.input_values, self.input_color, center_y, half_height, -1)
-        self._draw_series(self.output_values, self.output_color, center_y, half_height, 1)
+        ceiling = float(self.series.get("ceiling") or 0)
+        self._draw_series("input", self.input_color, center_y, half_height, -1, ceiling)
+        self._draw_series("output", self.output_color, center_y, half_height, 1, ceiling)
         self.draw_at_default_position()
 
 
@@ -390,6 +430,7 @@ def _telemetry_widgets(home, colors):
     return [
         OpenRouterCredit(script, colors, name="openrouter_credit", **common),
         OpenRouterRate(script, colors, name="openrouter_rate", **common),
+        OpenRouterGraphRange(colors, name="openrouter_graph_range", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",
             frequency=POLL_SECONDS,
@@ -399,12 +440,8 @@ def _telemetry_widgets(home, colors):
             midline_color=_color(colors, 2),
             background=background,
         ),
-        OpenRouterRotatingMetric(
-            script, colors, "tokens", name="openrouter_token_totals", **common
-        ),
-        OpenRouterRotatingMetric(
-            script, colors, "spend", name="openrouter_spend_totals", **common
-        ),
+        OpenRouterRotatingMetric(script, colors, "tokens", name="openrouter_token_totals", **common),
+        OpenRouterRotatingMetric(script, colors, "spend", name="openrouter_spend_totals", **common),
     ]
 
 

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -7,8 +7,9 @@ This file is the source of truth for the OpenRouter Qtile widgets and the
 =Super+Ctrl+Shift+R= dotfiles sync-and-reload binding.
 
 The collector persists trusted provider buckets in a local SQLite history under
-=XDG_STATE_HOME=.  The graph reads that local store and visibly rotates every
-five seconds through =1m → 5m → 1h → 6h → 12h → 1d → 1w → 1mo → 1y=.
+=XDG_STATE_HOME=.  The graph reads that local store from a daemon worker so a
+SQLite lock cannot stall Qtile's event loop, then visibly rotates every five
+seconds through =1m → 5m → 1h → 6h → 12h → 1d → 1w → 1mo → 1y=.
 Provider buckets are never interpolated to invent detail.  Input and output use
 one shared scale so their relative magnitude remains truthful.
 
@@ -102,11 +103,16 @@ def _fetch_payload(script):
         if cached:
             payload = dict(cached)
             payload["stale"] = True
-            if isinstance(payload, dict) and completed.stderr:
+            if completed.stderr:
                 payload.setdefault("last_error", completed.stderr.strip())
             _last_payload = payload
             return payload
-        return payload if isinstance(payload, dict) else None
+        if isinstance(payload, dict):
+            # Cache provider/auth error payloads for the same one-second window
+            # too; five widgets should not fan out five failing subprocesses.
+            _last_payload = payload
+            return payload
+        return None
 
 
 def _notify(summary, body="", urgency="normal"):
@@ -336,6 +342,8 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.series = {"range": "1m", "start": 0, "end": 1, "ceiling": 0, "samples": []}
         self._last_signature = None
+        self._query_lock = threading.Lock()
+        self._query_running = False
 
     def timer_setup(self):
         self._update()
@@ -343,17 +351,51 @@ class OpenRouterIOGraph(base._Widget):
 
     def _update(self):
         label = _rotate_graph_range()
-        try:
-            series = openrouter_history.query_series(label, points=self.samples)
-        except (OSError, ValueError):
-            return
-        samples = series.get("samples", [])
-        newest = samples[-1].get("timestamp") if samples else None
-        signature = (label, len(samples), newest, series.get("ceiling"))
-        if signature != self._last_signature:
-            self.series = series
-            self._last_signature = signature
-            self.draw()
+        with self._query_lock:
+            if self._query_running:
+                return
+            self._query_running = True
+
+        def worker():
+            try:
+                series = openrouter_history.query_series(label, points=self.samples)
+            except Exception:
+                series = None
+
+            def apply():
+                with self._query_lock:
+                    self._query_running = False
+                if series is None:
+                    return
+                samples = series.get("samples", [])
+                signature = (
+                    label,
+                    tuple(
+                        (
+                            sample.get("timestamp"),
+                            sample.get("input"),
+                            sample.get("output"),
+                            sample.get("bucket_seconds"),
+                        )
+                        for sample in samples
+                    ),
+                )
+                if signature != self._last_signature:
+                    self.series = series
+                    self._last_signature = signature
+                    self.draw()
+
+            try:
+                self.qtile.call_soon_threadsafe(apply)
+            except Exception:
+                with self._query_lock:
+                    self._query_running = False
+
+        threading.Thread(
+            target=worker,
+            name="qtile-openrouter-graph",
+            daemon=True,
+        ).start()
 
     def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
         samples = self.series.get("samples", [])

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -632,6 +632,8 @@ def build_screen_widgets(
     role: str,
     config_globals: dict[str, Any],
     telemetry_widgets_factory: Callable[[str, Any], list[Any]],
+    *,
+    show_date: bool | None = None,
 ):
     from libqtile import widget
     from libqtile.lazy import lazy
@@ -642,6 +644,12 @@ def build_screen_widgets(
     foreground = palette["white"]
     items = _base_widgets(config_globals)
     role = base_role(role)
+    if show_date is None:
+        # Compatibility fallback for direct screen_widgets() callers. The
+        # generated multi-monitor layout overrides this so the left Org screen
+        # owns the single date whenever that role exists.
+        show_date = role == "center"
+    clock_format = "󰃭 %Y-%m-%d   %H:%M" if show_date else " %H:%M"
 
     if role == "center":
         items.extend(telemetry_widgets_factory(home, config_globals["colors"]))
@@ -663,7 +671,7 @@ def build_screen_widgets(
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format="󰃭 %Y-%m-%d   %H:%M",
+                    format=clock_format,
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
                 widget.Systray(background=background, icon_size=20, padding=4),
@@ -716,7 +724,7 @@ def build_screen_widgets(
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format=" %H:%M",
+                    format=clock_format,
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
@@ -742,7 +750,7 @@ def build_screen_widgets(
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format=" %H:%M",
+                    format=clock_format,
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
@@ -755,7 +763,7 @@ def build_screen_widgets(
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format=" %H:%M",
+                    format=clock_format,
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
@@ -815,15 +823,21 @@ def install_desktop_control(
     load_private_env()
     _install_control_scratchpad(config_globals)
 
-    def screen_widgets(role: str = "center"):
-        return build_screen_widgets(role, config_globals, telemetry_widgets_factory)
+    def screen_widgets(role: str = "center", show_date: bool | None = None):
+        return build_screen_widgets(
+            role,
+            config_globals,
+            telemetry_widgets_factory,
+            show_date=show_date,
+        )
 
     def generate_screens(output_info):
         roles = screen_roles(output_info)
+        date_role = "left" if any(base_role(role) == "left" for role in roles) else "center"
         return [
             Screen(
                 top=bar.Bar(
-                    screen_widgets(role),
+                    screen_widgets(role, show_date=base_role(role) == date_role),
                     26,
                     opacity=0.8,
                 )

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -34,7 +34,10 @@ PRIVATE_ENV_PATH = Path("~/.config/qtile/private.env").expanduser()
 WORKFLOWS_PATH = Path("~/.config/qtile/workflows.json").expanduser()
 EMACS_HELPER = Path("~/.config/qtile/qtile-desktop.el").expanduser()
 WORKFLOW_HELPER = Path("~/.config/qtile/qtile-workflow.el").expanduser()
+GPT_TODOS_SYNC = Path("~/.dotfiles/scripts/gpt-todos-sync").expanduser()
 _group_owner_roles: dict[str, str] = {}
+_gpt_todos_sync_lock = threading.Lock()
+_gpt_todos_sync_running = False
 
 
 def _geometry(item: Any) -> tuple[int, int]:
@@ -249,6 +252,40 @@ def _notify(summary: str, body: str = "") -> None:
         pass
 
 
+def _sync_gpt_todos(_qtile: Any) -> None:
+    """Run GPT TODO synchronization off the Qtile event loop."""
+    global _gpt_todos_sync_running
+    with _gpt_todos_sync_lock:
+        if _gpt_todos_sync_running:
+            _notify("GPT TODO sync", "Already syncing.")
+            return
+        _gpt_todos_sync_running = True
+    _notify("GPT TODO sync", "Synchronizing all agenda files…")
+
+    def worker() -> None:
+        global _gpt_todos_sync_running
+        try:
+            completed = subprocess.run(
+                ["bash", str(GPT_TODOS_SYNC)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            detail = (completed.stderr or completed.stdout or "").strip()
+            if completed.returncode == 0:
+                _notify("GPT TODO sync complete", detail[-500:] or "Agenda files are synchronized.")
+            else:
+                _notify("GPT TODO sync failed", detail[-800:] or f"exit {completed.returncode}")
+        except (OSError, subprocess.SubprocessError) as error:
+            _notify("GPT TODO sync failed", str(error))
+        finally:
+            with _gpt_todos_sync_lock:
+                _gpt_todos_sync_running = False
+
+    threading.Thread(target=worker, name="qtile-gpt-todos-sync", daemon=True).start()
+
+
 def _role_to_screen_index(screens: Iterable[Any]) -> dict[str, int]:
     screens = list(screens)
     roles = screen_roles(screens)
@@ -347,10 +384,6 @@ def _owned_group_box(config_globals: dict[str, Any]):
             return groups
 
         def next_group(self):
-            # Qtile <=0.33 next_group cycles until it finds a member of
-            # self.groups; an empty visible set would spin forever and stall
-            # the Qtile event loop. Navigate only among visible groups and
-            # never loop when nothing is visible.
             group = next_visible_group(self.groups, self.qtile.current_group)
             if group is not None:
                 self.go_to_group(group)
@@ -626,10 +659,11 @@ def build_screen_widgets(
                     },
                 ),
                 widget.Clock(
+                    font="Hack Nerd Regular",
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format="%Y-%m-%d %H:%M",
+                    format="󰃭 %Y-%m-%d   %H:%M",
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
                 widget.Systray(background=background, icon_size=20, padding=4),
@@ -661,6 +695,14 @@ def build_screen_widgets(
                     },
                 ),
                 widget.TextBox(
+                    name="gpt_todos_sync_button",
+                    text=" 󰑓 SYNC ",
+                    font="Hack Nerd Regular",
+                    foreground=palette["green"],
+                    background=background,
+                    mouse_callbacks={"Button1": lazy.function(_sync_gpt_todos)},
+                ),
+                widget.TextBox(
                     name="workflow_button",
                     text=" WF ",
                     foreground=palette["orange"],
@@ -670,10 +712,11 @@ def build_screen_widgets(
                     },
                 ),
                 widget.Clock(
+                    font="Hack Nerd Regular",
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format="%H:%M",
+                    format=" %H:%M",
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
@@ -695,10 +738,11 @@ def build_screen_widgets(
                     markup=False,
                 ),
                 widget.Clock(
+                    font="Hack Nerd Regular",
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format="%H:%M",
+                    format=" %H:%M",
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
@@ -707,10 +751,11 @@ def build_screen_widgets(
         items.extend(
             [
                 widget.Clock(
+                    font="Hack Nerd Regular",
                     foreground=foreground,
                     background=background,
                     fontsize=12,
-                    format="%H:%M",
+                    format=" %H:%M",
                 ),
                 widget.Volume(foreground=palette["red"], background=background),
             ]

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -8,24 +8,29 @@ import shutil
 import subprocess
 import threading
 import time
-from collections import deque
 from pathlib import Path
 
 from libqtile.config import Key
 from libqtile.lazy import lazy
 from libqtile.widget import base
 
+import openrouter_history
+
 POLL_SECONDS = 1
-GRAPH_SAMPLES = 300
-GRAPH_WIDTH = 82
+GRAPH_SAMPLES = 82
+GRAPH_WIDTH = 96
 RATE_FONTSIZE = 12
 ROTATE_SECONDS = 5
+GRAPH_RANGES = tuple(label for label, _seconds in openrouter_history.TIMEFRAMES)
 
 _poll_lock = threading.Lock()
 _last_poll_at = 0.0
 _last_payload = None
 _sync_lock = threading.Lock()
 _sync_in_progress = False
+_graph_lock = threading.Lock()
+_graph_range_index = 0
+_graph_range_changed_at = time.monotonic()
 
 
 def _color(colors, index):
@@ -82,9 +87,11 @@ def _fetch_payload(script):
         if cached:
             payload = dict(cached)
             payload["stale"] = True
+            if isinstance(payload, dict) and completed.stderr:
+                payload.setdefault("last_error", completed.stderr.strip())
             _last_payload = payload
             return payload
-        return None
+        return payload if isinstance(payload, dict) else None
 
 
 def _notify(summary, body="", urgency="normal"):
@@ -148,6 +155,26 @@ def _sync_and_reload(qtile):
     threading.Thread(target=worker, name="qtile-dotfiles-sync", daemon=True).start()
 
 
+def _rotate_graph_range(now=None):
+    global _graph_range_index, _graph_range_changed_at
+    with _graph_lock:
+        now = time.monotonic() if now is None else float(now)
+        elapsed = now - _graph_range_changed_at
+        if elapsed >= ROTATE_SECONDS:
+            steps = max(int(elapsed // ROTATE_SECONDS), 1)
+            _graph_range_index = (_graph_range_index + steps) % len(GRAPH_RANGES)
+            _graph_range_changed_at += steps * ROTATE_SECONDS
+        return GRAPH_RANGES[_graph_range_index]
+
+
+def _step_graph_range(step):
+    global _graph_range_index, _graph_range_changed_at
+    with _graph_lock:
+        _graph_range_index = (_graph_range_index + int(step)) % len(GRAPH_RANGES)
+        _graph_range_changed_at = time.monotonic()
+        return GRAPH_RANGES[_graph_range_index]
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -186,14 +213,16 @@ class OpenRouterRate(base.BackgroundPoll):
 
     def poll(self):
         payload = _fetch_payload(self.script)
-        if not payload:
-            return f'<span foreground="{_color(self.colors, 8)}">AI offline</span>'
+        if not payload or payload.get("error"):
+            reason = (payload or {}).get("error", "offline")
+            return f'<span foreground="{_color(self.colors, 8)}">AI {reason}</span>'
         incoming = _compact_count(payload.get("input_tokens_per_minute", 0))
         outgoing = _compact_count(payload.get("output_tokens_per_minute", 0))
+        warning = " !" if payload.get("last_error") else ""
         stale = " ~" if payload.get("stale") else ""
         return (
             f'<span foreground="{_color(self.colors, 6)}">{incoming}↓/m</span>\n'
-            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{stale}</span>'
+            f'<span foreground="{_color(self.colors, 4)}">{outgoing}↑/m{warning}{stale}</span>'
         )
 
 
@@ -209,18 +238,9 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         self.index = 0
         self.last_rotate = time.monotonic()
         self.specs = (
-            (
-                ("M", "tokens_month"),
-                ("W", "tokens_week"),
-                ("D", "tokens_day"),
-                ("H", "tokens_hour"),
-            )
+            (("M", "tokens_month"), ("W", "tokens_week"), ("D", "tokens_day"), ("H", "tokens_hour"))
             if metric == "tokens"
-            else (
-                ("D", "spend_day"),
-                ("W", "spend_week"),
-                ("M", "spend_month"),
-            )
+            else (("D", "spend_day"), ("W", "spend_week"), ("M", "spend_month"))
         )
         self.icon = "" if metric == "tokens" else ""
         super().__init__(text=f"{self.icon} …", **config)
@@ -250,7 +270,7 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         color_index = (4, 6, 3, 7)[self.index % 4]
         color = _color(self.colors, color_index)
         if value is None:
-            rendered = "—"
+            rendered = "!" if payload.get("usage_error") else "—"
         elif self.metric == "tokens":
             rendered = _compact_count(value)
         else:
@@ -258,13 +278,36 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         return f'<span foreground="{color}">{self.icon} {label} {rendered}</span>'
 
 
+class OpenRouterGraphRange(base.BackgroundPoll):
+    """Visible controller for the persistent graph range."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+
+    def __init__(self, colors, **config):
+        self.colors = colors
+        super().__init__(text="󰓅 1m", **config)
+        self.add_callbacks({"Button1": self.next, "Button4": self.previous, "Button5": self.next})
+
+    def previous(self):
+        _step_graph_range(-1)
+        self.tick()
+
+    def next(self):
+        _step_graph_range(1)
+        self.tick()
+
+    def poll(self):
+        label = _rotate_graph_range()
+        return f'<span foreground="{_color(self.colors, 3)}">󰓅 {label}</span>'
+
+
 class OpenRouterIOGraph(base._Widget):
-    """Sparkline of trusted input/output token-rate samples."""
+    """Persistent input/output graph with one truthful shared Y scale."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("frequency", POLL_SECONDS, "Graph refresh interval in seconds."),
-        ("samples", GRAPH_SAMPLES, "Maximum number of changed samples."),
+        ("samples", GRAPH_SAMPLES, "Maximum local history points."),
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
@@ -276,47 +319,45 @@ class OpenRouterIOGraph(base._Widget):
     def __init__(self, width=GRAPH_WIDTH, **config):
         super().__init__(width, **config)
         self.add_defaults(self.defaults)
-        self.input_values = deque(maxlen=self.samples)
-        self.output_values = deque(maxlen=self.samples)
-        self._last_sample = None
+        self.series = {"range": "1m", "start": 0, "end": 1, "ceiling": 0, "samples": []}
+        self._last_signature = None
 
     def timer_setup(self):
         self._update()
         self.timeout_add(self.frequency, self.timer_setup)
 
     def _update(self):
-        status = _read_cached_status()
-        if status:
-            sample = (
-                status.get("window_end"),
-                status.get("input_tokens_per_minute"),
-                status.get("output_tokens_per_minute"),
-            )
-            if sample != self._last_sample and sample[0] is not None:
-                self.input_values.append(float(sample[1] or 0))
-                self.output_values.append(float(sample[2] or 0))
-                self._last_sample = sample
-                self.draw()
+        label = _rotate_graph_range()
+        try:
+            series = openrouter_history.query_series(label, points=self.samples)
+        except (OSError, ValueError):
+            return
+        samples = series.get("samples", [])
+        newest = samples[-1].get("timestamp") if samples else None
+        signature = (label, len(samples), newest, series.get("ceiling"))
+        if signature != self._last_signature:
+            self.series = series
+            self._last_signature = signature
+            self.draw()
 
-    def _draw_series(self, values, color, center_y, half_height, direction):
-        if len(values) < 2:
+    def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
+        samples = self.series.get("samples", [])
+        if not samples or ceiling <= 0:
             return
-        values = list(values)
-        minimum = min(values)
-        maximum = max(values)
-        if maximum <= minimum:
-            return
-        span = maximum - minimum
+        start = float(self.series.get("start", 0))
+        end = float(self.series.get("end", start + 1))
+        span = max(end - start, 1.0)
         usable_width = max(self.width - 2 * self.margin_x, 1)
-        step = usable_width / max(len(values) - 1, 1)
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-        for index, value in enumerate(values):
-            x = self.margin_x + index * step
-            normalized = (float(value) - minimum) / span
-            distance = (0.15 + 0.85 * normalized) * half_height
-            y = center_y + direction * distance
-            if index == 0:
+        for index, sample in enumerate(samples):
+            x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
+            normalized = min(max(float(sample.get(key, 0)) / ceiling, 0.0), 1.0)
+            y = center_y + direction * normalized * half_height
+            if len(samples) == 1:
+                self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
+                self.drawer.ctx.line_to(min(self.width - self.margin_x, x + 2), y)
+            elif index == 0:
                 self.drawer.ctx.move_to(x, y)
             else:
                 self.drawer.ctx.line_to(x, y)
@@ -331,8 +372,9 @@ class OpenRouterIOGraph(base._Widget):
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
-        self._draw_series(self.input_values, self.input_color, center_y, half_height, -1)
-        self._draw_series(self.output_values, self.output_color, center_y, half_height, 1)
+        ceiling = float(self.series.get("ceiling") or 0)
+        self._draw_series("input", self.input_color, center_y, half_height, -1, ceiling)
+        self._draw_series("output", self.output_color, center_y, half_height, 1, ceiling)
         self.draw_at_default_position()
 
 
@@ -373,6 +415,7 @@ def _telemetry_widgets(home, colors):
     return [
         OpenRouterCredit(script, colors, name="openrouter_credit", **common),
         OpenRouterRate(script, colors, name="openrouter_rate", **common),
+        OpenRouterGraphRange(colors, name="openrouter_graph_range", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",
             frequency=POLL_SECONDS,
@@ -382,12 +425,8 @@ def _telemetry_widgets(home, colors):
             midline_color=_color(colors, 2),
             background=background,
         ),
-        OpenRouterRotatingMetric(
-            script, colors, "tokens", name="openrouter_token_totals", **common
-        ),
-        OpenRouterRotatingMetric(
-            script, colors, "spend", name="openrouter_spend_totals", **common
-        ),
+        OpenRouterRotatingMetric(script, colors, "tokens", name="openrouter_token_totals", **common),
+        OpenRouterRotatingMetric(script, colors, "spend", name="openrouter_spend_totals", **common),
     ]
 
 

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -87,11 +87,16 @@ def _fetch_payload(script):
         if cached:
             payload = dict(cached)
             payload["stale"] = True
-            if isinstance(payload, dict) and completed.stderr:
+            if completed.stderr:
                 payload.setdefault("last_error", completed.stderr.strip())
             _last_payload = payload
             return payload
-        return payload if isinstance(payload, dict) else None
+        if isinstance(payload, dict):
+            # Cache provider/auth error payloads for the same one-second window
+            # too; five widgets should not fan out five failing subprocesses.
+            _last_payload = payload
+            return payload
+        return None
 
 
 def _notify(summary, body="", urgency="normal"):
@@ -321,6 +326,8 @@ class OpenRouterIOGraph(base._Widget):
         self.add_defaults(self.defaults)
         self.series = {"range": "1m", "start": 0, "end": 1, "ceiling": 0, "samples": []}
         self._last_signature = None
+        self._query_lock = threading.Lock()
+        self._query_running = False
 
     def timer_setup(self):
         self._update()
@@ -328,17 +335,51 @@ class OpenRouterIOGraph(base._Widget):
 
     def _update(self):
         label = _rotate_graph_range()
-        try:
-            series = openrouter_history.query_series(label, points=self.samples)
-        except (OSError, ValueError):
-            return
-        samples = series.get("samples", [])
-        newest = samples[-1].get("timestamp") if samples else None
-        signature = (label, len(samples), newest, series.get("ceiling"))
-        if signature != self._last_signature:
-            self.series = series
-            self._last_signature = signature
-            self.draw()
+        with self._query_lock:
+            if self._query_running:
+                return
+            self._query_running = True
+
+        def worker():
+            try:
+                series = openrouter_history.query_series(label, points=self.samples)
+            except Exception:
+                series = None
+
+            def apply():
+                with self._query_lock:
+                    self._query_running = False
+                if series is None:
+                    return
+                samples = series.get("samples", [])
+                signature = (
+                    label,
+                    tuple(
+                        (
+                            sample.get("timestamp"),
+                            sample.get("input"),
+                            sample.get("output"),
+                            sample.get("bucket_seconds"),
+                        )
+                        for sample in samples
+                    ),
+                )
+                if signature != self._last_signature:
+                    self.series = series
+                    self._last_signature = signature
+                    self.draw()
+
+            try:
+                self.qtile.call_soon_threadsafe(apply)
+            except Exception:
+                with self._query_lock:
+                    self._query_running = False
+
+        threading.Thread(
+            target=worker,
+            name="qtile-openrouter-graph",
+            daemon=True,
+        ).start()
 
     def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
         samples = self.series.get("samples", [])

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Collect trustworthy OpenRouter rate, balance, token, and spend telemetry."""
+"""Collect trustworthy OpenRouter rate, balance, token, spend, and history telemetry."""
 
 from __future__ import annotations
 
@@ -8,14 +8,21 @@ import concurrent.futures
 import fcntl
 import json
 import os
+import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+QTILE_DIR = Path(__file__).resolve().parents[1]
+if str(QTILE_DIR) not in sys.path:
+    sys.path.insert(0, str(QTILE_DIR))
+
+import openrouter_history as history
 
 API_BASE = "https://openrouter.ai/api/v1"
 AI_ICON = "\U000F09D1"
@@ -26,6 +33,9 @@ USAGE_REFRESH_SECONDS = 30
 BALANCE_REFRESH_SECONDS = 30
 REQUEST_TIMEOUT_SECONDS = 5
 DEFAULT_MAX_TPM = 10_000_000
+BACKFILL_INTERVAL_SECONDS = 6 * 60 * 60
+BACKFILL_DAYS = 365
+BACKFILL_FINE_DAYS = 7
 
 
 @dataclass(frozen=True)
@@ -43,6 +53,9 @@ class Status:
     spend_day: float | None = None
     usage_fetched_at: str | None = None
     balance_fetched_at: str | None = None
+    usage_error: str | None = None
+    balance_error: str | None = None
+    last_error: str | None = None
 
     @property
     def total_tokens_per_minute(self) -> int:
@@ -78,6 +91,8 @@ def _management_key_file() -> Path:
 
 
 def load_management_key() -> str:
+    # OPENROUTER_API_KEY remains a compatibility fallback for users who place
+    # a management key there. Analytics itself requires management-key scope.
     for env_name in ("OPENROUTER_MANAGEMENT_KEY", "OPENROUTER_API_KEY"):
         value = os.environ.get(env_name, "").strip()
         if value:
@@ -98,7 +113,7 @@ def _request_json(
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}",
-        "User-Agent": "qtile-openrouter-status/4",
+        "User-Agent": "qtile-openrouter-status/5",
     }
     if payload is not None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -111,7 +126,9 @@ def _request_json(
             return json.load(response)
     except urllib.error.HTTPError as exc:
         if exc.code in (401, 403):
-            raise RuntimeError("management key rejected") from exc
+            raise RuntimeError(
+                "management key rejected (OpenRouter Analytics requires management-key scope)"
+            ) from exc
         if exc.code == 429:
             raise RuntimeError("OpenRouter rate limited") from exc
         raise RuntimeError(f"OpenRouter HTTP {exc.code}") from exc
@@ -171,6 +188,48 @@ def parse_usage_summary(payload: dict[str, Any]) -> tuple[int, float]:
     return int(round(tokens)), spend
 
 
+def _parse_bucket_timestamp(row: dict[str, Any], granularity: str) -> datetime:
+    value = (
+        row.get(f"created_at__{granularity}")
+        or row.get(f"date__{granularity}")
+        or row.get("timestamp")
+        or row.get("date")
+    )
+    if not value:
+        raise RuntimeError("OpenRouter analytics bucket timestamp missing")
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError("OpenRouter analytics bucket timestamp malformed") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_history_rows(payload: dict[str, Any], granularity: str) -> list[dict[str, Any]]:
+    duration = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity)
+    if duration is None:
+        raise ValueError(f"unsupported history granularity: {granularity}")
+    result: list[dict[str, Any]] = []
+    for row in _rows(payload):
+        try:
+            incoming = int(round(float(row.get("tokens_prompt") or 0)))
+            outgoing = int(round(float(row.get("tokens_completion") or 0)))
+            spend = float(row.get("total_usage") or 0)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("OpenRouter history metric malformed") from exc
+        result.append(
+            {
+                "start": _parse_bucket_timestamp(row, granularity),
+                "seconds": duration,
+                "input": incoming,
+                "output": outgoing,
+                "spend": spend,
+            }
+        )
+    return result
+
+
 def _closed_minute_window(now: datetime | None = None) -> tuple[datetime, datetime]:
     now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     end = now.replace(second=0, microsecond=0)
@@ -201,6 +260,22 @@ def fetch_usage_range(key: str, start: datetime, end: datetime) -> tuple[int, fl
         "limit": 1000,
     }
     return parse_usage_summary(_request_json("POST", "/analytics/query", key, payload))
+
+
+def fetch_history_range(
+    key: str, start: datetime, end: datetime, granularity: str
+) -> list[dict[str, Any]]:
+    payload = {
+        "metrics": ["tokens_prompt", "tokens_completion", "total_usage"],
+        "granularity": granularity,
+        "time_range": {
+            "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "end": end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "limit": 1000,
+    }
+    response = _request_json("POST", "/analytics/query", key, payload)
+    return parse_history_rows(response, granularity)
 
 
 def fetch_balance(key: str) -> float:
@@ -321,12 +396,20 @@ def fetch_status(key: str, previous: Status | None = None) -> Status:
     if previous is None or previous.window_end != window_end:
         input_tokens, output_tokens = fetch_tokens(key, start, end)
         validate_rate(input_tokens, output_tokens)
+        history.upsert_sample(
+            start,
+            RATE_WINDOW_SECONDS,
+            input_tokens,
+            output_tokens,
+            source="live-minute",
+        )
 
     values = asdict(previous) if previous else asdict(Status(input_tokens, output_tokens))
     values.update(
         input_tokens_per_minute=input_tokens,
         output_tokens_per_minute=output_tokens,
         window_end=window_end,
+        last_error=None,
     )
 
     usage_due = (
@@ -346,15 +429,17 @@ def fetch_status(key: str, previous: Status | None = None) -> Status:
                 try:
                     values.update(usage_future.result())
                     values["usage_fetched_at"] = _iso_now(now_utc)
-                except RuntimeError:
-                    pass
+                    values["usage_error"] = None
+                except RuntimeError as exc:
+                    values["usage_error"] = str(exc)
 
             if balance_future is not None:
                 try:
                     values["balance_usd"] = balance_future.result()
                     values["balance_fetched_at"] = _iso_now(now_utc)
-                except RuntimeError:
-                    pass
+                    values["balance_error"] = None
+                except RuntimeError as exc:
+                    values["balance_error"] = str(exc)
 
     return Status(**values)
 
@@ -372,23 +457,121 @@ def status_with_cache(key: str, *, force: bool = False) -> tuple[Status, bool]:
             return cached_status, False
         try:
             status = fetch_status(key, cached_status)
-        except RuntimeError:
+        except RuntimeError as exc:
             if cached_status:
-                return cached_status, True
+                return replace(cached_status, last_error=str(exc)), True
             raise
         _write_cache(path, status, fetched_at=time.time())
         return status, False
+
+
+def _persist_history_rows(rows: list[dict[str, Any]], source: str) -> int:
+    count = 0
+    for row in rows:
+        history.upsert_sample(
+            row["start"],
+            int(row["seconds"]),
+            int(row["input"]),
+            int(row["output"]),
+            spend=float(row["spend"]),
+            source=source,
+        )
+        count += 1
+    return count
+
+
+def backfill_history(key: str, now: datetime | None = None) -> dict[str, int]:
+    """Seed one year locally without pretending coarse history is minute data."""
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    hour_end = now.replace(minute=0, second=0, microsecond=0)
+    fine_start = (hour_end - timedelta(days=BACKFILL_FINE_DAYS)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    year_start = (hour_end - timedelta(days=BACKFILL_DAYS)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    counts = {"day": 0, "hour": 0}
+    if year_start < fine_start:
+        counts["day"] = _persist_history_rows(
+            fetch_history_range(key, year_start, fine_start, "day"),
+            "backfill-day",
+        )
+    if fine_start < hour_end:
+        counts["hour"] = _persist_history_rows(
+            fetch_history_range(key, fine_start, hour_end, "hour"),
+            "backfill-hour",
+        )
+    history.set_metadata("backfill_last_success", _iso_now(now))
+    return counts
+
+
+def _launch_backfill_if_due() -> None:
+    try:
+        due = history.claim_due("backfill_last_attempt", BACKFILL_INTERVAL_SECONDS)
+    except OSError:
+        return
+    if not due:
+        return
+    try:
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--backfill"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        pass
+
+
+def _json_payload(status: Status, stale: bool) -> dict[str, Any]:
+    payload = asdict(status)
+    payload["total_tokens_per_minute"] = status.total_tokens_per_minute
+    payload["stale"] = stale
+    try:
+        info = history.summary()
+    except OSError:
+        info = {"rows": 0, "oldest": None, "newest": None}
+    payload["history_rows"] = info.get("rows", 0)
+    payload["history_oldest"] = info.get("oldest")
+    payload["history_newest"] = info.get("newest")
+    payload["history_backfill"] = history.get_metadata("backfill_last_success")
+    return payload
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print machine-readable status")
     parser.add_argument("--force", action="store_true", help="ignore the short process cache")
+    parser.add_argument("--backfill", action="store_true", help="backfill persistent history and exit")
+    parser.add_argument("--history", choices=tuple(history.TIMEFRAME_SECONDS), help="print a local history range and exit")
+    parser.add_argument("--points", type=int, default=82, help="maximum local history points")
+    parser.add_argument("--doctor", action="store_true", help="print local telemetry diagnostics and exit")
     args = parser.parse_args(argv)
+
+    if args.history:
+        print(json.dumps(history.query_series(args.history, points=args.points), sort_keys=True))
+        return 0
+
+    if args.doctor:
+        info = history.summary()
+        info["management_key_file"] = str(_management_key_file())
+        info["management_key_available"] = bool(
+            os.environ.get("OPENROUTER_MANAGEMENT_KEY")
+            or os.environ.get("OPENROUTER_API_KEY")
+            or _management_key_file().exists()
+        )
+        info["backfill_last_success"] = history.get_metadata("backfill_last_success")
+        print(json.dumps(info, sort_keys=True))
+        return 0
+
     try:
         key = load_management_key()
         if not key:
             raise RuntimeError("management key missing")
+        if args.backfill:
+            print(json.dumps(backfill_history(key), sort_keys=True))
+            return 0
         status, stale = status_with_cache(key, force=args.force)
     except RuntimeError as exc:
         if args.json:
@@ -397,11 +580,10 @@ def main(argv: list[str] | None = None) -> int:
             short = "key?" if "key" in str(exc).lower() else "offline"
             print(render_error(short))
         return 1
+
+    _launch_backfill_if_due()
     if args.json:
-        payload = asdict(status)
-        payload["total_tokens_per_minute"] = status.total_tokens_per_minute
-        payload["stale"] = stale
-        print(json.dumps(payload, sort_keys=True))
+        print(json.dumps(_json_payload(status, stale), sort_keys=True))
     else:
         print(render(status, stale=stale))
     return 0

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -8,6 +8,7 @@ import concurrent.futures
 import fcntl
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import time
@@ -393,23 +394,27 @@ def fetch_status(key: str, previous: Status | None = None) -> Status:
 
     input_tokens = previous.input_tokens_per_minute if previous else 0
     output_tokens = previous.output_tokens_per_minute if previous else 0
+    history_error = None
     if previous is None or previous.window_end != window_end:
         input_tokens, output_tokens = fetch_tokens(key, start, end)
         validate_rate(input_tokens, output_tokens)
-        history.upsert_sample(
-            start,
-            RATE_WINDOW_SECONDS,
-            input_tokens,
-            output_tokens,
-            source="live-minute",
-        )
+        try:
+            history.upsert_sample(
+                start,
+                RATE_WINDOW_SECONDS,
+                input_tokens,
+                output_tokens,
+                source="live-minute",
+            )
+        except (OSError, sqlite3.Error) as exc:
+            history_error = f"history storage unavailable: {exc}"
 
     values = asdict(previous) if previous else asdict(Status(input_tokens, output_tokens))
     values.update(
         input_tokens_per_minute=input_tokens,
         output_tokens_per_minute=output_tokens,
         window_end=window_end,
-        last_error=None,
+        last_error=history_error,
     )
 
     usage_due = (
@@ -508,7 +513,7 @@ def backfill_history(key: str, now: datetime | None = None) -> dict[str, int]:
 def _launch_backfill_if_due() -> None:
     try:
         due = history.claim_due("backfill_last_attempt", BACKFILL_INTERVAL_SECONDS)
-    except OSError:
+    except (OSError, sqlite3.Error):
         return
     if not due:
         return
@@ -524,18 +529,32 @@ def _launch_backfill_if_due() -> None:
         pass
 
 
+def _history_diagnostics() -> dict[str, Any]:
+    try:
+        info = history.summary()
+        info["backfill_last_success"] = history.get_metadata("backfill_last_success")
+        info["history_error"] = None
+        return info
+    except (OSError, sqlite3.Error) as exc:
+        return {
+            "rows": 0,
+            "oldest": None,
+            "newest": None,
+            "backfill_last_success": None,
+            "history_error": str(exc),
+        }
+
+
 def _json_payload(status: Status, stale: bool) -> dict[str, Any]:
     payload = asdict(status)
     payload["total_tokens_per_minute"] = status.total_tokens_per_minute
     payload["stale"] = stale
-    try:
-        info = history.summary()
-    except OSError:
-        info = {"rows": 0, "oldest": None, "newest": None}
+    info = _history_diagnostics()
     payload["history_rows"] = info.get("rows", 0)
     payload["history_oldest"] = info.get("oldest")
     payload["history_newest"] = info.get("newest")
-    payload["history_backfill"] = history.get_metadata("backfill_last_success")
+    payload["history_backfill"] = info.get("backfill_last_success")
+    payload["history_error"] = info.get("history_error")
     return payload
 
 
@@ -549,23 +568,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--doctor", action="store_true", help="print local telemetry diagnostics and exit")
     args = parser.parse_args(argv)
 
-    if args.history:
-        print(json.dumps(history.query_series(args.history, points=args.points), sort_keys=True))
-        return 0
-
-    if args.doctor:
-        info = history.summary()
-        info["management_key_file"] = str(_management_key_file())
-        info["management_key_available"] = bool(
-            os.environ.get("OPENROUTER_MANAGEMENT_KEY")
-            or os.environ.get("OPENROUTER_API_KEY")
-            or _management_key_file().exists()
-        )
-        info["backfill_last_success"] = history.get_metadata("backfill_last_success")
-        print(json.dumps(info, sort_keys=True))
-        return 0
-
     try:
+        if args.history:
+            print(json.dumps(history.query_series(args.history, points=args.points), sort_keys=True))
+            return 0
+
+        if args.doctor:
+            info = _history_diagnostics()
+            info["management_key_file"] = str(_management_key_file())
+            info["management_key_available"] = bool(
+                os.environ.get("OPENROUTER_MANAGEMENT_KEY")
+                or os.environ.get("OPENROUTER_API_KEY")
+                or _management_key_file().exists()
+            )
+            print(json.dumps(info, sort_keys=True))
+            return 0
+
         key = load_management_key()
         if not key:
             raise RuntimeError("management key missing")
@@ -573,8 +591,8 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(backfill_history(key), sort_keys=True))
             return 0
         status, stale = status_with_cache(key, force=args.force)
-    except RuntimeError as exc:
-        if args.json:
+    except (RuntimeError, OSError, sqlite3.Error) as exc:
+        if args.json or args.history or args.backfill:
             print(json.dumps({"error": str(exc)}))
         else:
             short = "key?" if "key" in str(exc).lower() else "offline"

--- a/.config/qtile/tests/test_openrouter_backfill.py
+++ b/.config/qtile/tests/test_openrouter_backfill.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sqlite3
 import sys
 import unittest
 from datetime import datetime, timezone
@@ -84,6 +85,39 @@ class OpenRouterBackfillTests(unittest.TestCase):
         self.assertEqual(status.output_tokens_per_minute, 10)
         persist.assert_called_once()
         self.assertEqual(persist.call_args.kwargs["source"], "live-minute")
+
+    def test_history_db_failure_does_not_destroy_live_rate(self):
+        now_end = MODULE._closed_minute_window()[1]
+        previous = MODULE.Status(
+            1,
+            1,
+            window_end=(now_end - MODULE.timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+            usage_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+            balance_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+        )
+        with (
+            mock.patch.object(MODULE, "fetch_tokens", return_value=(321, 45)),
+            mock.patch.object(
+                MODULE.history,
+                "upsert_sample",
+                side_effect=sqlite3.OperationalError("readonly database"),
+            ),
+        ):
+            status = MODULE.fetch_status("key", previous)
+        self.assertEqual(status.input_tokens_per_minute, 321)
+        self.assertEqual(status.output_tokens_per_minute, 45)
+        self.assertIn("history storage unavailable", status.last_error)
+        self.assertIn("readonly database", status.last_error)
+
+    def test_history_diagnostics_report_storage_error(self):
+        with mock.patch.object(
+            MODULE.history,
+            "summary",
+            side_effect=sqlite3.OperationalError("locked"),
+        ):
+            info = MODULE._history_diagnostics()
+        self.assertEqual(info["rows"], 0)
+        self.assertEqual(info["history_error"], "locked")
 
     def test_stale_cache_reports_provider_error_instead_of_silently_hiding_it(self):
         cached = MODULE.Status(100, 10, window_end="2026-08-23T04:00:00Z")

--- a/.config/qtile/tests/test_openrouter_backfill.py
+++ b/.config/qtile/tests/test_openrouter_backfill.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Regression tests for OpenRouter persistent-history backfill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+QTILE_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = QTILE_DIR / "scripts" / "openrouter_status.py"
+sys.path.insert(0, str(QTILE_DIR))
+SPEC = importlib.util.spec_from_file_location("openrouter_status_backfill", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenRouterBackfillTests(unittest.TestCase):
+    def test_parse_history_rows_keeps_real_bucket_granularity(self):
+        payload = {
+            "data": {
+                "data": [
+                    {
+                        "created_at__hour": "2026-08-23T03:00:00Z",
+                        "tokens_prompt": 600,
+                        "tokens_completion": 60,
+                        "total_usage": 0.25,
+                    }
+                ]
+            }
+        }
+        rows = MODULE.parse_history_rows(payload, "hour")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["seconds"], 3600)
+        self.assertEqual(rows[0]["input"], 600)
+        self.assertEqual(rows[0]["output"], 60)
+        self.assertAlmostEqual(rows[0]["spend"], 0.25)
+
+    def test_history_query_requests_prompt_completion_and_spend(self):
+        start = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        end = datetime(2026, 8, 23, tzinfo=timezone.utc)
+        response = {"data": {"data": []}}
+        with mock.patch.object(MODULE, "_request_json", return_value=response) as request:
+            self.assertEqual(MODULE.fetch_history_range("key", start, end, "hour"), [])
+        query = request.call_args.args[3]
+        self.assertEqual(
+            query["metrics"],
+            ["tokens_prompt", "tokens_completion", "total_usage"],
+        )
+        self.assertEqual(query["granularity"], "hour")
+
+    def test_backfill_uses_daily_old_history_and_hourly_recent_history(self):
+        now = datetime(2026, 8, 23, 4, 38, tzinfo=timezone.utc)
+        with (
+            mock.patch.object(MODULE, "fetch_history_range", return_value=[]) as fetch,
+            mock.patch.object(MODULE.history, "set_metadata"),
+        ):
+            result = MODULE.backfill_history("key", now)
+        self.assertEqual(result, {"day": 0, "hour": 0})
+        self.assertEqual(fetch.call_count, 2)
+        granularities = [call.args[3] for call in fetch.call_args_list]
+        self.assertEqual(granularities, ["day", "hour"])
+
+    def test_new_closed_minute_is_persisted_once(self):
+        now_end = MODULE._closed_minute_window()[1]
+        previous = MODULE.Status(
+            1,
+            1,
+            window_end=(now_end - MODULE.timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+            usage_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+            balance_fetched_at=MODULE._iso_now(MODULE.datetime.now(MODULE.timezone.utc)),
+        )
+        with (
+            mock.patch.object(MODULE, "fetch_tokens", return_value=(100, 10)),
+            mock.patch.object(MODULE.history, "upsert_sample") as persist,
+        ):
+            status = MODULE.fetch_status("key", previous)
+        self.assertEqual(status.input_tokens_per_minute, 100)
+        self.assertEqual(status.output_tokens_per_minute, 10)
+        persist.assert_called_once()
+        self.assertEqual(persist.call_args.kwargs["source"], "live-minute")
+
+    def test_stale_cache_reports_provider_error_instead_of_silently_hiding_it(self):
+        cached = MODULE.Status(100, 10, window_end="2026-08-23T04:00:00Z")
+        fake_cache = {"fetched_at": 0, "status": MODULE.asdict(cached)}
+        lock = mock.mock_open()
+        with (
+            mock.patch.object(MODULE, "_read_cache", return_value=fake_cache),
+            mock.patch.object(MODULE, "fetch_status", side_effect=RuntimeError("OpenRouter rate limited")),
+            mock.patch.object(MODULE, "_cache_path", return_value=Path("/tmp/fake-openrouter-status.json")),
+            mock.patch.object(Path, "open", lock),
+            mock.patch.object(MODULE.fcntl, "flock"),
+        ):
+            status, stale = MODULE.status_with_cache("key")
+        self.assertTrue(stale)
+        self.assertEqual(status.last_error, "OpenRouter rate limited")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_history.py
+++ b/.config/qtile/tests/test_openrouter_history.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Tests for persistent OpenRouter telemetry history."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "openrouter_history.py"
+SPEC = importlib.util.spec_from_file_location("openrouter_history", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenRouterHistoryTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.db = Path(self.temp.name) / "history.sqlite3"
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_requested_ranges_exist_in_order(self):
+        self.assertEqual(
+            tuple(label for label, _seconds in MODULE.TIMEFRAMES),
+            ("1m", "5m", "1h", "6h", "12h", "1d", "1w", "1mo", "1y"),
+        )
+
+    def test_upsert_is_idempotent_and_persistent(self):
+        start = datetime(2026, 8, 23, 4, 10, tzinfo=timezone.utc)
+        MODULE.upsert_sample(start, 60, 100, 10, source="live", path=self.db)
+        MODULE.upsert_sample(start, 60, 120, 12, source="live", path=self.db)
+        info = MODULE.summary(path=self.db)
+        self.assertEqual(info["rows"], 1)
+        series = MODULE.query_series(
+            "1m",
+            now=datetime(2026, 8, 23, 4, 11, 20, tzinfo=timezone.utc),
+            path=self.db,
+        )
+        self.assertEqual(series["samples"][0]["input"], 120.0)
+        self.assertEqual(series["samples"][0]["output"], 12.0)
+
+    def test_query_aligns_to_last_complete_minute(self):
+        MODULE.upsert_sample(
+            datetime(2026, 8, 23, 4, 10, tzinfo=timezone.utc),
+            60,
+            60,
+            6,
+            path=self.db,
+        )
+        series = MODULE.query_series(
+            "1m",
+            now=datetime(2026, 8, 23, 4, 11, 59, tzinfo=timezone.utc),
+            path=self.db,
+        )
+        self.assertEqual(series["start"], int(datetime(2026, 8, 23, 4, 10, tzinfo=timezone.utc).timestamp()))
+        self.assertEqual(len(series["samples"]), 1)
+
+    def test_hour_backfill_prevents_minute_double_count(self):
+        hour = datetime(2026, 8, 23, 3, 0, tzinfo=timezone.utc)
+        MODULE.upsert_sample(hour, 3600, 3600, 360, source="backfill-hour", path=self.db)
+        MODULE.upsert_sample(
+            datetime(2026, 8, 23, 3, 30, tzinfo=timezone.utc),
+            60,
+            5000,
+            500,
+            source="live",
+            path=self.db,
+        )
+        series = MODULE.query_series(
+            "6h",
+            now=datetime(2026, 8, 23, 4, 0, tzinfo=timezone.utc),
+            path=self.db,
+        )
+        self.assertEqual(len(series["samples"]), 1)
+        self.assertEqual(series["samples"][0]["source"], "backfill-hour")
+        self.assertEqual(series["samples"][0]["input"], 60.0)
+
+    def test_shared_ceiling_uses_both_io_series(self):
+        end = datetime(2026, 8, 23, 4, 12, tzinfo=timezone.utc)
+        MODULE.upsert_sample(
+            datetime(2026, 8, 23, 4, 10, tzinfo=timezone.utc),
+            60,
+            900,
+            90,
+            path=self.db,
+        )
+        MODULE.upsert_sample(
+            datetime(2026, 8, 23, 4, 11, tzinfo=timezone.utc),
+            60,
+            100,
+            700,
+            path=self.db,
+        )
+        series = MODULE.query_series("5m", now=end, path=self.db)
+        self.assertEqual(series["ceiling"], 900.0)
+
+    def test_coarse_history_is_not_interpolated(self):
+        start = datetime(2026, 8, 20, 0, 0, tzinfo=timezone.utc)
+        for day in range(3):
+            MODULE.upsert_sample(
+                int(start.timestamp()) + day * 86400,
+                86400,
+                86400,
+                8640,
+                source="backfill-day",
+                path=self.db,
+            )
+        series = MODULE.query_series(
+            "1w",
+            points=82,
+            now=datetime(2026, 8, 23, 0, 0, tzinfo=timezone.utc),
+            path=self.db,
+        )
+        self.assertEqual(len(series["samples"]), 3)
+        self.assertTrue(all(sample["bucket_seconds"] == 86400 for sample in series["samples"]))
+
+    def test_downsample_never_exceeds_point_budget(self):
+        end = datetime(2026, 8, 23, 4, 20, tzinfo=timezone.utc)
+        base = int(datetime(2026, 8, 23, 4, 0, tzinfo=timezone.utc).timestamp())
+        for minute in range(20):
+            MODULE.upsert_sample(base + minute * 60, 60, minute + 1, minute, path=self.db)
+        series = MODULE.query_series("1h", points=5, now=end, path=self.db)
+        self.assertLessEqual(len(series["samples"]), 5)
+
+    def test_claim_due_is_atomic_interval_gate(self):
+        self.assertTrue(MODULE.claim_due("backfill", 3600, path=self.db))
+        self.assertFalse(MODULE.claim_due("backfill", 3600, path=self.db))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_range_rotation.py
+++ b/.config/qtile/tests/test_openrouter_range_rotation.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Behavioral tests for OpenRouter graph timeframe rotation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+QTILE_DIR = Path(__file__).resolve().parents[1]
+SOURCE = QTILE_DIR / "qtile_openrouter.py"
+sys.path.insert(0, str(QTILE_DIR))
+
+
+def _install_libqtile_stub() -> None:
+    libqtile = types.ModuleType("libqtile")
+    config = types.ModuleType("libqtile.config")
+    lazy_module = types.ModuleType("libqtile.lazy")
+    widget = types.ModuleType("libqtile.widget")
+    base = types.ModuleType("libqtile.widget.base")
+
+    class Key:
+        pass
+
+    class BackgroundPoll:
+        pass
+
+    class Widget:
+        pass
+
+    config.Key = Key
+    lazy_module.lazy = types.SimpleNamespace()
+    base.BackgroundPoll = BackgroundPoll
+    base._Widget = Widget
+    base.ORIENTATION_HORIZONTAL = 1
+    widget.base = base
+    libqtile.config = config
+    libqtile.lazy = lazy_module
+    libqtile.widget = widget
+
+    sys.modules["libqtile"] = libqtile
+    sys.modules["libqtile.config"] = config
+    sys.modules["libqtile.lazy"] = lazy_module
+    sys.modules["libqtile.widget"] = widget
+    sys.modules["libqtile.widget.base"] = base
+
+
+_install_libqtile_stub()
+SPEC = importlib.util.spec_from_file_location("qtile_openrouter_rotation", SOURCE)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenRouterRangeRotationTests(unittest.TestCase):
+    def setUp(self):
+        MODULE._graph_range_index = 0
+        MODULE._graph_range_changed_at = 100.0
+
+    def test_exact_requested_range_order(self):
+        self.assertEqual(
+            MODULE.GRAPH_RANGES,
+            ("1m", "5m", "1h", "6h", "12h", "1d", "1w", "1mo", "1y"),
+        )
+
+    def test_rotation_changes_only_at_five_second_boundaries(self):
+        self.assertEqual(MODULE._rotate_graph_range(104.999), "1m")
+        self.assertEqual(MODULE._rotate_graph_range(105.0), "5m")
+        self.assertEqual(MODULE._rotate_graph_range(109.999), "5m")
+        self.assertEqual(MODULE._rotate_graph_range(110.0), "1h")
+
+    def test_delayed_tick_catches_up_without_drift(self):
+        self.assertEqual(MODULE._rotate_graph_range(117.0), "6h")
+        self.assertEqual(MODULE._graph_range_changed_at, 115.0)
+        self.assertEqual(MODULE._rotate_graph_range(120.0), "12h")
+
+    def test_full_cycle_wraps_to_one_minute(self):
+        self.assertEqual(MODULE._rotate_graph_range(145.0), "1m")
+        self.assertEqual(MODULE._graph_range_index, 0)
+
+    def test_manual_step_moves_both_directions_and_restarts_timer(self):
+        with mock.patch.object(MODULE.time, "monotonic", return_value=222.0):
+            self.assertEqual(MODULE._step_graph_range(1), "5m")
+        self.assertEqual(MODULE._graph_range_changed_at, 222.0)
+        with mock.patch.object(MODULE.time, "monotonic", return_value=223.0):
+            self.assertEqual(MODULE._step_graph_range(-1), "1m")
+        self.assertEqual(MODULE._graph_range_changed_at, 223.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -60,6 +60,12 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertNotIn("self.input_values", SOURCE_TEXT)
         self.assertNotIn("self.output_values", SOURCE_TEXT)
 
+    def test_graph_history_query_runs_off_qtile_event_loop(self):
+        self.assertIn("self._query_running", SOURCE_TEXT)
+        self.assertIn('name="qtile-openrouter-graph"', SOURCE_TEXT)
+        self.assertIn("self.qtile.call_soon_threadsafe(apply)", SOURCE_TEXT)
+        self.assertIn("daemon=True", SOURCE_TEXT)
+
     def test_graph_has_one_shared_scale_and_does_not_hide_flat_series(self):
         self.assertIn('ceiling = float(self.series.get("ceiling") or 0)', SOURCE_TEXT)
         self.assertIn('_draw_series("input"', SOURCE_TEXT)
@@ -70,6 +76,11 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
     def test_rate_poll_respects_status_cache(self):
         self.assertIn('["python3", script, "--json"]', SOURCE_TEXT)
         self.assertNotIn('"--force"', SOURCE_TEXT)
+
+    def test_provider_errors_are_cached_for_one_poll_window(self):
+        self.assertIn("if isinstance(payload, dict):", SOURCE_TEXT)
+        self.assertIn("_last_payload = payload", SOURCE_TEXT)
+        self.assertIn("five widgets should not fan out five failing subprocesses", SOURCE_TEXT)
 
     def test_collector_errors_are_visible(self):
         self.assertIn('payload.get("last_error")', SOURCE_TEXT)

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -22,14 +22,16 @@ def assigned_constant(name):
 
 
 class OpenRouterWidgetStructureTests(unittest.TestCase):
-    def test_one_second_render_poll_and_sparse_graph_capacity(self):
+    def test_one_second_render_poll_and_graph_point_budget(self):
         self.assertEqual(assigned_constant("POLL_SECONDS"), 1)
-        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 300)
+        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 82)
+        self.assertEqual(assigned_constant("ROTATE_SECONDS"), 5)
 
-    def test_credit_rate_graph_and_rotating_metrics_exist(self):
+    def test_credit_rate_graph_range_graph_and_rotating_metrics_exist(self):
         classes = {node.name for node in TREE.body if isinstance(node, ast.ClassDef)}
         self.assertIn("OpenRouterCredit", classes)
         self.assertIn("OpenRouterRate", classes)
+        self.assertIn("OpenRouterGraphRange", classes)
         self.assertIn("OpenRouterIOGraph", classes)
         self.assertIn("OpenRouterRotatingMetric", classes)
 
@@ -43,22 +45,35 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
             self.assertIn(value, SOURCE_TEXT)
         for value in ("spend_day", "spend_week", "spend_month"):
             self.assertIn(value, SOURCE_TEXT)
+
+    def test_graph_uses_all_requested_persistent_ranges(self):
+        self.assertIn("openrouter_history.TIMEFRAMES", SOURCE_TEXT)
+        self.assertIn("_rotate_graph_range", SOURCE_TEXT)
+        self.assertIn("_step_graph_range", SOURCE_TEXT)
+        self.assertIn('name="openrouter_graph_range"', SOURCE_TEXT)
         self.assertIn('"Button4": self.previous', SOURCE_TEXT)
         self.assertIn('"Button5": self.next', SOURCE_TEXT)
+
+    def test_graph_queries_local_history_instead_of_ram_deque(self):
+        self.assertIn("openrouter_history.query_series", SOURCE_TEXT)
+        self.assertNotIn("from collections import deque", SOURCE_TEXT)
+        self.assertNotIn("self.input_values", SOURCE_TEXT)
+        self.assertNotIn("self.output_values", SOURCE_TEXT)
+
+    def test_graph_has_one_shared_scale_and_does_not_hide_flat_series(self):
+        self.assertIn('ceiling = float(self.series.get("ceiling") or 0)', SOURCE_TEXT)
+        self.assertIn('_draw_series("input"', SOURCE_TEXT)
+        self.assertIn('_draw_series("output"', SOURCE_TEXT)
+        self.assertNotIn("minimum = min(values)", SOURCE_TEXT)
+        self.assertNotIn("if maximum <= minimum:", SOURCE_TEXT)
 
     def test_rate_poll_respects_status_cache(self):
         self.assertIn('["python3", script, "--json"]', SOURCE_TEXT)
         self.assertNotIn('"--force"', SOURCE_TEXT)
 
-    def test_graph_only_appends_changed_trusted_sample(self):
-        self.assertIn("sample != self._last_sample", SOURCE_TEXT)
-        self.assertIn('status.get("window_end")', SOURCE_TEXT)
-        self.assertIn("self._last_sample = sample", SOURCE_TEXT)
-
-    def test_graph_uses_adaptive_range_and_hides_constant_series(self):
-        self.assertIn("minimum = min(values)", SOURCE_TEXT)
-        self.assertIn("maximum = max(values)", SOURCE_TEXT)
-        self.assertIn("if maximum <= minimum:", SOURCE_TEXT)
+    def test_collector_errors_are_visible(self):
+        self.assertIn('payload.get("last_error")', SOURCE_TEXT)
+        self.assertIn('payload.get("usage_error")', SOURCE_TEXT)
 
     def test_sync_reload_uses_qtile_process_not_external_cli(self):
         self.assertIn("lazy.function(_sync_and_reload)", SOURCE_TEXT)

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -155,6 +155,26 @@ class QtileControlTests(unittest.TestCase):
         self.assertIn("widget.GenPollCommand", SOURCE_TEXT)
         self.assertIn('name="org_clocked_task"', SOURCE_TEXT)
 
+    def test_left_org_screen_has_gpt_todo_sync_button(self):
+        left = SOURCE_TEXT.index('elif role == "left":')
+        right = SOURCE_TEXT.index('elif role == "right":')
+        left_text = SOURCE_TEXT[left:right]
+        self.assertIn('name="gpt_todos_sync_button"', left_text)
+        self.assertIn("lazy.function(_sync_gpt_todos)", left_text)
+        self.assertIn('text=" 󰑓 SYNC "', left_text)
+
+    def test_gpt_todo_sync_is_off_event_loop_and_notifies(self):
+        self.assertIn('threading.Thread(target=worker, name="qtile-gpt-todos-sync", daemon=True).start()', SOURCE_TEXT)
+        self.assertIn('["bash", str(GPT_TODOS_SYNC)]', SOURCE_TEXT)
+        self.assertIn('"Synchronizing all agenda files…"', SOURCE_TEXT)
+        self.assertIn('"GPT TODO sync complete"', SOURCE_TEXT)
+        self.assertIn('"GPT TODO sync failed"', SOURCE_TEXT)
+
+    def test_clock_icons_and_single_full_date(self):
+        self.assertEqual(SOURCE_TEXT.count('format="󰃭 %Y-%m-%d   %H:%M"'), 1)
+        self.assertEqual(SOURCE_TEXT.count('format=" %H:%M"'), 3)
+        self.assertGreaterEqual(SOURCE_TEXT.count('font="Hack Nerd Regular"'), 4)
+
     def test_agent_zero_chat_is_centered_and_todo_is_right_aligned(self):
         self.assertIn('x=0.19,\n                    y=0.04,', SOURCE_TEXT)
         self.assertIn('x=0.42,\n                    y=0.02,', SOURCE_TEXT)

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -170,10 +170,16 @@ class QtileControlTests(unittest.TestCase):
         self.assertIn('"GPT TODO sync complete"', SOURCE_TEXT)
         self.assertIn('"GPT TODO sync failed"', SOURCE_TEXT)
 
-    def test_clock_icons_and_single_full_date(self):
-        self.assertEqual(SOURCE_TEXT.count('format="󰃭 %Y-%m-%d   %H:%M"'), 1)
-        self.assertEqual(SOURCE_TEXT.count('format=" %H:%M"'), 3)
+    def test_clock_icons_and_single_date_policy(self):
+        self.assertEqual(SOURCE_TEXT.count('"󰃭 %Y-%m-%d   %H:%M"'), 1)
+        self.assertEqual(SOURCE_TEXT.count('" %H:%M"'), 1)
+        self.assertIn('clock_format = "󰃭 %Y-%m-%d   %H:%M" if show_date else " %H:%M"', SOURCE_TEXT)
         self.assertGreaterEqual(SOURCE_TEXT.count('font="Hack Nerd Regular"'), 4)
+
+    def test_generated_layout_puts_date_on_left_or_center_for_n1(self):
+        self.assertIn('date_role = "left" if any(base_role(role) == "left" for role in roles) else "center"', SOURCE_TEXT)
+        self.assertIn('show_date=base_role(role) == date_role', SOURCE_TEXT)
+        self.assertIn('show_date = role == "center"', SOURCE_TEXT)
 
     def test_agent_zero_chat_is_centered_and_todo_is_right_aligned(self):
         self.assertIn('x=0.19,\n                    y=0.04,', SOURCE_TEXT)

--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -162,6 +162,14 @@ list_org_paths() {
   done < <(git -C "$REPO_DIR" ls-tree -r --name-only "$ref" -- agenda)
 }
 
+list_local_org_paths() {
+  local path rel
+  while IFS= read -r -d '' path; do
+    rel="${path#"$ORG_DIR/"}"
+    printf 'agenda/%s\n' "$rel"
+  done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
+}
+
 sync_dotfiles_literate
 repair_legacy_imports
 
@@ -183,11 +191,12 @@ mapfile -t org_paths < <(
   {
     list_org_paths "$BASE"
     list_org_paths "$REMOTE_HEAD"
+    list_local_org_paths
   } | sort -u
 )
 
 if ((${#org_paths[@]} == 0)); then
-  printf 'gpt-todos-sync: no tracked agenda/*.org files; nothing to sync\n'
+  printf 'gpt-todos-sync: no agenda .org files; nothing to sync\n'
   exit 0
 fi
 
@@ -208,10 +217,15 @@ for rel in "${org_paths[@]}"; do
   fi
 
   if [[ "$base_hash" == "-" ]]; then
-    if [[ "$local_hash" != "-" && "$local_hash" != "$remote_hash" ]]; then
-      printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
-      conflicts=$((conflicts + 1))
+    if [[ "$remote_hash" == "-" ]]; then
+      [[ "$local_hash" == "-" ]] || local_changes+=("$rel")
+      continue
     fi
+    if [[ "$local_hash" == "-" || "$local_hash" == "$remote_hash" ]]; then
+      continue
+    fi
+    printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
     continue
   fi
 
@@ -238,6 +252,7 @@ git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
 
 for rel in "${local_changes[@]}"; do
   local_rel="${rel#agenda/}"
+  mkdir -p "$(dirname "$REPO_DIR/$rel")"
   cp -p -- "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
 done
 

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -4,19 +4,18 @@
 
 * Sync
 
-This is the canonical literate source for the task-state sync helper.  Org files
-already tracked under =gpt-todos/agenda/= are synchronized bidirectionally with
-the live Org agenda.  The durable checkout's current =HEAD= is the synchronization
-baseline: the helper fetches the upstream ref, compares Git blob identities, and
-only copies a side when that side changed relative to the baseline.  Concurrent
-local and remote edits to the same file are rejected instead of being resolved
-by filesystem timestamps.
+This is the canonical literate source for the task-state sync helper.  Every
+=.org= file in the configured recursive Org agenda tree is synchronized
+bidirectionally with =gpt-todos/agenda/=, including newly created local agenda
+files and nested project paths.  This matches the Doom configuration that builds
+=org-agenda-files= recursively from =~/Documents/Notes/org/agenda/=.
 
-Untracked files from =~/Documents/Notes/org/agenda/= are deliberately not
-imported, so unrelated agenda data cannot leak into the GPT TODO repository.
-Missing local copies are restored from the repository; repository-side deletion
-requires manual resolution.  The default durable checkout is
-=~/Documents/gpt-todos=.
+The durable checkout's current =HEAD= is the synchronization baseline: the helper
+fetches the upstream ref, compares Git blob identities, and only copies a side
+when that side changed relative to the baseline.  Concurrent local and remote
+edits to the same file are rejected instead of being resolved by filesystem
+timestamps.  Repository-side deletion still requires manual resolution.
+The default durable checkout is =~/Documents/gpt-todos=.
 
 The same command also owns deployment.  Run =gpt-todos-sync --deploy 5= to
 perform the initial sync and install the five-minute cron entry.  Git operations
@@ -188,6 +187,14 @@ list_org_paths() {
   done < <(git -C "$REPO_DIR" ls-tree -r --name-only "$ref" -- agenda)
 }
 
+list_local_org_paths() {
+  local path rel
+  while IFS= read -r -d '' path; do
+    rel="${path#"$ORG_DIR/"}"
+    printf 'agenda/%s\n' "$rel"
+  done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
+}
+
 sync_dotfiles_literate
 repair_legacy_imports
 
@@ -209,11 +216,12 @@ mapfile -t org_paths < <(
   {
     list_org_paths "$BASE"
     list_org_paths "$REMOTE_HEAD"
+    list_local_org_paths
   } | sort -u
 )
 
 if ((${#org_paths[@]} == 0)); then
-  printf 'gpt-todos-sync: no tracked agenda/*.org files; nothing to sync\n'
+  printf 'gpt-todos-sync: no agenda .org files; nothing to sync\n'
   exit 0
 fi
 
@@ -234,10 +242,15 @@ for rel in "${org_paths[@]}"; do
   fi
 
   if [[ "$base_hash" == "-" ]]; then
-    if [[ "$local_hash" != "-" && "$local_hash" != "$remote_hash" ]]; then
-      printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
-      conflicts=$((conflicts + 1))
+    if [[ "$remote_hash" == "-" ]]; then
+      [[ "$local_hash" == "-" ]] || local_changes+=("$rel")
+      continue
     fi
+    if [[ "$local_hash" == "-" || "$local_hash" == "$remote_hash" ]]; then
+      continue
+    fi
+    printf 'gpt-todos-sync: new remote file conflicts with local file: %s\n' "$rel" >&2
+    conflicts=$((conflicts + 1))
     continue
   fi
 
@@ -264,6 +277,7 @@ git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
 
 for rel in "${local_changes[@]}"; do
   local_rel="${rel#agenda/}"
+  mkdir -p "$(dirname "$REPO_DIR/$rel")"
   cp -p -- "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
 done
 

--- a/tests/gpt-todos-sync.sh
+++ b/tests/gpt-todos-sync.sh
@@ -38,19 +38,34 @@ run_sync() {
     bash "$SYNC"
 }
 
+# Initial remote state is restored into the complete local agenda tree.
 run_sync
 cmp "$ORG/shared.org" "$SEED/agenda/shared.org"
 cmp "$ORG/remote.org" "$SEED/agenda/remote.org"
 
-printf '* TODO private-local-only\n' > "$ORG/private.org"
+# New local agenda files, including nested project files, are first-class sync
+# inputs because Emacs discovers the agenda tree recursively.
+printf '* TODO local-only\n' > "$ORG/local-only.org"
+mkdir -p "$ORG/projects/demo"
+printf '* TODO nested-local\n' > "$ORG/projects/demo/tasks.org"
 printf '* DONE shared-local\n' > "$ORG/shared.org"
 run_sync
 git -C "$SEED" pull >/dev/null 2>&1
 cmp "$ORG/shared.org" "$SEED/agenda/shared.org"
-if git -C "$SEED" ls-files --error-unmatch agenda/private.org >/dev/null 2>&1; then
-  printf 'untracked local agenda file leaked into gpt-todos\n' >&2
-  exit 1
-fi
+cmp "$ORG/local-only.org" "$SEED/agenda/local-only.org"
+cmp "$ORG/projects/demo/tasks.org" "$SEED/agenda/projects/demo/tasks.org"
+git -C "$SEED" ls-files --error-unmatch agenda/local-only.org >/dev/null
+git -C "$SEED" ls-files --error-unmatch agenda/projects/demo/tasks.org >/dev/null
+
+# A new remote nested agenda file is restored locally without flattening it.
+mkdir -p "$SEED/agenda/projects/remote"
+printf '* TODO remote-nested\n' > "$SEED/agenda/projects/remote/tasks.org"
+git -C "$SEED" add agenda/projects/remote/tasks.org
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -m remote-nested >/dev/null
+git -C "$SEED" push >/dev/null 2>&1
+run_sync
+grep -q 'remote-nested' "$ORG/projects/remote/tasks.org"
 
 printf '* DONE remote-change\n' > "$SEED/agenda/remote.org"
 git -C "$SEED" add agenda/remote.org
@@ -60,6 +75,7 @@ git -C "$SEED" push >/dev/null 2>&1
 run_sync
 grep -q 'remote-change' "$ORG/remote.org"
 
+# Concurrent edits remain fail-closed.
 printf '* TODO local-conflict\n' > "$ORG/shared.org"
 git -C "$SEED" pull >/dev/null 2>&1
 printf '* TODO remote-conflict\n' > "$SEED/agenda/shared.org"
@@ -75,4 +91,4 @@ set -e
 [[ "$rc" -eq 5 ]]
 grep -q 'local-conflict' "$ORG/shared.org"
 
-printf 'gpt-todos bidirectional sync tests passed\n'
+printf 'gpt-todos recursive agenda sync tests passed\n'


### PR DESCRIPTION
RAGE implementation for #128 and #129.

## OpenRouter telemetry
- replace the volatile ~5h in-memory graph deque with persistent SQLite history under XDG state
- persist trusted closed-minute I/O samples idempotently
- bounded detached backfill: recent history hourly, older history daily, no invented interpolation
- graph visibly rotates every 5 seconds through `1m`, `5m`, `1h`, `6h`, `12h`, `1d`, `1w`, `1mo`, `1y`
- manual graph range stepping via mouse
- graph DB reads run on a daemon worker and marshal draws back to Qtile's event loop
- one shared Y scale for input/output
- flat non-zero series no longer disappear
- history DB failure degrades independently instead of taking down live rate/balance telemetry
- collector exposes stale/error diagnostics instead of silently swallowing every failure
- `--history`, `--doctor`, and `--backfill` diagnostics/actions
- canonical `qtile-openrouter.org` updated with tangled output

## Org/browser screen
- add left-screen GPT TODO sync button
- run sync off the Qtile event loop with success/failure notifications
- add Nerd Font calendar/clock icons
- retain exactly one full date: left/Org screen when present, center fallback on a one-monitor layout; all other clocks remain time-only

## Agenda sync
- synchronize every recursive `.org` file in the configured agenda tree, matching the Emacs `org-agenda-files` recursion
- new local files and nested project paths are imported instead of silently ignored
- remote additions restore locally
- concurrent local/remote edits and remote deletions remain fail-closed
- update canonical `scripts/gpt-todos-sync.org` alongside the tangled helper

## Tests
Adds/updates coverage for persistent history, range mapping, backfill granularity, idempotency, shared scale, no interpolation, history-store degradation, recursive/nested agenda files, Org sync UI, and clock/date icon policy.

Closes #128
Closes #129