### PR TITLE
feat(nyxt): synthwave foundation for operator overhaul

### DIFF
--- a/.config/nyxt/config.lisp
+++ b/.config/nyxt/config.lisp
@@ -1,77 +1,75 @@
-;; Load slynk
+;; Nyxt configuration.
+;; The visual layer is in theme.lisp; capture/reporting commands are in
+;; reporting.lisp.
 
 (in-package :nyxt)
 
 (when (asdf:load-system :slynk)
   (define-command start-slynk (&optional (slynk-port 4006))
-    "Start a Slynk server that can be connected to, for instance, in
-Emacs via SLY.
+    "Start a Slynk server for SLY.
 
-Warning: This allows Nyxt to be controlled remotely, that is, to
-execute arbitrary code with the privileges of the user running Nyxt.
-Make sure you understand the security risks associated with this
-before running this command."
+This exposes arbitrary code execution with the privileges of the Nyxt process.
+Only run it on a trusted machine/session."
     (slynk:create-server :port slynk-port :dont-close t)
     (echo "Slynk server started at port ~a" slynk-port)))
 
-
 (in-package #:nyxt-user)
 
-;; Auto config stuff
-(define-configuration (web-buffer prompt-buffer panel-buffer
-                                  nyxt/mode/editor:editor-buffer)
-  ((default-modes (pushnew 'nyxt/mode/vi:vi-normal-mode %slot-value%))))
-
-
-
-(define-configuration (web-buffer)
-  ((default-modes (pushnew 'nyxt/mode/blocker:blocker-mode %slot-value%))))
-
-(define-configuration (web-buffer)
+;; Vi where navigation is useful, insert mode in the command/prompt UI.
+(define-configuration (web-buffer panel-buffer nyxt/mode/editor:editor-buffer)
   ((default-modes
-    (pushnew 'nyxt/mode/reduce-tracking:reduce-tracking-mode %slot-value%))))
+    (pushnew 'nyxt/mode/vi:vi-normal-mode %slot-value%))))
 
-(define-configuration (web-buffer)
-  ((default-modes (pushnew 'nyxt/mode/blocker:blocker-mode %slot-value%))))
-
-
-
-;; Make the Web buffers vi mode.
 (define-configuration prompt-buffer
-  ((default-modes (append '(vi-insert-mode) %slot-default%))))
+  ((default-modes
+    (pushnew 'nyxt/mode/vi:vi-insert-mode %slot-value%))))
 
+;; Privacy defaults.
+(define-configuration web-buffer
+  ((default-modes
+    (remove-duplicates
+     (append
+      '(nyxt/mode/blocker:blocker-mode
+        nyxt/mode/reduce-tracking:reduce-tracking-mode)
+      %slot-value%)
+     :test #'eq))))
 
 (defvar *my-search-engines*
   (list
    '("google" "https://google.com/search?q=~a" "https://google.com")
+   '("brave" "https://search.brave.com/search?q=~a" "https://search.brave.com")
    '("sp" "https://www.startpage.com/do/search?query=~a" "https://www.startpage.com")
-   '("py" "https://docs.python.org/3/search.html?q=~a"
-     "https://docs.python.org/3")
+   '("gh" "https://github.com/search?q=~a" "https://github.com")
+   '("py" "https://docs.python.org/3/search.html?q=~a" "https://docs.python.org/3")
    '("cve" "https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=~a")
-   '("fec" "https://www.fec.gov/data/receipts/individual-contributions/?contributor_name=~a" "https://www.fec.gov/data/receipts/individual-contributions/")
-   '("nixpkgs" "https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=~a" "https://search.nixos.org/packages")
-   '("brave" "https://search.brave.com/search?q=~a" "https://search.brave.com/search"))
-
-  "List of search engines.")
+   '("fec"
+     "https://www.fec.gov/data/receipts/individual-contributions/?contributor_name=~a"
+     "https://www.fec.gov/data/receipts/individual-contributions/")
+   '("nixpkgs"
+     "https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=~a"
+     "https://search.nixos.org/packages"))
+  "Search engines available from the prompt.")
 
 (define-configuration context-buffer
-  "Go through the search engines above and make-search-engine out of them."
   ((search-engines
     (append
-     (mapcar (lambda (engine) (apply 'make-search-engine engine))
+     (mapcar (lambda (engine)
+               (apply #'make-search-engine engine))
              *my-search-engines*)
-     %slot-default%)))
+     %slot-default%))))
 
+(define-configuration browser
+  ((external-editor-program
+    (list "emacsclient" "-c" "-F" "'(name . \"floating\")"))))
 
-
-  ;; Use emacs
-
-  (define-configuration browser
-      ((external-editor-program (list "emacsclient" "-c" "-F" "'(name . \"floating\")")))))
-
-
+;; Retain the compositor workaround that fixed blank WebKit rendering on this
+;; setup.
 (setf (uiop:getenv "WEBKIT_DISABLE_COMPOSITING_MODE") "1")
 
-(nyxt::load-lisp "~/.config/nyxt/proxy.lisp")
+;; Load visual configuration before status configuration so the status buffer
+;; picks up the synthwave theme.
+(nyxt::load-lisp "~/.config/nyxt/theme.lisp")
 (nyxt::load-lisp "~/.config/nyxt/status.lisp")
+(nyxt::load-lisp "~/.config/nyxt/reporting.lisp")
+(nyxt::load-lisp "~/.config/nyxt/proxy.lisp")
 (nyxt::load-lisp "~/.config/nyxt/crunchbase.lisp")

--- a/.config/nyxt/reporting.lisp
+++ b/.config/nyxt/reporting.lisp
@@ -1,0 +1,111 @@
+(in-package #:nyxt-user)
+
+(defparameter *operation* "default"
+  "Current capture/reporting operation name.")
+
+(defparameter *document-path*
+  (uiop:merge-pathnames* #P"nx-document/" (user-homedir-pathname))
+  "Root directory for Nyxt operation artifacts.")
+
+(defun safe-path-component (value)
+  "Return VALUE as a filesystem-friendly component."
+  (let ((string (princ-to-string value)))
+    (with-output-to-string (stream)
+      (loop for character across string
+            do (write-char
+                (if (or (alphanumericp character)
+                        (find character "-_."))
+                    character
+                    #\_)
+                stream)))))
+
+(defun shortened-component (value &optional (limit 96))
+  "Return a sanitized VALUE capped at LIMIT characters."
+  (let ((safe (safe-path-component value)))
+    (if (zerop (length safe))
+        "nyxt"
+        (subseq safe 0 (min limit (length safe))))))
+
+(defun operation-directory ()
+  "Return the current operation directory, creating it if needed."
+  (let ((path
+          (merge-pathnames
+           (format nil "~a/" (shortened-component *operation* 64))
+           *document-path*)))
+    (ensure-directories-exist path)
+    path))
+
+(defun operation-image-directory ()
+  "Return the current operation image directory, creating it if needed."
+  (let ((path (merge-pathnames #P"images/" (operation-directory))))
+    (ensure-directories-exist path)
+    path))
+
+(defun capture-label (&optional (buffer (current-buffer)))
+  "Return a useful filename stem for BUFFER."
+  (cond
+    ((and buffer (web-buffer-p buffer) (url buffer))
+     (shortened-component (render-url (url buffer))))
+    (buffer
+     (shortened-component (title buffer)))
+    (t
+     "nyxt")))
+
+(defun capture-path (&optional (buffer (current-buffer)))
+  "Return a new PNG pathname for BUFFER in the current operation."
+  (merge-pathnames
+   (format nil "~d-~a.png" (get-universal-time) (capture-label buffer))
+   (operation-image-directory)))
+
+(defun run-scrot (arguments path)
+  "Run scrot with ARGUMENTS and write the capture to PATH."
+  (handler-case
+      (progn
+        (uiop:run-program
+         (append (list "scrot") arguments (list "-F" (namestring path)))
+         :output *standard-output*
+         :error-output *error-output*)
+        path)
+    (error (condition)
+      (echo "scrot failed: ~a" condition)
+      nil)))
+
+(define-command scrot (&optional (buffer (current-buffer)))
+  "Capture the focused Nyxt window into the current operation."
+  (let ((path (capture-path buffer)))
+    (when (run-scrot '("-u") path)
+      (echo "Saved capture: ~a" (namestring path)))))
+
+(define-command scrot-select (&optional (buffer (current-buffer)))
+  "Interactively select a region and save it into the current operation."
+  (let ((path (capture-path buffer)))
+    (when (run-scrot '("-s") path)
+      (echo "Saved selection: ~a" (namestring path)))))
+
+(define-command set-operation ()
+  "Set the operation used by screenshot/reporting commands."
+  (let* ((input
+           (prompt1
+             :prompt "Operation"
+             :sources 'prompter:raw-source))
+         (name
+           (string-trim
+            '(#\Space #\Tab #\Newline #\Return)
+            input)))
+    (if (zerop (length name))
+        (echo "Operation unchanged: ~a" *operation*)
+        (progn
+          (setf *operation* name)
+          (operation-image-directory)
+          (echo "Operation: ~a" *operation*)))))
+
+(define-command show-operation ()
+  "Display the current operation and capture directory."
+  (echo "~a → ~a"
+        *operation*
+        (namestring (operation-image-directory))))
+
+(define-command open-operation-directory ()
+  "Open the current operation directory with the desktop file manager."
+  (uiop:launch-program
+   (list "xdg-open" (namestring (operation-directory)))))

--- a/.config/nyxt/status.lisp
+++ b/.config/nyxt/status.lisp
@@ -1,33 +1,41 @@
 (in-package #:nyxt-user)
 
-(define-configuration :status-buffer
-  "Display modes as short glyphs."
+(define-configuration status-buffer
   ((glyph-mode-presentation-p t)))
 
-(define-configuration :force-https-mode ((glyph "ϕ")))
-(define-configuration :user-script-mode ((glyph "u")))
-(define-configuration :blocker-mode ((glyph "β")))
-(define-configuration :proxy-mode ((glyph "π")))
-(define-configuration :reduce-tracking-mode ((glyph "τ")))
-(define-configuration :certificate-exception-mode ((glyph "χ")))
-(define-configuration :style-mode ((glyph "ϕ")))
-(define-configuration :cruise-control-mode ((glyph "σ")))
+(define-configuration :force-https-mode
+  ((glyph "ϕ")))
 
-(define-configuration status-buffer
-  "Hide most of the status elements but URL and modes."
-  ((style (str:concat
-           %slot-value%
-           (theme:themed-css (theme *browser*)))
-          `("#controls,#tabs"
-            :display none !important))))
+(define-configuration :user-script-mode
+  ((glyph "u")))
+
+(define-configuration :blocker-mode
+  ((glyph "β")))
+
+(define-configuration :proxy-mode
+  ((glyph "π")))
+
+(define-configuration :reduce-tracking-mode
+  ((glyph "τ")))
+
+(define-configuration :certificate-exception-mode
+  ((glyph "χ")))
+
+(define-configuration :style-mode
+  ((glyph "ϕ")))
+
+(define-configuration :cruise-control-mode
+  ((glyph "σ")))
 
 (defmethod format-status-load-status ((status status-buffer))
-  "A fancier load status."
+  "Display a compact loading state."
+  (declare (ignore status))
   (spinneret:with-html-string
-      (:span (if (and (current-buffer)
-                      (web-buffer-p (current-buffer)))
-                 (case (slot-value (current-buffer) 'nyxt::status)
-                   (:unloaded "∅")
-                   (:loading "∞")
-                   (:finished ""))
-                 ""))))
+    (:span
+     (if (and (current-buffer)
+              (web-buffer-p (current-buffer)))
+         (case (slot-value (current-buffer) 'nyxt::status)
+           (:unloaded "∅")
+           (:loading "∞")
+           (:finished ""))
+         ""))))

--- a/.config/nyxt/theme.lisp
+++ b/.config/nyxt/theme.lisp
@@ -1,0 +1,92 @@
+(in-package #:nyxt-user)
+
+(defparameter *synthwave-theme*
+  (make-instance
+   'theme:theme
+   :background-color "#170c32"
+   :primary-color "#202146"
+   :secondary-color "#92406e"
+   :action-color "#f6019d"
+   :success-color "#2de2e6"
+   :warning-color "#fba922"
+   :highlight-color "#2de2e6")
+  "Synthwave palette derived from the archived Nyxt theme.")
+
+(define-configuration browser
+  ((theme *synthwave-theme*)))
+
+(define-configuration prompt-buffer
+  ((style
+    (str:concat
+     %slot-value%
+     (theme:themed-css
+      (theme *browser*)
+      '("#prompt-area"
+        :border-radius "8px"
+        :box-shadow "0 0 16px rgba(246, 1, 157, 0.40)")
+      '("#input"
+        :box-shadow "inset 0 0 10px rgba(45, 226, 230, 0.12)")
+      '(".source-name"
+        :text-transform "uppercase"
+        :letter-spacing "0.08em")
+      '("#selection"
+        :box-shadow "inset 4px 0 0 #2de2e6, 0 0 10px rgba(246, 1, 157, 0.28)")
+      '(".marked"
+        :box-shadow "inset 4px 0 0 #fba922"))))))
+
+(define-configuration status-buffer
+  ((height 40)
+   (style
+    (str:concat
+     %slot-value%
+     (theme:themed-css
+      (theme *browser*)
+      '(body
+        :background "linear-gradient(90deg, #170c32 0%, #202146 58%, #170c32 100%)")
+      '("#container"
+        :gap "2px")
+      '("#controls"
+        :display "none")
+      '("#url"
+        :background-color "#170c32"
+        :color "#2de2e6"
+        :border "1px solid #92406e"
+        :border-radius "7px"
+        :box-shadow "inset 0 0 9px rgba(45, 226, 230, 0.12)")
+      '("#tabs"
+        :padding-left "0")
+      '(".tab"
+        :border "1px solid transparent"
+        :border-radius "7px"
+        :transition "background-color 120ms ease, color 120ms ease, box-shadow 120ms ease")
+      '(".selected-tab"
+        :background-color "#f6019d"
+        :color "#170c32"
+        :border-color "#2de2e6"
+        :box-shadow "0 0 10px rgba(246, 1, 157, 0.35)")
+      '("#modes"
+        :background-color "#202146"
+        :color "#fba922"
+        :border "1px solid #92406e"
+        :border-radius "7px"
+        :box-shadow "inset 0 0 8px rgba(246, 1, 157, 0.10)"))))))
+
+(define-configuration (internal-buffer panel-buffer message-buffer)
+  ((style
+    (str:concat
+     %slot-value%
+     (theme:themed-css
+      (theme *browser*)
+      '(body
+        :background-color "#170c32"
+        :color "#f3f4f5")
+      '(a
+        :color "#2de2e6")
+      '("a:hover"
+        :color "#f6019d")
+      '(hr
+        :border-color "#92406e")
+      '(".button"
+        :background-color "#202146"
+        :color "#f3f4f5"
+        :border-radius "6px"))))))


### PR DESCRIPTION
## Status

**Foundation only.** This PR recovers the old Nyxt synthwave/scrot behavior and establishes a modular baseline. The full modernization is tracked by #152 and should deeply integrate StarIntel, Hackmode and the OWASP ZAP API rather than stop at theming.

## What this PR provides
- restored synthwave palette/design seed
- prompt/status/internal-buffer styling
- visible neon tab treatment
- restored/hardened `scrot` and `scrot-select`
- operation-oriented local capture directory compatibility
- config modularization seed
- cleanup of duplicate modes
- preserved Slynk/Emacs, proxy, Crunchbase and WebKit workaround

## Follow-on architecture
- #147 operator shell/dashboard/design system
- #148 StarIntel capability-discovered Nyxt mode
- #149 structured evidence workflow
- #150 Nix/runtime/secrets/tests
- #151 ZAP operator mode
- #152 cross-repo execution epic
- lost-rob0t/hackmode#20 Nyxt runtime client
- lost-rob0t/hackmode#21 ZAP provider actor
- lost-rob0t/hackmode#22 ZAP findings bridge
- lost-rob0t/starintel-server#120 interactive client contract coverage

## Compatibility
The current dotfiles flake pins Nixpkgs `56c02bc00adcf003215cc4bd996d6efaf4cff188`, whose Nyxt package is 3.12.0. Theme/config APIs in this foundation were checked against Nyxt 3.12.0 source.

`scrot` is already installed by the desktop Home Manager module.

## Verification
- branch is cleanly based on `master`
- API shapes checked against Nyxt 3.12.0 source
- CI is the repository gate
- live desktop Nyxt smoke remains required before treating this foundation as ready