### PR TITLE
feat(qtile): finish bar interactions and truthful telemetry graphs

### DIFF
--- a/.config/dunst/dunst.org
+++ b/.config/dunst/dunst.org
@@ -90,7 +90,7 @@ icon_theme = Adwaita
 icon_position = left
 
     # Scale small icons up to this size, set to 0 to disable. Helpful
-    # for e.g. small files or high-dpi screens. In case of conf :tangle ~/.dotfiles/.config/dunst/dunstrclict,
+    # for e.g. small icons in case of conflict,
     # max_icon_size takes precedence over this.
 min_icon_size = 32
 
@@ -180,6 +180,13 @@ progress_bar_corner_radius = 0
 #+end_src
 
 ** History
+Keep every notification in Dunst's in-memory history for the lifetime of the daemon.
+A value of zero is Dunst's unlimited-history mode.
+#+begin_src conf :tangle ~/.dotfiles/.config/dunst/dunstrc
+sticky_history = yes
+history_length = 0
+#+end_src
+
 ** Misc
 Set path to a dmenu
 #+begin_src conf :tangle ~/.dotfiles/.config/dunst/dunstrc
@@ -231,7 +238,7 @@ script = dunstify "hello"
     foreground = "#ffffff"
     timeout = 10
     # Icon for notifications with normal urgency, uncomment to enable
-    #default_icon = /path/to/icon
+#default_icon = /path/to/icon
 
 
 #+end_src

--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -41,7 +41,7 @@ icon_theme = Adwaita
 icon_position = left
 
     # Scale small icons up to this size, set to 0 to disable. Helpful
-    # for e.g. small files or high-dpi screens. In case of conf :tangle ~/.dotfiles/.config/dunst/dunstrclict,
+    # for e.g. small icons in case of conflict,
     # max_icon_size takes precedence over this.
 min_icon_size = 32
 
@@ -93,6 +93,9 @@ progress_bar_max_width = 300
 # Corner radius for the progress bar. 0 disables rounded corners.
 progress_bar_corner_radius = 0
 
+sticky_history = yes
+history_length = 0
+
 dmenu = ~/.nix-profile/bin/j4-dmenu-desktop -p dunst:
 
 browser = ~/.nix-profile/bin/xdg-open
@@ -121,7 +124,7 @@ script = dunstify "hello"
     foreground = "#ffffff"
     timeout = 10
     # Icon for notifications with normal urgency, uncomment to enable
-    #default_icon = /path/to/icon
+#default_icon = /path/to/icon
 
 [urgency_critical]
     background = "#fba922"

--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -14,9 +14,10 @@ collector persists trusted provider buckets in a local SQLite history under
 SQLite lock cannot stall Qtile's event loop, then visibly rotates every five
 seconds through =1m → 5m → 1h → 6h → 12h → 1d → 1w → 1mo → 1y=.
 Provider buckets are never interpolated to invent detail.  Input and output use
-one shared =log1p= display transform and one shared ceiling: zero remains the
-center line and ordering remains truthful, while large prompt-token spikes no
-longer crush smaller completion-token activity into a subpixel line.
+one shared =log1p= display transform and one shared ceiling.  Each provider
+bucket is rendered across its real time boundaries as a horizontal step;
+contiguous buckets transition vertically and genuine history gaps remain gaps
+instead of becoming smooth synthetic ramps.
 
 #+begin_src python
 """OpenRouter telemetry widgets and Qtile runtime helpers."""
@@ -39,7 +40,7 @@ from libqtile.widget import base
 import openrouter_history
 
 POLL_SECONDS = 1
-GRAPH_SAMPLES = 82
+GRAPH_SAMPLES = 192
 GRAPH_WIDTH = 96
 METRIC_FONTSIZE = 12
 RATE_FONTSIZE = 10
@@ -243,6 +244,13 @@ def _graph_normalized(value, ceiling):
     return min(math.log1p(value) / math.log1p(ceiling), 1.0)
 
 
+def _bucket_bounds(sample):
+    """Return the provider bucket edges represented by one history sample."""
+    center = float(sample.get("timestamp") or 0)
+    duration = max(float(sample.get("bucket_seconds") or 1), 1.0)
+    return center - duration / 2.0, center + duration / 2.0
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -370,7 +378,7 @@ class OpenRouterGraphRange(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Persistent input/output graph with one shared logarithmic Y transform."""
+    """Persistent I/O graph with shared log scaling and truthful bucket edges."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
@@ -445,6 +453,7 @@ class OpenRouterIOGraph(base._Widget):
         ).start()
 
     def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
+        """Draw provider buckets as steps; never interpolate ramps across gaps."""
         samples = self.series.get("samples", [])
         if not samples or ceiling <= 0:
             return
@@ -454,17 +463,27 @@ class OpenRouterIOGraph(base._Widget):
         usable_width = max(self.width - 2 * self.margin_x, 1)
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-        for index, sample in enumerate(samples):
-            x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
+        previous_end = None
+        previous_y = None
+        for sample in samples:
+            bucket_start, bucket_end = _bucket_bounds(sample)
+            clipped_start = max(bucket_start, start)
+            clipped_end = min(bucket_end, end)
+            if clipped_end <= clipped_start:
+                continue
+            x0 = self.margin_x + ((clipped_start - start) / span) * usable_width
+            x1 = self.margin_x + ((clipped_end - start) / span) * usable_width
             normalized = _graph_normalized(sample.get(key, 0), ceiling)
             y = center_y + direction * normalized * half_height
-            if len(samples) == 1:
-                self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
-                self.drawer.ctx.line_to(min(self.width - self.margin_x, x + 2), y)
-            elif index == 0:
-                self.drawer.ctx.move_to(x, y)
+            contiguous = previous_end is not None and abs(clipped_start - previous_end) <= 0.5
+            if contiguous and previous_y is not None:
+                self.drawer.ctx.move_to(x0, previous_y)
+                self.drawer.ctx.line_to(x0, y)
             else:
