### PR TITLE
fix(qtile): prevent background Emacs fallback launch

### DIFF
--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -750,7 +750,8 @@ def build_screen_widgets(
             [
                 widget.GenPollCommand(
                     name="org_clocked_task",
-                    cmd=["emacsclient", "-a", "emacs", "--eval", clock_expression],
+                    # Background polling must never fall back to launching a GUI.
+                    cmd=["emacsclient", "-s", "qtile", "-a", "false", "--eval", clock_expression],
                     parse=_parse_clock_output,
                     update_interval=5,
                     foreground=palette["pink"],


### PR DESCRIPTION
The Qtile Org clock status widget polls every 5 seconds. Using `emacsclient -a emacs` allowed a missing server to launch a graphical Emacs as a side effect.

Use the named `qtile` server with `-a false` so background polling fails quietly without starting Emacs.

Validation:
- `python3 -m unittest discover -s .config/qtile/tests -p 'test_qtile_control.py'`\n- `qtile check`