### PR TITLE
Wire Brave Search MCP into llm module

### DIFF
--- a/docs/wiki/nix.org
+++ b/docs/wiki/nix.org
@@ -65,6 +65,29 @@ If =home-manager= is not installed globally, bootstrap through Nix:
 
 See [[file:../logos-home-manager-bootstrap.md][Logos Home Manager bootstrap]] for the existing Logos-specific notes.
 
+* LLM tooling and Brave Search MCP
+[[file:../../nix/home-manager/mods/llm.nix][llm.nix]] owns the LLM tool plane.  Enabling =llm.enable= enables the reusable [[file:../../nix/home-manager/mods/brave-mcp.nix][Brave MCP module]] by default, installs Brave's =bx= CLI plus the typed =brave-mcp= stdio adapter, and exposes that MCP server to OpenCode through the shared MCP Home Manager integration.  A host may still override =braveMcp.enable = false= explicitly.
+
+The Brave Search API key is runtime user state and must not be written into Nix configuration or the Nix store.  After switching the Home Manager profile, configure it interactively:
+
+#+begin_src shell
+  bx config set-key
+#+end_src
+
+On Linux, =bx= stores its user configuration under =~/.config/brave-search/config.json=.  For ephemeral sessions, =BRAVE_SEARCH_API_KEY= is also supported:
+
+#+begin_src shell
+  export BRAVE_SEARCH_API_KEY='...'
+#+end_src
+
+Prefer =bx config set-key= without putting the key on the command line so it does not enter shell history.  Verify the CLI before starting OpenCode:
+
+#+begin_src shell
+  bx context "NixOS Home Manager documentation" --max-tokens 1024
+#+end_src
+
+The MCP adapter exposes bounded, typed search tools rather than arbitrary =bx= argv or shell execution.  Its package lives at [[file:../../nix/packages/brave-mcp/][nix/packages/brave-mcp/]] and its protocol regression test is [[file:../../tests/brave-mcp.py][tests/brave-mcp.py]].
+
 * Editing rule
 Host-specific composition belongs under =nix/home-manager/systems/= or =nix/nixos/hosts/=.  Reusable behavior belongs in modules rather than being copied between hosts.  Keep =flake.nix= focused on wiring outputs together.
 

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -18,7 +18,6 @@
     ./llm.nix
     ./screen-capture.nix
     ./prolog-mcp.nix
-    ./brave-mcp.nix
     ./proxmox-mcp.nix
     ./discord-mcp.nix
     ./unifi-mcp.nix

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -1,30 +1,38 @@
 { lib, pkgs, inputs, config, ... }:
 