-                self.drawer.ctx.line_to(x, y)
+                self.drawer.ctx.move_to(x0, y)
+            self.drawer.ctx.line_to(x1, y)
+            previous_end = clipped_end
+            previous_y = y
         self.drawer.ctx.stroke()
 
     def draw(self):

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import ast
+import calendar
 import json
 import os
 import shlex
 import subprocess
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
@@ -35,6 +37,7 @@ WORKFLOWS_PATH = Path("~/.config/qtile/workflows.json").expanduser()
 EMACS_HELPER = Path("~/.config/qtile/qtile-desktop.el").expanduser()
 WORKFLOW_HELPER = Path("~/.config/qtile/qtile-workflow.el").expanduser()
 GPT_TODOS_SYNC = Path("~/.dotfiles/scripts/gpt-todos-sync").expanduser()
+DUNST_MENU = Path("~/.config/qtile/scripts/dunst_menu.py").expanduser()
 _group_owner_roles: dict[str, str] = {}
 _gpt_todos_sync_lock = threading.Lock()
 _gpt_todos_sync_running = False
@@ -268,6 +271,17 @@ def _notify(summary: str, body: str = "") -> None:
         pass
 
 
+def month_calendar_text(now: datetime | None = None) -> str:
+    """Return a stable monospace month calendar for Dunst."""
+    stamp = now or datetime.now()
+    return calendar.TextCalendar(firstweekday=0).formatmonth(stamp.year, stamp.month).rstrip()
+
+
+def _show_month_calendar(_qtile: Any) -> None:
+    stamp = datetime.now()
+    _notify(stamp.strftime("%B %Y"), month_calendar_text(stamp))
+
+
 def _sync_gpt_todos(_qtile: Any) -> None:
     """Run GPT TODO synchronization off the Qtile event loop."""
     global _gpt_todos_sync_running
@@ -361,6 +375,23 @@ def _emacs_frame_command(function: str, title: str) -> str:
         f"(load-file (expand-file-name {json.dumps(str(EMACS_HELPER))})) "
         f"({function}))"
     )
