### PR TITLE
fix(qtile): detach OpenRouter collection from reload

### DIFF
--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -147,6 +147,22 @@ def visible_window_groups(groups: Iterable[Any]) -> list[Any]:
     ]
 
 
+def group_indicator_geometry(
+    offset: int | float,
+    width: int | float,
+    padding_x: int | float,
+) -> tuple[int | float, int | float]:
+    """Inset the screen indicator to the glyph area without moving its center."""
+    inset = max(float(padding_x), 0.0)
+    if float(width) <= inset * 2:
+        return offset, width
+    aligned_offset = float(offset) + inset
+    aligned_width = float(width) - inset * 2
+    if isinstance(offset, int) and isinstance(width, int) and float(padding_x).is_integer():
+        return int(aligned_offset), int(aligned_width)
+    return aligned_offset, aligned_width
+
+
 def _screen_index(screens: list[Any], screen: Any) -> int | None:
     for index, candidate in enumerate(screens):
         if candidate is screen:
@@ -414,13 +430,18 @@ def _owned_group_box(config_globals: dict[str, Any]):
                 current = self.bar.screen.group == group
                 focused = current and self.qtile.current_screen == self.bar.screen
                 width = self.box_width([group])
-                self.drawbox(
+                visual_offset, visual_width = group_indicator_geometry(
                     offset,
+                    width,
+                    self.padding_x,
+                )
+                self.drawbox(
+                    visual_offset,
                     group.label,
                     palette["white"] if current else None,
                     text_color,
                     highlight_color=[palette["deep"], owner_color],
-                    width=width,
+                    width=visual_width,
                     rounded=True,
                     block=False,
                     line=current,

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -37,6 +37,15 @@ DEFAULT_MAX_TPM = 10_000_000
 BACKFILL_INTERVAL_SECONDS = 6 * 60 * 60
 BACKFILL_DAYS = 365
 BACKFILL_FINE_DAYS = 7
+DAEMON_POLL_SECONDS = 1.0
+DAEMON_HEARTBEAT_STALE_SECONDS = 5.0
+COLLECTOR_KEYS = (
+    "collector_pid",
+    "collector_parent_pid",
+    "collector_heartbeat",
+    "collector_error",
+    "collector_stale",
+)
 
 
 @dataclass(frozen=True)
@@ -92,8 +101,6 @@ def _management_key_file() -> Path:
 
 
 def load_management_key() -> str:
-    # OPENROUTER_API_KEY remains a compatibility fallback for users who place
-    # a management key there. Analytics itself requires management-key scope.
     for env_name in ("OPENROUTER_MANAGEMENT_KEY", "OPENROUTER_API_KEY"):
         value = os.environ.get(env_name, "").strip()
         if value:
@@ -114,7 +121,7 @@ def _request_json(
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}",
-        "User-Agent": "qtile-openrouter-status/5",
+        "User-Agent": "qtile-openrouter-status/6",
     }
     if payload is not None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -344,6 +351,10 @@ def _cache_path() -> Path:
     return root / "qtile" / "openrouter-status.json"
 
 
+def _daemon_lock_path() -> Path:
+    return _cache_path().with_suffix(".daemon.lock")
+
+
 def _read_cache(path: Path) -> dict[str, Any] | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -360,17 +371,34 @@ def _status_from_cache(cache: dict[str, Any] | None) -> Status | None:
         return None
 
 
-def _write_cache(path: Path, status: Status, *, fetched_at: float) -> None:
+def _write_document(path: Path, document: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(".tmp")
     temporary.write_text(
-        json.dumps(
-            {"fetched_at": fetched_at, "status": asdict(status)},
-            separators=(",", ":"),
-        ),
+        json.dumps(document, separators=(",", ":")),
         encoding="utf-8",
     )
     temporary.replace(path)
+
+
+def _write_cache(
+    path: Path,
+    status: Status,
+    *,
+    fetched_at: float,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    existing = _read_cache(path) or {}
+    document: dict[str, Any] = {
+        "fetched_at": fetched_at,
+        "status": asdict(status),
+    }
+    for key in COLLECTOR_KEYS:
+        if key in existing:
+            document[key] = existing[key]
+    if metadata:
+        document.update(metadata)
+    _write_document(path, document)
 
 
 def _iso_now(now: datetime) -> str:
@@ -558,10 +586,202 @@ def _json_payload(status: Status, stale: bool) -> dict[str, Any]:
     return payload
 
 
+def _pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 1:
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except (OSError, ValueError, TypeError):
+        return False
+    return True
+
+
+def _cached_json_payload(
+    cache: dict[str, Any] | None,
+    *,
+    now: float | None = None,
+) -> dict[str, Any] | None:
+    if not cache:
+        return None
+    now = time.time() if now is None else float(now)
+    status = _status_from_cache(cache)
+    collector_error = cache.get("collector_error")
+    if status is None:
+        if collector_error:
+            return {
+                "error": str(collector_error),
+                "collector_pid": cache.get("collector_pid"),
+                "collector_parent_pid": cache.get("collector_parent_pid"),
+                "collector_heartbeat": cache.get("collector_heartbeat"),
+            }
+        return None
+
+    payload = asdict(status)
+    payload["total_tokens_per_minute"] = status.total_tokens_per_minute
+    heartbeat = float(cache.get("collector_heartbeat") or 0)
+    fetched_at = float(cache.get("fetched_at") or 0)
+    if heartbeat:
+        stale = now - heartbeat > DAEMON_HEARTBEAT_STALE_SECONDS
+    else:
+        stale = now - fetched_at > max(USAGE_REFRESH_SECONDS * 2, 90)
+    stale = bool(cache.get("collector_stale")) or stale
+    payload["stale"] = stale
+    payload["collector_pid"] = cache.get("collector_pid")
+    payload["collector_parent_pid"] = cache.get("collector_parent_pid")
+    payload["collector_heartbeat"] = cache.get("collector_heartbeat")
+    payload["collector_error"] = collector_error
+    if collector_error and not payload.get("last_error"):
+        payload["last_error"] = str(collector_error)
+    return payload
+
+
+def _collector_is_fresh(
+    cache: dict[str, Any] | None,
+    parent_pid: int,
+    *,
+    now: float | None = None,
+) -> bool:
+    if not cache:
+        return False
+    now = time.time() if now is None else float(now)
+    try:
+        pid = int(cache.get("collector_pid") or 0)
+        recorded_parent = int(cache.get("collector_parent_pid") or 0)
+        heartbeat = float(cache.get("collector_heartbeat") or 0)
+    except (TypeError, ValueError):
+        return False
+    return (
+        recorded_parent == int(parent_pid)
+        and heartbeat > 0
+        and now - heartbeat <= DAEMON_HEARTBEAT_STALE_SECONDS
+        and _pid_alive(pid)
+    )
+
+
+def _ensure_daemon(parent_pid: int, *, now: float | None = None) -> bool:
+    cache = _read_cache(_cache_path())
+    if _collector_is_fresh(cache, parent_pid, now=now):
+        return False
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--daemon",
+                "--parent-pid",
+                str(int(parent_pid)),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        return False
+    return True
+
+
+def _collector_metadata(
+    parent_pid: int,
+    *,
+    stale: bool,
+    error: str | None,
+) -> dict[str, Any]:
+    return {
+        "collector_pid": os.getpid(),
+        "collector_parent_pid": int(parent_pid),
+        "collector_heartbeat": time.time(),
+        "collector_error": error,
+        "collector_stale": bool(stale),
+    }
+
+
+def _publish_collector_error(parent_pid: int, error: str) -> None:
+    path = _cache_path()
+    cache = _read_cache(path) or {}
+    status = _status_from_cache(cache)
+    if status is not None:
+        status = replace(status, last_error=error)
+        _write_cache(
+            path,
+            status,
+            fetched_at=float(cache.get("fetched_at") or 0),
+            metadata=_collector_metadata(parent_pid, stale=True, error=error),
+        )
+        return
+    document = {
+        key: value
+        for key, value in cache.items()
+        if key not in COLLECTOR_KEYS
+    }
+    document.update(_collector_metadata(parent_pid, stale=True, error=error))
+    _write_document(path, document)
+
+
+def _sleep_while_parent_alive(parent_pid: int, seconds: float) -> bool:
+    deadline = time.monotonic() + max(seconds, 0)
+    while time.monotonic() < deadline:
+        if not _pid_alive(parent_pid):
+            return False
+        time.sleep(min(0.1, max(deadline - time.monotonic(), 0)))
+    return _pid_alive(parent_pid)
+
+
+def run_daemon(parent_pid: int) -> int:
+    """Run one Qtile-owned collector. Network work never occurs in widget polling."""
+    lock_path = _daemon_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return 0
+        lock.seek(0)
+        lock.truncate()
+        lock.write(json.dumps({"pid": os.getpid(), "parent_pid": int(parent_pid)}))
+        lock.flush()
+
+        while _pid_alive(parent_pid):
+            try:
+                key = load_management_key()
+                if not key:
+                    raise RuntimeError("management key missing")
+                status, stale = status_with_cache(key, force=True)
+                _write_cache(
+                    _cache_path(),
+                    status,
+                    fetched_at=time.time(),
+                    metadata=_collector_metadata(parent_pid, stale=stale, error=None),
+                )
+                _launch_backfill_if_due()
+            except (RuntimeError, OSError, sqlite3.Error) as exc:
+                _publish_collector_error(parent_pid, str(exc))
+            if not _sleep_while_parent_alive(parent_pid, DAEMON_POLL_SECONDS):
+                break
+    return 0
+
+
+def _doctor_payload() -> dict[str, Any]:
+    info = _history_diagnostics()
+    info["management_key_file"] = str(_management_key_file())
+    info["management_key_available"] = bool(
+        os.environ.get("OPENROUTER_MANAGEMENT_KEY")
+        or os.environ.get("OPENROUTER_API_KEY")
+        or _management_key_file().exists()
+    )
+    cache = _read_cache(_cache_path()) or {}
+    for key in COLLECTOR_KEYS:
+        info[key] = cache.get(key)
+    info["collector_alive"] = _pid_alive(cache.get("collector_pid"))
+    return info
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--json", action="store_true", help="print machine-readable status")
-    parser.add_argument("--force", action="store_true", help="ignore the short process cache")
+    parser.add_argument("--json", action="store_true", help="print cache-only machine-readable status")
+    parser.add_argument("--force", action="store_true", help="perform a synchronous one-shot provider refresh")
+    parser.add_argument("--daemon", action="store_true", help="run the Qtile-owned background collector")
+    parser.add_argument("--parent-pid", type=int, help="owner PID for daemon lifecycle")
     parser.add_argument("--backfill", action="store_true", help="backfill persistent history and exit")
     parser.add_argument("--history", choices=tuple(history.TIMEFRAME_SECONDS), help="print a local history range and exit")
     parser.add_argument("--points", type=int, default=82, help="maximum local history points")
@@ -574,14 +794,19 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.doctor:
-            info = _history_diagnostics()
-            info["management_key_file"] = str(_management_key_file())
-            info["management_key_available"] = bool(
-                os.environ.get("OPENROUTER_MANAGEMENT_KEY")
-                or os.environ.get("OPENROUTER_API_KEY")
-                or _management_key_file().exists()
-            )
-            print(json.dumps(info, sort_keys=True))
+            print(json.dumps(_doctor_payload(), sort_keys=True))
+            return 0
+
+        if args.daemon:
+            return run_daemon(args.parent_pid or os.getppid())
+
+        if args.json and not args.force:
+            parent_pid = args.parent_pid or os.getppid()
+            _ensure_daemon(parent_pid)
+            payload = _cached_json_payload(_read_cache(_cache_path()))
+            if payload is None:
+                payload = {"error": "starting", "collector_parent_pid": parent_pid}
+            print(json.dumps(payload, sort_keys=True))
             return 0
 
         key = load_management_key()

--- a/.config/qtile/tests/test_groupbox_navigation.py
+++ b/.config/qtile/tests/test_groupbox_navigation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Widget-level regression tests for OwnedGroupBox navigation.
+"""Widget-level regression tests for OwnedGroupBox navigation and geometry.
 
 The libqtile stub's GroupBox base carries the verbatim Qtile 0.33.0
 next_group/prev_group implementation, which spins forever when
@@ -253,6 +253,14 @@ class OwnedGroupBoxNavigationTests(unittest.TestCase):
         sentinel = object()
         self.assertIs(MODULE.next_visible_group([sentinel], sentinel), sentinel)
         self.assertIs(MODULE.next_visible_group([sentinel], object()), sentinel)
+
+    def test_group_indicator_insets_padding_without_moving_center(self):
+        offset, width = MODULE.group_indicator_geometry(100, 32, 6)
+        self.assertEqual((offset, width), (106, 20))
+        self.assertEqual(100 + 32 / 2, offset + width / 2)
+
+    def test_group_indicator_does_not_collapse_tiny_boxes(self):
+        self.assertEqual(MODULE.group_indicator_geometry(5, 8, 6), (5, 8))
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_openrouter_daemon.py
+++ b/.config/qtile/tests/test_openrouter_daemon.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Regression tests for the Qtile-owned OpenRouter collector daemon."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+QTILE_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = QTILE_DIR / "scripts" / "openrouter_status.py"
+sys.path.insert(0, str(QTILE_DIR))
+SPEC = importlib.util.spec_from_file_location("openrouter_status_daemon", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenRouterDaemonTests(unittest.TestCase):
+    def test_json_is_cache_only_and_never_calls_provider(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {"XDG_CACHE_HOME": directory}, clear=False):
+                MODULE._write_cache(
+                    MODULE._cache_path(),
+                    MODULE.Status(1234, 56, balance_usd=12.5),
+                    fetched_at=time.time(),
+                    metadata={
+                        "collector_pid": os.getpid(),
+                        "collector_parent_pid": os.getpid(),
+                        "collector_heartbeat": time.time(),
+                        "collector_error": None,
+                    },
+                )
+                output = io.StringIO()
+                with (
+                    mock.patch.object(MODULE, "_ensure_daemon", return_value=False),
+                    mock.patch.object(
+                        MODULE,
+                        "_request_json",
+                        side_effect=AssertionError("--json must never touch OpenRouter"),
+                    ),
+                    contextlib.redirect_stdout(output),
+                ):
+                    rc = MODULE.main(["--json"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["input_tokens_per_minute"], 1234)
+        self.assertEqual(payload["output_tokens_per_minute"], 56)
+        self.assertEqual(payload["balance_usd"], 12.5)
+
+    def test_empty_cache_returns_starting_immediately(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = io.StringIO()
+            with (
+                mock.patch.dict(os.environ, {"XDG_CACHE_HOME": directory}, clear=False),
+                mock.patch.object(MODULE, "_ensure_daemon", return_value=True) as ensure,
+                mock.patch.object(
+                    MODULE,
+                    "load_management_key",
+                    side_effect=AssertionError("cache reader must not load credentials"),
+                ),
+                contextlib.redirect_stdout(output),
+            ):
+                rc = MODULE.main(["--json"])
+        self.assertEqual(rc, 0)
+        ensure.assert_called_once()
+        self.assertEqual(json.loads(output.getvalue())["error"], "starting")
+
+    def test_fresh_matching_collector_is_not_spawned_again(self):
+        now = time.time()
+        cache = {
+            "collector_pid": os.getpid(),
+            "collector_parent_pid": 4242,
+            "collector_heartbeat": now,
+        }
+        with (
+            mock.patch.object(MODULE, "_read_cache", return_value=cache),
+            mock.patch.object(MODULE.subprocess, "Popen") as popen,
+        ):
+            started = MODULE._ensure_daemon(4242, now=now)
+        self.assertFalse(started)
+        popen.assert_not_called()
+
+    def test_stale_collector_is_relaunched_detached(self):
+        now = time.time()
+        cache = {
+            "collector_pid": 99999999,
+            "collector_parent_pid": 4242,
+            "collector_heartbeat": now - MODULE.DAEMON_HEARTBEAT_STALE_SECONDS - 1,
+        }
+        with (
+            mock.patch.object(MODULE, "_read_cache", return_value=cache),
+            mock.patch.object(MODULE.subprocess, "Popen") as popen,
+        ):
+            started = MODULE._ensure_daemon(4242, now=now)
+        self.assertTrue(started)
+        command = popen.call_args.args[0]
+        self.assertIn("--daemon", command)
+        self.assertIn("--parent-pid", command)
+        self.assertIn("4242", command)
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+
+    def test_widget_payload_surfaces_collector_error_without_network(self):
+        status = MODULE.Status(100, 10, balance_usd=7.0)
+        cache = {
+            "fetched_at": time.time(),
+            "status": MODULE.asdict(status),
+            "collector_pid": 12,
+            "collector_parent_pid": 34,
+            "collector_heartbeat": time.time(),
+            "collector_error": "management key missing",
+        }
+        payload = MODULE._cached_json_payload(cache, now=time.time())
+        self.assertEqual(payload["input_tokens_per_minute"], 100)
+        self.assertEqual(payload["collector_error"], "management key missing")
+        self.assertEqual(payload["last_error"], "management key missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
RAGE implementation for #131 plus the active-screen GroupBox alignment defect captured during live review.

## OpenRouter reload fix
- `openrouter_status.py --json` is cache-only and returns immediately
- the first Qtile poll ensures a detached `--daemon` collector owned by the Qtile parent PID
- all OpenRouter network requests, balance/usage metadata refreshes, minute sampling, and history/backfill work happen in the daemon
- reloads reuse a fresh collector rather than starting another long-lived fetcher
- collector heartbeat/PID/error state is stored with the cache
- empty cache renders `starting` instead of hanging on placeholders
- auth/provider failure is surfaced without blocking the bar
- `--force` preserves a synchronous one-shot diagnostic path; Qtile never uses it
- `--doctor` reports collector lifecycle state

## Group highlight alignment
- active/current screen underline no longer spans the full padded GroupBox cell
- visual indicator is inset by `padding_x` so it aligns with the Nerd Font group glyph
- original group center, spacing, and click geometry remain unchanged

## Regression gates
- cache-only `--json` cannot call the provider
- empty cache starts the collector and returns immediately
- fresh collector is not duplicated
- stale collector is relaunched detached
- collector errors remain visible alongside cached telemetry
- group-indicator geometry preserves center while removing horizontal padding
- existing OpenRouter/history/Qtile/literate/Nix gates remain in force

Closes #131