### PR TITLE
fix(qtile): unclip OpenRouter rate and reveal output graph

### DIFF
--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -14,7 +14,9 @@ collector persists trusted provider buckets in a local SQLite history under
 SQLite lock cannot stall Qtile's event loop, then visibly rotates every five
 seconds through =1m → 5m → 1h → 6h → 12h → 1d → 1w → 1mo → 1y=.
 Provider buckets are never interpolated to invent detail.  Input and output use
-one shared scale so their relative magnitude remains truthful.
+one shared =log1p= display transform and one shared ceiling: zero remains the
+center line and ordering remains truthful, while large prompt-token spikes no
+longer crush smaller completion-token activity into a subpixel line.
 
 #+begin_src python
 """OpenRouter telemetry widgets and Qtile runtime helpers."""
@@ -22,6 +24,7 @@ one shared scale so their relative magnitude remains truthful.
 from __future__ import annotations
 
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -38,7 +41,8 @@ import openrouter_history
 POLL_SECONDS = 1
 GRAPH_SAMPLES = 82
 GRAPH_WIDTH = 96
-RATE_FONTSIZE = 12
+METRIC_FONTSIZE = 12
+RATE_FONTSIZE = 10
 ROTATE_SECONDS = 5
 COLLECTOR_HEARTBEAT_STALE_SECONDS = 30
 GRAPH_RANGES = tuple(label for label, _seconds in openrouter_history.TIMEFRAMES)
@@ -224,6 +228,21 @@ def _step_graph_range(step):
         return GRAPH_RANGES[_graph_range_index]
 
 
+def _graph_normalized(value, ceiling):
+    """Compress a shared token scale without hiding the smaller I/O series.
+
+    Both input and output use this exact same log1p transform. Zero remains the
+    center line, the window ceiling remains full height, and ordering is
+    preserved while large prompt-token spikes stop crushing completion-token
+    activity into a subpixel line.
+    """
+    value = max(float(value or 0), 0.0)
+    ceiling = max(float(ceiling or 0), 0.0)
+    if value <= 0 or ceiling <= 0:
+        return 0.0
+    return min(math.log1p(value) / math.log1p(ceiling), 1.0)
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -351,7 +370,7 @@ class OpenRouterGraphRange(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Persistent input/output graph with one truthful shared Y scale."""
+    """Persistent input/output graph with one shared logarithmic Y transform."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
@@ -360,7 +379,7 @@ class OpenRouterIOGraph(base._Widget):
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
-        ("line_width", 1.4, "Graph line width."),
+        ("line_width", 1.8, "Graph line width."),
         ("margin_x", 2, "Horizontal graph margin."),
         ("margin_y", 2, "Vertical graph margin."),
     ]
@@ -437,7 +456,7 @@ class OpenRouterIOGraph(base._Widget):
         self.drawer.ctx.set_line_width(self.line_width)
         for index, sample in enumerate(samples):
             x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
-            normalized = min(max(float(sample.get(key, 0)) / ceiling, 0.0), 1.0)
+            normalized = _graph_normalized(sample.get(key, 0), ceiling)
             y = center_y + direction * normalized * half_height
             if len(samples) == 1:
                 self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
@@ -453,7 +472,7 @@ class OpenRouterIOGraph(base._Widget):
         center_y = self.height / 2.0
         half_height = max(center_y - self.margin_y - 1, 1)
         self.drawer.set_source_rgb(self.midline_color)
-        self.drawer.ctx.set_line_width(0.6)
+        self.drawer.ctx.set_line_width(0.5)
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
@@ -492,14 +511,19 @@ def _telemetry_widgets(home, colors):
         "update_interval": POLL_SECONDS,
         "markup": True,
         "font": "Hack Nerd Regular",
-        "fontsize": RATE_FONTSIZE,
+        "fontsize": METRIC_FONTSIZE,
         "padding": 3,
         "foreground": _color(colors, 5),
         "background": background,
     }