-let
-  comfyui = pkgs.comfyui.override { withManager = true; };
-
-  # Keep the OpenCode policy wrapper in dotfiles, not in the reusable skills
-  # repository.  Normal invocations are passed through unchanged; only
-  # `opencode --yolo` creates the StarIntel V4 tmpfs/Prolog-RLM environment.
-  opencodeYoloRuntime = pkgs.writeShellApplication {
-    name = "opencode-yolo-runtime";
-    runtimeInputs = [ pkgs.coreutils ];
-    text = builtins.readFile ../files/opencode-yolo.sh;
-  };
-
-  opencodeWrapped = pkgs.writeShellScriptBin "opencode" ''
-    export OPENCODE_REAL_BIN="${pkgs.opencode}/bin/opencode"
-    exec "${opencodeYoloRuntime}/bin/opencode-yolo-runtime" "$@"
-  '';
-in
 {
+  imports = [
+    ./brave-mcp.nix
+  ];
+
   options = with lib; {
     llm = {
       enable = mkEnableOption "Enable LLM and zara utils";
     };
   };
 
-  config = with lib; mkIf config.llm.enable {
+  config = with lib; mkIf config.llm.enable (let
+    comfyui = pkgs.comfyui.override { withManager = true; };
+
+    # Keep the OpenCode policy wrapper in dotfiles, not in the reusable skills
+    # repository. Normal invocations are passed through unchanged; only
+    # `opencode --yolo` creates the StarIntel V4 tmpfs/Prolog-RLM environment.
+    opencodeYoloRuntime = pkgs.writeShellApplication {
+      name = "opencode-yolo-runtime";
+      runtimeInputs = [ pkgs.coreutils ];
+      text = builtins.readFile ../files/opencode-yolo.sh;
+    };
+
+    opencodeWrapped = pkgs.writeShellScriptBin "opencode" ''
+      export OPENCODE_REAL_BIN="${pkgs.opencode}/bin/opencode"
+      exec "${opencodeYoloRuntime}/bin/opencode-yolo-runtime" "$@"
+    '';
+  in {
+    # Brave Search MCP is part of the default LLM tool plane. Authentication
+    # remains runtime/user state (`bx config set-key` or BRAVE_SEARCH_API_KEY),
+    # so the API key never enters the Nix store.
+    braveMcp.enable = mkDefault true;
+
     # Install required packages for MCP servers
     home.packages = with pkgs; [
       inputs.zara.packages.${stdenv.hostPlatform.system}.zarathushtra
@@ -93,5 +101,5 @@ in
     # home.activation.startMcpServers = lib.hm.dag.entryAfter ["writeBoundary"] ''
     #   $DRY_RUN_CMD ${pkgs.bash}/bin/bash $HOME/.local/bin/start-mcp-servers start
     # '';
-  };
+  });
 }

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -1,5 +1,22 @@
 { lib, pkgs, inputs, config, ... }:
 
+let
+  comfyui = pkgs.comfyui.override { withManager = true; };
+
+  # Keep the OpenCode policy wrapper in dotfiles, not in the reusable skills
+  # repository.  Normal invocations are passed through unchanged; only
+  # `opencode --yolo` creates the StarIntel V4 tmpfs/Prolog-RLM environment.
+  opencodeYoloRuntime = pkgs.writeShellApplication {
+    name = "opencode-yolo-runtime";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = builtins.readFile ../files/opencode-yolo.sh;
+  };
+
+  opencodeWrapped = pkgs.writeShellScriptBin "opencode" ''
+    export OPENCODE_REAL_BIN="${pkgs.opencode}/bin/opencode"
+    exec "${opencodeYoloRuntime}/bin/opencode-yolo-runtime" "$@"
+  '';
+in
 {
   imports = [
     ./brave-mcp.nix
@@ -11,23 +28,7 @@
     };
   };
 
-  config = with lib; mkIf config.llm.enable (let
-    comfyui = pkgs.comfyui.override { withManager = true; };
-
-    # Keep the OpenCode policy wrapper in dotfiles, not in the reusable skills
-    # repository. Normal invocations are passed through unchanged; only
-    # `opencode --yolo` creates the StarIntel V4 tmpfs/Prolog-RLM environment.
-    opencodeYoloRuntime = pkgs.writeShellApplication {
-      name = "opencode-yolo-runtime";
-      runtimeInputs = [ pkgs.coreutils ];
-      text = builtins.readFile ../files/opencode-yolo.sh;
-    };
-
-    opencodeWrapped = pkgs.writeShellScriptBin "opencode" ''
-      export OPENCODE_REAL_BIN="${pkgs.opencode}/bin/opencode"
-      exec "${opencodeYoloRuntime}/bin/opencode-yolo-runtime" "$@"
-    '';
-  in {
+  config = with lib; mkIf config.llm.enable {
     # Brave Search MCP is part of the default LLM tool plane. Authentication
     # remains runtime/user state (`bx config set-key` or BRAVE_SEARCH_API_KEY),
     # so the API key never enters the Nix store.
@@ -101,5 +102,5 @@
     # home.activation.startMcpServers = lib.hm.dag.entryAfter ["writeBoundary"] ''
     #   $DRY_RUN_CMD ${pkgs.bash}/bin/bash $HOME/.local/bin/start-mcp-servers start
     # '';
-  });
+  };
 }

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -28,10 +28,6 @@
     enable = true;
   };
 
-  braveMcp = {
-    enable = true;
-  };
-
   proxmoxMcp = {
     enable = true;
   };
@@ -79,7 +75,7 @@
   #
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
-  # changes in each release.
+  # changes.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;


### PR DESCRIPTION
## Summary
- make `nix/home-manager/mods/llm.nix` own/import the existing Brave Search MCP module
- enable `braveMcp` by default whenever `llm.enable = true`
- remove the duplicate top-level/default import and desktop-specific enable
- keep Brave API credentials out of Nix; configure at runtime with `bx config set-key` or `BRAVE_SEARCH_API_KEY`

The existing `brave-mcp` package remains the typed stdio adapter over Brave's `bx` CLI and existing CI already builds/tests it.