+    frame = f'((name . "{title}") (title . "{title}"))'
+    return " ".join(
+        [
+            "emacsclient",
+            "-c",
+            "-a",
+            "emacs",
+            "-F",
+            shlex.quote(frame),
+            "--eval",
+            shlex.quote(expression),
+        ]
+    )
+
+
+def _emacs_agenda_day_frame_command(title: str) -> str:
+    expression = "(progn (require 'org-agenda) (org-agenda-list nil (current-time) 1))"
     frame = f'((name . "{title}") (title . "{title}"))'
     return " ".join(
         [
@@ -499,6 +530,7 @@ def _base_widgets(config_globals: dict[str, Any]):
 
 def _system_telemetry(config_globals: dict[str, Any]):
     from libqtile import widget
+    from qtile_net_io import NetIOGraph
 
     palette = outrun_palette(config_globals["colors"])
     background = palette["background"]
@@ -548,25 +580,24 @@ def _system_telemetry(config_globals: dict[str, Any]):
             **graph_common,
         ),
         widget.TextBox(
-            text="󰖩",
+            text=(
+                f'󰖩 <span foreground="{palette["electric_blue"]}">↓</span>'
+                f'<span foreground="{palette["pink"]}">↑</span>'
+            ),
+            markup=True,
             font="Hack Nerd Regular",
-            foreground=palette["electric_blue"],
+            foreground=palette["white"],
             background=background,
             padding=2,
         ),
-        widget.NetGraph(
-            interface="auto",
-            bandwidth_type="down",
-            graph_color=palette["electric_blue"],
-            fill_color=palette["cyan"],
-            **graph_common,
-        ),
-        widget.NetGraph(
-            interface="auto",
-            bandwidth_type="up",
-            graph_color=palette["pink"],
-            fill_color=palette["purple"],
-            **graph_common,
+        NetIOGraph(
+            name="combined_network_io",
+            width=64,
+            frequency=1,
+            samples=60,
+            download_color=palette["electric_blue"],
+            upload_color=palette["pink"],
+            background=background,
         ),
         widget.Net(
             interface="auto",
@@ -585,10 +616,11 @@ def _notification_widget(config_globals: dict[str, Any], role: str):
     from libqtile.lazy import lazy
 
     palette = outrun_palette(config_globals["colors"])
+    script = config_globals["home"] + "/.config/qtile/scripts/dunst_menu.py"
     return widget.GenPollCommand(
         name=f"notifications_{role}",
-        cmd=["dunstctl", "count", "history"],
-        parse=lambda output: f" {output.strip() or '0'}",
+        cmd=["python3", script, "--status"],
+        parse=lambda output: output.strip() or " ?",
         update_interval=1,
         font="Hack Nerd Regular",
         fontsize=11,
@@ -596,8 +628,8 @@ def _notification_widget(config_globals: dict[str, Any], role: str):
         background=palette["background"],
         padding=3,
         mouse_callbacks={
-            "Button1": lazy.spawn("dunstctl history-pop"),
-            "Button3": lazy.spawn("dunstctl context"),
+            "Button1": lazy.spawn(f"python3 {shlex.quote(script)} --menu"),
+            "Button3": lazy.spawn("dunstctl set-paused toggle"),
             "Button4": lazy.spawn("dunstctl history-pop"),
             "Button5": lazy.spawn("dunstctl close"),
         },
@@ -671,13 +703,30 @@ def build_screen_widgets(
         # owns the single date whenever that role exists.
         show_date = role == "center"
     clock_format = "󰃭 %Y-%m-%d   %H:%M" if show_date else " %H:%M"
+    clock_callbacks = (
+        {"Button1": lazy.group["qtileControl"].dropdown_toggle("org-agenda-day")}
+        if show_date
+        else {"Button1": lazy.function(_show_month_calendar)}
+    )
+
+    def clock_widget():
+        return widget.Clock(
+            font="Hack Nerd Regular",
+            foreground=foreground,
+            background=background,
+            fontsize=12,
+            format=clock_format,
+            mouse_callbacks=clock_callbacks,
+        )
 
     if role == "center":
         items.extend(telemetry_widgets_factory(home, config_globals["colors"]))
         items.extend(_system_telemetry(config_globals))
+        if show_date:
+            # N=1 fallback: there is no left Org screen to own Pomodoro/date.
+            items.append(widget.Pomodoro(foreground=palette["pink"], background=background))
         items.extend(
             [
-                widget.Pomodoro(foreground=palette["pink"], background=background),
                 widget.TextBox(
                     name="agent_zero_button",
                     text=" A0 ",
@@ -687,13 +736,7 @@ def build_screen_widgets(
                         "Button1": lazy.group["qtileControl"].dropdown_toggle("agent-zero")
                     },
                 ),
-                widget.Clock(
-                    font="Hack Nerd Regular",
-                    foreground=foreground,
-                    background=background,
-                    fontsize=12,
-                    format=clock_format,
-                ),
+                clock_widget(),
                 widget.Volume(foreground=palette["red"], background=background),
                 widget.Systray(background=background, icon_size=20, padding=4),
             ]
@@ -740,13 +783,8 @@ def build_screen_widgets(
                         "Button1": lazy.function(_select_workflow, config_globals)
                     },
                 ),
-                widget.Clock(
-                    font="Hack Nerd Regular",
-                    foreground=foreground,
-                    background=background,
-                    fontsize=12,
-                    format=clock_format,
-                ),
+                widget.Pomodoro(foreground=palette["pink"], background=background),
+                clock_widget(),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
         )
@@ -766,26 +804,14 @@ def build_screen_widgets(
                     max_chars=80,
                     markup=False,
                 ),
-                widget.Clock(
-                    font="Hack Nerd Regular",
-                    foreground=foreground,
-                    background=background,
-                    fontsize=12,
-                    format=clock_format,
-                ),
+                clock_widget(),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
         )
     else:
         items.extend(
             [
-                widget.Clock(
-                    font="Hack Nerd Regular",
-                    foreground=foreground,
-                    background=background,
-                    fontsize=12,
-                    format=clock_format,
-                ),
+                clock_widget(),
                 widget.Volume(foreground=palette["red"], background=background),
             ]
         )
@@ -816,6 +842,17 @@ def _install_control_scratchpad(config_globals: dict[str, Any]) -> None:
                     opacity=0.97,
                     on_focus_lost_hide=True,
                     match=Match(title="qtile-org-todos"),
+                ),
+                DropDown(
+                    "org-agenda-day",
+                    _emacs_agenda_day_frame_command("qtile-org-agenda-day"),
+                    height=0.72,
+                    width=0.62,
+                    x=0.38,
+                    y=0.02,
+                    opacity=0.97,
+                    on_focus_lost_hide=True,
+                    match=Match(title="qtile-org-agenda-day"),
                 ),
                 DropDown(
                     "agent-zero",

--- a/.config/qtile/qtile_net_io.py
+++ b/.config/qtile/qtile_net_io.py
@@ -1,0 +1,123 @@
+"""Combined truthful download/upload graph for the Qtile system bar."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from pathlib import Path
+
+from libqtile.widget import base
+
+
+class NetIOGraph(base._Widget):
+    """Draw download and upload rates together on one shared linear scale.
+
+    Cyan/blue is incoming/download traffic. Pink/red is outgoing/upload traffic.
+    Both series use the same ceiling so relative magnitude stays truthful.
+    """
+
+    orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [
+        ("frequency", 1.0, "Refresh interval in seconds."),
+        ("samples", 60, "Number of samples retained."),
+        ("download_color", "#00b8ff", "Incoming/download line color."),
+        ("upload_color", "#f6019d", "Outgoing/upload line color."),
+        ("line_width", 1.2, "Line width."),
+        ("margin_x", 2, "Horizontal margin."),
+        ("margin_y", 2, "Vertical margin."),
+    ]
+
+    def __init__(self, width=64, **config):
+        super().__init__(width, **config)
+        self.add_defaults(self.defaults)
+        self.download = deque(maxlen=max(int(self.samples), 2))
+        self.upload = deque(maxlen=max(int(self.samples), 2))
+        self._last = None
+        self._last_at = None
+
+    @staticmethod
+    def _default_interface() -> str | None:
+        """Return the interface carrying the default IPv4 route."""
+        try:
+            lines = Path("/proc/net/route").read_text(encoding="utf-8").splitlines()[1:]
+        except OSError:
+            return None
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 4:
+                continue
+            interface, destination, _gateway, flags = fields[:4]
+            try:
+                route_flags = int(flags, 16)
+            except ValueError:
+                continue
+            if destination == "00000000" and route_flags & 0x1:
+                return interface
+        return None
+
+    @classmethod
+    def _read_bytes(cls) -> tuple[int, int] | None:
+        interface = cls._default_interface()
+        try:
+            lines = Path("/proc/net/dev").read_text(encoding="utf-8").splitlines()[2:]
+        except OSError:
+            return None
+        fallback = None
+        for line in lines:
+            name, _, data = line.partition(":")
+            name = name.strip()
+            fields = data.split()
+            if len(fields) < 16 or name == "lo":
+                continue
+            try:
+                rx, tx = int(fields[0]), int(fields[8])
+            except ValueError:
+                continue
+            if name == interface:
+                return rx, tx
+            if fallback is None or rx + tx > fallback[0] + fallback[1]:
+                fallback = (rx, tx)
+        return fallback
+
+    def timer_setup(self):
+        self._update()
+        self.timeout_add(self.frequency, self.timer_setup)
+
+    def _update(self):
+        now = time.monotonic()
+        current = self._read_bytes()
+        if current is not None and self._last is not None and self._last_at is not None:
+            elapsed = max(now - self._last_at, 0.001)
+            down = max((current[0] - self._last[0]) / elapsed, 0.0)
+            up = max((current[1] - self._last[1]) / elapsed, 0.0)
+            self.download.append(down)
+            self.upload.append(up)
+            self.draw()
+        if current is not None:
+            self._last = current
+            self._last_at = now
+
+    def _draw_series(self, values, color, ceiling, usable_height):
+        if not values or ceiling <= 0:
+            return
+        count = max(len(values) - 1, 1)
+        usable_width = max(self.width - 2 * self.margin_x, 1)
+        baseline = self.height - self.margin_y
+        self.drawer.set_source_rgb(color)
+        self.drawer.ctx.set_line_width(self.line_width)
+        for index, value in enumerate(values):
+            x = self.margin_x + (index / count) * usable_width
+            y = baseline - min(float(value) / ceiling, 1.0) * usable_height
+            if index == 0:
+                self.drawer.ctx.move_to(x, y)
+            else:
+                self.drawer.ctx.line_to(x, y)
+        self.drawer.ctx.stroke()
+
+    def draw(self):
+        self.drawer.clear(self.background or self.bar.background)
+        ceiling = max([*self.download, *self.upload, 0.0])
+        usable_height = max(self.height - 2 * self.margin_y, 1)
+        self._draw_series(self.download, self.download_color, ceiling, usable_height)
+        self._draw_series(self.upload, self.upload_color, ceiling, usable_height)
+        self.draw_at_default_position()

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -18,7 +18,7 @@ from libqtile.widget import base
 import openrouter_history
 
 POLL_SECONDS = 1
-GRAPH_SAMPLES = 82
+GRAPH_SAMPLES = 192
 GRAPH_WIDTH = 96
 METRIC_FONTSIZE = 12
 RATE_FONTSIZE = 10
@@ -222,6 +222,13 @@ def _graph_normalized(value, ceiling):
     return min(math.log1p(value) / math.log1p(ceiling), 1.0)
 
 
+def _bucket_bounds(sample):
+    """Return the provider bucket edges represented by one history sample."""
+    center = float(sample.get("timestamp") or 0)
+    duration = max(float(sample.get("bucket_seconds") or 1), 1.0)
+    return center - duration / 2.0, center + duration / 2.0
+
+
 class OpenRouterCredit(base.BackgroundPoll):
     """Display current OpenRouter account balance without blocking Qtile."""
 
@@ -349,7 +356,7 @@ class OpenRouterGraphRange(base.BackgroundPoll):
 
 
 class OpenRouterIOGraph(base._Widget):
-    """Persistent input/output graph with one shared logarithmic Y transform."""
+    """Persistent I/O graph with shared log scaling and truthful bucket edges."""
 
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
@@ -424,6 +431,7 @@ class OpenRouterIOGraph(base._Widget):
         ).start()
 
     def _draw_series(self, key, color, center_y, half_height, direction, ceiling):
+        """Draw provider buckets as steps; never interpolate ramps across gaps."""
         samples = self.series.get("samples", [])
         if not samples or ceiling <= 0:
             return
@@ -433,17 +441,27 @@ class OpenRouterIOGraph(base._Widget):
         usable_width = max(self.width - 2 * self.margin_x, 1)
         self.drawer.set_source_rgb(color)
         self.drawer.ctx.set_line_width(self.line_width)
-        for index, sample in enumerate(samples):
-            x = self.margin_x + ((float(sample["timestamp"]) - start) / span) * usable_width
+        previous_end = None
+        previous_y = None
+        for sample in samples:
+            bucket_start, bucket_end = _bucket_bounds(sample)
+            clipped_start = max(bucket_start, start)
+            clipped_end = min(bucket_end, end)
+            if clipped_end <= clipped_start:
+                continue
+            x0 = self.margin_x + ((clipped_start - start) / span) * usable_width
+            x1 = self.margin_x + ((clipped_end - start) / span) * usable_width
             normalized = _graph_normalized(sample.get(key, 0), ceiling)
             y = center_y + direction * normalized * half_height
-            if len(samples) == 1:
-                self.drawer.ctx.move_to(max(self.margin_x, x - 2), y)
-                self.drawer.ctx.line_to(min(self.width - self.margin_x, x + 2), y)
-            elif index == 0:
-                self.drawer.ctx.move_to(x, y)
+            contiguous = previous_end is not None and abs(clipped_start - previous_end) <= 0.5
+            if contiguous and previous_y is not None:
+                self.drawer.ctx.move_to(x0, previous_y)
+                self.drawer.ctx.line_to(x0, y)
             else:
-                self.drawer.ctx.line_to(x, y)
+                self.drawer.ctx.move_to(x0, y)
+            self.drawer.ctx.line_to(x1, y)
+            previous_end = clipped_end
+            previous_y = y
         self.drawer.ctx.stroke()
 
     def draw(self):

--- a/.config/qtile/scripts/dunst_menu.py
+++ b/.config/qtile/scripts/dunst_menu.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Qtile-friendly Dunst notification history/menu helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from typing import Any
+
+
+def _run(command: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+
+def _typed(item: dict[str, Any], key: str, default: Any = "") -> Any:
+    value = item.get(key, {})
+    if isinstance(value, dict):
+        return value.get("data", default)
+    return default
+
+
+def history_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten dunstctl's aa{sv} JSON envelope into useful records."""
+    entries: list[dict[str, Any]] = []
+    for group in payload.get("data", []):
+        if not isinstance(group, list):
+            continue
+        for item in group:
+            if not isinstance(item, dict):
+                continue
+            try:
+                identifier = int(_typed(item, "id", -1))
+            except (TypeError, ValueError):
+                continue
+            if identifier < 0:
+                continue
+            entries.append(
+                {
+                    "id": identifier,
+                    "app": str(_typed(item, "appname", "")),
+                    "summary": str(_typed(item, "summary", "")),
+                    "body": str(_typed(item, "body", "")),
+                }
+            )
+    return entries
+
+
+def _history() -> list[dict[str, Any]]:
+    completed = _run(["dunstctl", "history"])
+    if completed.returncode != 0:
+        return []
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return []
+    return history_entries(payload) if isinstance(payload, dict) else []
+
+
+def _paused() -> bool:
+    completed = _run(["dunstctl", "is-paused"])
+    return completed.returncode == 0 and completed.stdout.strip().lower() == "true"
+
+
+def status_text() -> str:
+    count = _run(["dunstctl", "count", "history"])
+    amount = count.stdout.strip() if count.returncode == 0 else "?"
+    return f"{'' if _paused() else ''} {amount or '0'}"
+
+
+def _clean(value: str, limit: int = 100) -> str:
+    value = " ".join(value.replace("\n", " ").split())
+    return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
+def menu_rows(entries: list[dict[str, Any]], paused: bool) -> list[str]:
+    rows = [
+        f" DND: {'ON' if paused else 'OFF'}  — toggle",
+        "󰆴 Clear notification history",
+    ]
+    for entry in entries:
+        app = _clean(entry["app"], 24) or "notification"
+        summary = _clean(entry["summary"], 55)
+        body = _clean(entry["body"], 70)
+        detail = summary or body or "(empty)"
+        if body and summary and body != summary:
+            detail += f" — {body}"
+        rows.append(f"#{entry['id']}  {app}: {detail}")
+    return rows
+
+
+def _dmenu(rows: list[str]) -> str | None:
+    executable = shutil.which("dmenu")
+    if not executable:
+        return None
+    completed = _run(
+        [executable, "-i", "-l", "20", "-p", "Notifications:"],
+        stdin="\n".join(rows) + "\n",
+    )
+    if completed.returncode != 0:
+        return None
+    selected = completed.stdout.strip()
+    return selected or None
+
+
+def show_menu() -> int:
+    entries = _history()
+    selected = _dmenu(menu_rows(entries, _paused()))
+    if not selected:
+        return 0
+    if selected.startswith(" DND:"):
+        return _run(["dunstctl", "set-paused", "toggle"]).returncode
+    if selected.startswith("󰆴 Clear"):
+        return _run(["dunstctl", "history-clear"]).returncode
+    if selected.startswith("#"):
+        token = selected.split(maxsplit=1)[0][1:]
+        if token.isdigit():
+            return _run(["dunstctl", "history-pop", token]).returncode
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--status", action="store_true")
+    mode.add_argument("--menu", action="store_true")
+    args = parser.parse_args()
+    if args.status:
+        print(status_text())
+        return 0
+    return show_menu()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/qtile/tests/test_clock_interactions.py
+++ b/.config/qtile/tests/test_clock_interactions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Lightweight source contracts for Qtile clock interactions."""
+
+from pathlib import Path
+import unittest
+
+SOURCE = (Path(__file__).resolve().parents[1] / "qtile_control.py").read_text(encoding="utf-8")
+
+
+class ClockInteractionTests(unittest.TestCase):
+    def test_full_date_opens_single_day_org_agenda(self):
+        self.assertIn('dropdown_toggle("org-agenda-day")', SOURCE)
+        self.assertIn("org-agenda-list nil (current-time) 1", SOURCE)
+
+    def test_time_only_clock_uses_dunst_month_calendar(self):
+        self.assertIn("lazy.function(_show_month_calendar)", SOURCE)
+        self.assertIn("calendar.TextCalendar", SOURCE)
+        self.assertIn('_notify(stamp.strftime("%B %Y"), month_calendar_text(stamp))', SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_dunst_history_config.py
+++ b/.config/qtile/tests/test_dunst_history_config.py
@@ -4,9 +4,9 @@
 from pathlib import Path
 import unittest
 
-ROOT = Path(__file__).resolve().parents[3]
-ORG = (ROOT / "dunst" / "dunst.org").read_text(encoding="utf-8")
-CONFIG = (ROOT / "dunst" / "dunstrc").read_text(encoding="utf-8")
+CONFIG_ROOT = Path(__file__).resolve().parents[2]
+ORG = (CONFIG_ROOT / "dunst" / "dunst.org").read_text(encoding="utf-8")
+CONFIG = (CONFIG_ROOT / "dunst" / "dunstrc").read_text(encoding="utf-8")
 
 
 class DunstHistoryConfigTests(unittest.TestCase):

--- a/.config/qtile/tests/test_dunst_history_config.py
+++ b/.config/qtile/tests/test_dunst_history_config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Regression checks for the canonical Dunst history configuration."""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[3]
+ORG = (ROOT / "dunst" / "dunst.org").read_text(encoding="utf-8")
+CONFIG = (ROOT / "dunst" / "dunstrc").read_text(encoding="utf-8")
+
+
+class DunstHistoryConfigTests(unittest.TestCase):
+    def test_unlimited_history_is_canonical_and_tangled(self):
+        for text in (ORG, CONFIG):
+            self.assertIn("sticky_history = yes", text)
+            self.assertIn("history_length = 0", text)
+            self.assertNotIn("history_length = 20", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_dunst_menu.py
+++ b/.config/qtile/tests/test_dunst_menu.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the Qtile Dunst history helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SOURCE = Path(__file__).resolve().parents[1] / "scripts" / "dunst_menu.py"
+SPEC = importlib.util.spec_from_file_location("dunst_menu", SOURCE)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class DunstMenuTests(unittest.TestCase):
+    def test_flattens_typed_dunst_history(self):
+        payload = {
+            "type": "aa{sv}",
+            "data": [[
+                {
+                    "id": {"type": "i", "data": 42},
+                    "appname": {"type": "s", "data": "Emacs"},
+                    "summary": {"type": "s", "data": "Build done"},
+                    "body": {"type": "s", "data": "Everything passed"},
+                }
+            ]],
+        }
+        self.assertEqual(
+            MODULE.history_entries(payload),
+            [{"id": 42, "app": "Emacs", "summary": "Build done", "body": "Everything passed"}],
+        )
+
+    def test_menu_contains_dnd_clear_and_every_history_entry(self):
+        entries = [
+            {"id": index, "app": "App", "summary": f"Message {index}", "body": ""}
+            for index in range(1, 31)
+        ]
+        rows = MODULE.menu_rows(entries, paused=True)
+        self.assertEqual(len(rows), 32)
+        self.assertIn("DND: ON", rows[0])
+        self.assertIn("Clear notification history", rows[1])
+        self.assertTrue(rows[-1].startswith("#30"))
+
+    def test_status_marks_paused_and_running(self):
+        count = mock.Mock(returncode=0, stdout="27\n")
+        with mock.patch.object(MODULE, "_run", return_value=count), mock.patch.object(MODULE, "_paused", return_value=False):
+            self.assertEqual(MODULE.status_text(), " 27")
+        with mock.patch.object(MODULE, "_run", return_value=count), mock.patch.object(MODULE, "_paused", return_value=True):
+            self.assertEqual(MODULE.status_text(), " 27")
+
+    def test_selection_replays_exact_history_id(self):
+        entries = [{"id": 91, "app": "A", "summary": "S", "body": "B"}]
+        commands = []
+
+        def fake_run(command, **_kwargs):
+            commands.append(command)
+            return mock.Mock(returncode=0, stdout="false\n")
+
+        with mock.patch.object(MODULE, "_history", return_value=entries), \
+             mock.patch.object(MODULE, "_paused", return_value=False), \
+             mock.patch.object(MODULE, "_dmenu", return_value="#91  A: S — B"), \
+             mock.patch.object(MODULE, "_run", side_effect=fake_run):
+            self.assertEqual(MODULE.show_menu(), 0)
+        self.assertIn(["dunstctl", "history-pop", "91"], commands)
+
+    def test_clear_and_dnd_actions_use_dunstctl(self):
+        for selection, expected in (
+            (" DND: OFF  — toggle", ["dunstctl", "set-paused", "toggle"]),
+            ("󰆴 Clear notification history", ["dunstctl", "history-clear"]),
+        ):
+            commands = []
+
+            def fake_run(command, **_kwargs):
+                commands.append(command)
+                return mock.Mock(returncode=0, stdout="")
+
+            with mock.patch.object(MODULE, "_history", return_value=[]), \
+                 mock.patch.object(MODULE, "_paused", return_value=False), \
+                 mock.patch.object(MODULE, "_dmenu", return_value=selection), \
+                 mock.patch.object(MODULE, "_run", side_effect=fake_run):
+                self.assertEqual(MODULE.show_menu(), 0)
+            self.assertIn(expected, commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_openrouter_range_rotation.py
+++ b/.config/qtile/tests/test_openrouter_range_rotation.py
@@ -107,6 +107,20 @@ class OpenRouterRangeRotationTests(unittest.TestCase):
         self.assertEqual(values, sorted(values))
         self.assertEqual(len(set(values)), len(values))
 
+    def test_bucket_bounds_preserve_provider_resolution(self):
+        self.assertEqual(
+            MODULE._bucket_bounds({"timestamp": 150.0, "bucket_seconds": 60}),
+            (120.0, 180.0),
+        )
+        self.assertEqual(
+            MODULE._bucket_bounds({"timestamp": 5_400.0, "bucket_seconds": 3_600}),
+            (3_600.0, 7_200.0),
+        )
+
+    def test_missing_bucket_duration_never_creates_zero_width_sample(self):
+        start, end = MODULE._bucket_bounds({"timestamp": 10.0, "bucket_seconds": 0})
+        self.assertGreater(end, start)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -28,10 +28,19 @@ def function_source(name):
     raise AssertionError(f"missing function {name}")
 
 
+def method_source(class_name, method_name):
+    for node in TREE.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == method_name:
+                    return ast.get_source_segment(SOURCE_TEXT, child) or ""
+    raise AssertionError(f"missing method {class_name}.{method_name}")
+
+
 class OpenRouterWidgetStructureTests(unittest.TestCase):
     def test_one_second_render_poll_and_graph_point_budget(self):
         self.assertEqual(assigned_constant("POLL_SECONDS"), 1)
-        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 82)
+        self.assertEqual(assigned_constant("GRAPH_SAMPLES"), 192)
         self.assertEqual(assigned_constant("ROTATE_SECONDS"), 5)
         self.assertGreaterEqual(assigned_constant("COLLECTOR_HEARTBEAT_STALE_SECONDS"), 15)
 
@@ -82,6 +91,16 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertIn("math.log1p", function_source("_graph_normalized"))
         self.assertNotIn("minimum = min(values)", SOURCE_TEXT)
         self.assertNotIn("if maximum <= minimum:", SOURCE_TEXT)
+
+    def test_graph_draws_provider_bucket_steps_without_gap_interpolation(self):
+        source = method_source("OpenRouterIOGraph", "_draw_series")
+        self.assertIn("_bucket_bounds(sample)", source)
+        self.assertIn("clipped_start", source)
+        self.assertIn("clipped_end", source)
+        self.assertIn("contiguous", source)
+        self.assertIn("self.drawer.ctx.line_to(x0, y)", source)
+        self.assertIn("self.drawer.ctx.line_to(x1, y)", source)
+        self.assertNotIn('float(sample["timestamp"]) - start', source)
 
     def test_stacked_rate_uses_smaller_font_than_single_line_metrics(self):
         self.assertLess(assigned_constant("RATE_FONTSIZE"), assigned_constant("METRIC_FONTSIZE"))

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -7,6 +7,7 @@ import importlib.util
 import tempfile
 import unittest
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 SOURCE = Path(__file__).resolve().parents[1] / "qtile_control.py"
@@ -132,20 +133,31 @@ class QtileControlTests(unittest.TestCase):
         self.assertGreater(SOURCE_TEXT.index("widget.Mpris2", right), right)
         self.assertEqual(SOURCE_TEXT.count("widget.Mpris2"), 1)
 
-    def test_center_restores_system_graphs(self):
+    def test_center_has_one_combined_network_graph(self):
+        self.assertIn("from qtile_net_io import NetIOGraph", SOURCE_TEXT)
+        self.assertEqual(SOURCE_TEXT.count("NetIOGraph("), 1)
+        self.assertNotIn("widget.NetGraph(", SOURCE_TEXT)
+        self.assertIn('name="combined_network_io"', SOURCE_TEXT)
+        self.assertIn('download_color=palette["electric_blue"]', SOURCE_TEXT)
+        self.assertIn('upload_color=palette["pink"]', SOURCE_TEXT)
+        self.assertIn('format="↓{down}{down_suffix} ↑{up}{up_suffix}"', SOURCE_TEXT)
+        self.assertIn('foreground="{palette[\"electric_blue\"]}">↓', SOURCE_TEXT)
+        self.assertIn('foreground="{palette[\"pink\"]}">↑', SOURCE_TEXT)
+
+    def test_center_restores_cpu_memory_system_graphs(self):
         center = SOURCE_TEXT.index('if role == "center":')
-        right = SOURCE_TEXT.index('elif role == "left":')
-        center_text = SOURCE_TEXT[center:right]
+        left = SOURCE_TEXT.index('elif role == "left":')
+        center_text = SOURCE_TEXT[center:left]
         self.assertIn("_system_telemetry(config_globals)", center_text)
         self.assertIn("widget.CPUGraph", SOURCE_TEXT)
         self.assertIn("widget.MemoryGraph", SOURCE_TEXT)
-        self.assertGreaterEqual(SOURCE_TEXT.count("widget.NetGraph"), 2)
         self.assertIn('format="{Available: .1f}{mm} free"', SOURCE_TEXT)
-        self.assertIn('format="↓{down}{down_suffix} ↑{up}{up_suffix}"', SOURCE_TEXT)
 
     def test_exactly_one_legacy_systray_and_notifications_every_role(self):
         self.assertEqual(SOURCE_TEXT.count("widget.Systray"), 1)
-        self.assertIn('cmd=["dunstctl", "count", "history"]', SOURCE_TEXT)
+        self.assertIn('cmd=["python3", script, "--status"]', SOURCE_TEXT)
+        self.assertIn('lazy.spawn(f"python3 {shlex.quote(script)} --menu")', SOURCE_TEXT)
+        self.assertIn('lazy.spawn("dunstctl set-paused toggle")', SOURCE_TEXT)
         self.assertIn("items.append(_notification_widget(config_globals, role))", SOURCE_TEXT)
 
     def test_volume_uses_outrun_red(self):
@@ -170,20 +182,37 @@ class QtileControlTests(unittest.TestCase):
         self.assertIn('"GPT TODO sync complete"', SOURCE_TEXT)
         self.assertIn('"GPT TODO sync failed"', SOURCE_TEXT)
 
-    def test_clock_icons_and_single_date_policy(self):
+    def test_pomodoro_lives_on_left_with_n1_center_fallback(self):
+        center = SOURCE_TEXT.index('if role == "center":')
+        left = SOURCE_TEXT.index('elif role == "left":')
+        right = SOURCE_TEXT.index('elif role == "right":')
+        center_text = SOURCE_TEXT[center:left]
+        left_text = SOURCE_TEXT[left:right]
+        self.assertIn("if show_date:", center_text)
+        self.assertEqual(center_text.count("widget.Pomodoro"), 1)
+        self.assertEqual(left_text.count("widget.Pomodoro"), 1)
+        self.assertEqual(SOURCE_TEXT.count("widget.Pomodoro"), 2)
+
+    def test_clock_icons_single_date_and_click_actions(self):
         self.assertEqual(SOURCE_TEXT.count('"󰃭 %Y-%m-%d   %H:%M"'), 1)
         self.assertEqual(SOURCE_TEXT.count('" %H:%M"'), 1)
-        self.assertIn('clock_format = "󰃭 %Y-%m-%d   %H:%M" if show_date else " %H:%M"', SOURCE_TEXT)
-        self.assertGreaterEqual(SOURCE_TEXT.count('font="Hack Nerd Regular"'), 4)
+        self.assertIn('dropdown_toggle("org-agenda-day")', SOURCE_TEXT)
+        self.assertIn("lazy.function(_show_month_calendar)", SOURCE_TEXT)
+        self.assertIn("org-agenda-list nil (current-time) 1", SOURCE_TEXT)
+        expected = MODULE.month_calendar_text(datetime(2026, 8, 23, 12, 0))
+        self.assertIn("August 2026", expected)
+        self.assertIn("23", expected)
 
     def test_generated_layout_puts_date_on_left_or_center_for_n1(self):
         self.assertIn('date_role = "left" if any(base_role(role) == "left" for role in roles) else "center"', SOURCE_TEXT)
         self.assertIn('show_date=base_role(role) == date_role', SOURCE_TEXT)
         self.assertIn('show_date = role == "center"', SOURCE_TEXT)
 
-    def test_agent_zero_chat_is_centered_and_todo_is_right_aligned(self):
-        self.assertIn('x=0.19,\n                    y=0.04,', SOURCE_TEXT)
+    def test_agenda_and_todo_dropdowns_are_right_aligned(self):
+        self.assertIn('"org-agenda-day"', SOURCE_TEXT)
+        self.assertIn('x=0.38,\n                    y=0.02,', SOURCE_TEXT)
         self.assertIn('x=0.42,\n                    y=0.02,', SOURCE_TEXT)
+        self.assertIn('x=0.19,\n                    y=0.04,', SOURCE_TEXT)
         self.assertIn('qtile-workflow.el', SOURCE_TEXT)
         self.assertIn("qtile-workflow-read-right", SOURCE_TEXT)
 

--- a/.config/qtile/tests/test_qtile_net_io.py
+++ b/.config/qtile/tests/test_qtile_net_io.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Behavioral/structural tests for the combined Qtile network graph."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SOURCE = Path(__file__).resolve().parents[1] / "qtile_net_io.py"
+SOURCE_TEXT = SOURCE.read_text(encoding="utf-8")
+
+
+def _install_libqtile_stub() -> None:
+    libqtile = types.ModuleType("libqtile")
+    widget = types.ModuleType("libqtile.widget")
+    base = types.ModuleType("libqtile.widget.base")
+
+    class Widget:
+        def __init__(self, width=0, **config):
+            self.width = width
+            self.height = config.get("height", 26)
+            for key, value in config.items():
+                setattr(self, key, value)
+
+        def add_defaults(self, defaults):
+            for name, value, _desc in defaults:
+                if not hasattr(self, name):
+                    setattr(self, name, value)
+
+    base._Widget = Widget
+    base.ORIENTATION_HORIZONTAL = 1
+    widget.base = base
+    libqtile.widget = widget
+    sys.modules["libqtile"] = libqtile
+    sys.modules["libqtile.widget"] = widget
+    sys.modules["libqtile.widget.base"] = base
+
+
+_install_libqtile_stub()
+SPEC = importlib.util.spec_from_file_location("qtile_net_io", SOURCE)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class NetIOGraphTests(unittest.TestCase):
+    def test_color_contract_is_explicit(self):
+        self.assertIn("Cyan/blue is incoming/download traffic", SOURCE_TEXT)
+        self.assertIn("Pink/red is outgoing/upload traffic", SOURCE_TEXT)
+        self.assertIn('download_color", "#00b8ff"', SOURCE_TEXT)
+        self.assertIn('upload_color", "#f6019d"', SOURCE_TEXT)
+
+    def test_one_widget_owns_both_series_and_shared_ceiling(self):
+        graph = MODULE.NetIOGraph(samples=4)
+        graph.download.extend([100.0, 200.0])
+        graph.upload.extend([10.0, 20.0])
+        self.assertEqual(list(graph.download), [100.0, 200.0])
+        self.assertEqual(list(graph.upload), [10.0, 20.0])
+        self.assertIn("max([*self.download, *self.upload, 0.0])", SOURCE_TEXT)
+
+    def test_rate_sampling_uses_one_elapsed_interval_for_both_directions(self):
+        graph = MODULE.NetIOGraph(samples=4)
+        graph._last = (1000, 500)
+        graph._last_at = 10.0
+        with mock.patch.object(graph, "_read_bytes", return_value=(1600, 800)), \
+             mock.patch.object(MODULE.time, "monotonic", return_value=12.0), \
+             mock.patch.object(graph, "draw"):
+            graph._update()
+        self.assertEqual(list(graph.download), [300.0])
+        self.assertEqual(list(graph.upload), [150.0])
+
+    def test_default_route_detection_ignores_loopback_fallback(self):
+        route = "Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT\neth0 00000000 01020304 0003 0 0 0 00000000 0 0 0\n"
+        dev = "Inter-| Receive | Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\nlo: 999 0 0 0 0 0 0 0 999 0 0 0 0 0 0 0\neth0: 100 0 0 0 0 0 0 0 200 0 0 0 0 0 0 0\n"
+
+        def fake_read_text(path, **_kwargs):
+            return route if str(path).endswith("/proc/net/route") else dev
+
+        with mock.patch.object(MODULE.Path, "read_text", autospec=True, side_effect=fake_read_text):
+            self.assertEqual(MODULE.NetIOGraph._default_interface(), "eth0")
+            self.assertEqual(MODULE.NetIOGraph._read_bytes(), (100, 200))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -60,6 +60,7 @@
         keepassxc
         xdg-utils
         dunst
+        dmenu
         gotop
         pavucontrol
         xkill


### PR DESCRIPTION
RAGE implementation for #136 based on the live 17:32 Qtile screenshots.

## Graph diagnosis/fix
The overly smooth OpenRouter history was primarily a renderer/resolution issue, not simply low usage. Coarse provider buckets were being connected center-to-center as diagonal ramps. The graph now draws each provider bucket across its real time boundaries, uses vertical transitions only for contiguous buckets, and leaves real gaps empty. The shared `log1p` input/output scale remains truthful. The point budget is raised to 192 so a full week of hourly provider history is not unnecessarily averaged below native resolution.

## Desktop bar changes
- merge network download/upload into one shared-scale graph
  - cyan/blue = incoming/download
  - pink/red = outgoing/upload
- retain live numeric `↓/↑` network rates beside the combined graph
- move Pomodoro to the left Org screen; N=1 keeps a center fallback
- clicking the single full date/time opens a one-day Org agenda
- clicking time-only clocks displays the current month calendar through Dunst
- Dunst history is unlimited (`history_length = 0`)
- notification button opens a menu containing every retained history item plus DND toggle and clear-history actions
- right-click notification button is a quick DND toggle
- preserve N=1..4 topology behavior, one systray, right-only MPRIS, GPT TODO sync, and existing telemetry

## Gates
Adds behavioral/structural tests for bucket boundaries/no-gap interpolation, combined network sampling/color contract, Dunst history parsing/actions/config, Pomodoro placement, and clock interactions. Canonical Dunst/OpenRouter Org sources remain paired with generated outputs. Full literate, Qtile, Emacs, Nix and Home Manager gates are required before merge.

Closes #136