+    rate_common = {
+        **common,
+        "fontsize": RATE_FONTSIZE,
+        "padding": 2,
+    }
     return [
         OpenRouterCredit(script, colors, name="openrouter_credit", **common),
-        OpenRouterRate(script, colors, name="openrouter_rate", **common),
+        OpenRouterRate(script, colors, name="openrouter_rate", **rate_common),
         OpenRouterGraphRange(colors, name="openrouter_graph_range", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -19,7 +20,8 @@ import openrouter_history
 POLL_SECONDS = 1
 GRAPH_SAMPLES = 82
 GRAPH_WIDTH = 96
-RATE_FONTSIZE = 12
+METRIC_FONTSIZE = 12
+RATE_FONTSIZE = 10
 ROTATE_SECONDS = 5
 COLLECTOR_HEARTBEAT_STALE_SECONDS = 30
 GRAPH_RANGES = tuple(label for label, _seconds in openrouter_history.TIMEFRAMES)
@@ -205,6 +207,21 @@ def _step_graph_range(step):
         return GRAPH_RANGES[_graph_range_index]
 
 
+def _graph_normalized(value, ceiling):
+    """Compress a shared token scale without hiding the smaller I/O series.
+
+    Both input and output use this exact same log1p transform. Zero remains the
+    center line, the window ceiling remains full height, and ordering is
+    preserved while large prompt-token spikes stop crushing completion-token
+    activity into a subpixel line.
+    """
+    value = max(float(value or 0), 0.0)
+    ceiling = max(float(ceiling or 0), 0.0)
+    if value <= 0 or ceiling <= 0:
+        return 0.0
+    return min(math.log1p(value) / math.log1p(ceiling), 1.0)
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -332,7 +349,7 @@ class OpenRouterGraphRange(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Persistent input/output graph with one truthful shared Y scale."""
+    """Persistent input/output graph with one shared logarithmic Y transform."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
@@ -341,7 +358,7 @@ class OpenRouterIOGraph(base._Widget):
         ("input_color", "#f6019d", "Prompt-token graph color."),
         ("output_color", "#2de2e6", "Completion-token graph color."),
         ("midline_color", "#92406e", "Graph center-line color."),
-        ("line_width", 1.4, "Graph line width."),
+        ("line_width", 1.8, "Graph line width."),
         ("margin_x", 2, "Horizontal graph margin."),
         ("margin_y", 2, "Vertical graph margin."),
     ]
@@ -418,7 +435,7 @@ class OpenRouterIOGraph(base._Widget):
         self.drawer.ctx.set_line_width(self.line_width)
         for index, sample in enumerate(samples):
             x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
-            normalized = min(max(float(sample.get(key, 0)) / ceiling, 0.0), 1.0)
+            normalized = _graph_normalized(sample.get(key, 0), ceiling)
             y = center_y + direction * normalized * half_height
             if len(samples) == 1:
                 self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
@@ -434,7 +451,7 @@ class OpenRouterIOGraph(base._Widget):
         center_y = self.height / 2.0
         half_height = max(center_y - self.margin_y - 1, 1)
         self.drawer.set_source_rgb(self.midline_color)
-        self.drawer.ctx.set_line_width(0.6)
+        self.drawer.ctx.set_line_width(0.5)
         self.drawer.ctx.move_to(self.margin_x, center_y)
         self.drawer.ctx.line_to(self.width - self.margin_x, center_y)
         self.drawer.ctx.stroke()
@@ -473,14 +490,19 @@ def _telemetry_widgets(home, colors):
         "update_interval": POLL_SECONDS,
         "markup": True,
         "font": "Hack Nerd Regular",
-        "fontsize": RATE_FONTSIZE,
+        "fontsize": METRIC_FONTSIZE,
         "padding": 3,
         "foreground": _color(colors, 5),
         "background": background,
     }
+    rate_common = {
+        **common,
+        "fontsize": RATE_FONTSIZE,
+        "padding": 2,
+    }
     return [
         OpenRouterCredit(script, colors, name="openrouter_credit", **common),
-        OpenRouterRate(script, colors, name="openrouter_rate", **common),
+        OpenRouterRate(script, colors, name="openrouter_rate", **rate_common),
         OpenRouterGraphRange(colors, name="openrouter_graph_range", **common),
         OpenRouterIOGraph(
             name="openrouter_io_graph",

--- a/.config/qtile/tests/test_openrouter_range_rotation.py
+++ b/.config/qtile/tests/test_openrouter_range_rotation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Behavioral tests for OpenRouter graph timeframe rotation."""
+"""Behavioral tests for OpenRouter graph timeframe rotation and scaling."""
 
 from __future__ import annotations
 
@@ -88,6 +88,24 @@ class OpenRouterRangeRotationTests(unittest.TestCase):
         with mock.patch.object(MODULE.time, "monotonic", return_value=223.0):
             self.assertEqual(MODULE._step_graph_range(-1), "1m")
         self.assertEqual(MODULE._graph_range_changed_at, 223.0)
+
+    def test_log_scale_keeps_zero_at_baseline_and_ceiling_at_full_height(self):
+        self.assertEqual(MODULE._graph_normalized(0, 10_000), 0.0)
+        self.assertEqual(MODULE._graph_normalized(-1, 10_000), 0.0)
+        self.assertAlmostEqual(MODULE._graph_normalized(10_000, 10_000), 1.0)
+
+    def test_log_scale_keeps_small_output_visibly_above_subpixel_linear_scale(self):
+        # 100 output vs 10k input would be 1% of half-height on a linear graph.
+        # The shared log transform keeps both on the same mathematical scale but
+        # compresses dynamic range so the smaller completion series is readable.
+        normalized = MODULE._graph_normalized(100, 10_000)
+        self.assertGreater(normalized, 0.45)
+        self.assertLess(normalized, 0.55)
+
+    def test_log_scale_is_monotonic_and_shared_for_both_series(self):
+        values = [MODULE._graph_normalized(value, 100_000) for value in (0, 10, 100, 1_000, 10_000, 100_000)]
+        self.assertEqual(values, sorted(values))
+        self.assertEqual(len(set(values)), len(values))
 
 
 if __name__ == "__main__":

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -74,12 +74,21 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertIn("self.qtile.call_soon_threadsafe(apply)", SOURCE_TEXT)
         self.assertIn("daemon=True", SOURCE_TEXT)
 
-    def test_graph_has_one_shared_scale_and_does_not_hide_flat_series(self):
+    def test_graph_uses_one_shared_log_scale_for_both_series(self):
         self.assertIn('ceiling = float(self.series.get("ceiling") or 0)', SOURCE_TEXT)
         self.assertIn('_draw_series("input"', SOURCE_TEXT)
         self.assertIn('_draw_series("output"', SOURCE_TEXT)
+        self.assertIn("_graph_normalized", SOURCE_TEXT)
+        self.assertIn("math.log1p", function_source("_graph_normalized"))
         self.assertNotIn("minimum = min(values)", SOURCE_TEXT)
         self.assertNotIn("if maximum <= minimum:", SOURCE_TEXT)
+
+    def test_stacked_rate_uses_smaller_font_than_single_line_metrics(self):
+        self.assertLess(assigned_constant("RATE_FONTSIZE"), assigned_constant("METRIC_FONTSIZE"))
+        source = function_source("_telemetry_widgets")
+        self.assertIn('"fontsize": METRIC_FONTSIZE', source)
+        self.assertIn('"fontsize": RATE_FONTSIZE', source)
+        self.assertIn("OpenRouterRate", source)
 
     def test_widget_poll_is_cache_only(self):
         source = function_source("_fetch_payload")


### PR DESCRIPTION
RAGE fix from live Qtile screenshots.

## Observed
- cyan output TPM line is vertically clipped in the stacked rate widget
- completion-token graph is effectively invisible when prompt-token spikes dominate a shared linear ceiling

## Fix
- keep single-line telemetry at 12px but render the two-line I/O rate at 10px with tighter padding so both rows fit the 26px bar
- replace shared linear graph normalization with one shared `log1p` transform and one shared ceiling for both input/output
- zero remains exactly on the center line, ordering is preserved, and neither series gets an independent fake auto-scale
- slightly strengthen graph line weight and reduce midline weight
- keep canonical `qtile-openrouter.org` exactly synchronized with tangled Python

## Regression gates
- behavioral tests verify zero->baseline, ceiling->full height, monotonic scale, and small completion values remain visibly above subpixel linear scale
- structural tests require the rate font to be smaller than single-line metrics and require the shared log transform
- existing daemon/cache/history/timeframe/literate/Nix/Home Manager gates remain required