### PR TITLE
feat(emacs): add canonical cross-repo research approval

### DIFF
--- a/.doom.d/autoload/research-approval.el
+++ b/.doom.d/autoload/research-approval.el
@@ -1,12 +1,21 @@
 ;;; research-approval.el -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
-(require 'org)
 (require 'subr-x)
 
 (defconst nsa/research-approval--path-regexp
-  "\\`\\(?:research\\|rage\\)/.+\\.org\\'"
+  "\\`research/[^/]+\\.org\\'"
   "Repository-relative paths accepted by the approval command.")
+
+(defconst nsa/research-approval--fields
+  '("approval_schema" "approval_state" "approval_actor"
+    "approval_evidence" "approval_base_commit" "approval_base_blob"
+    "approval_decided_at")
+  "Approval fields in their required order.")
+
+(defconst nsa/research-approval--schema
+  "prolog-rlm.research-approval.v1"
+  "Canonical research approval schema identifier.")
 
 (defun nsa/research-approval--git-result (directory &rest arguments)
   "Run Git with ARGUMENTS in DIRECTORY and return (STATUS . OUTPUT)."
@@ -17,19 +26,18 @@
             (string-trim-right (buffer-string))))))
 
 (defun nsa/research-approval--git (directory &rest arguments)
-  "Run Git with ARGUMENTS in DIRECTORY and return its output.
-Signal a `user-error' when Git fails."
+  "Run Git with ARGUMENTS and signal a `user-error' on failure."
   (pcase-let ((`(,status . ,output)
                (apply #'nsa/research-approval--git-result
                       directory arguments)))
-    (unless (zerop status)
+    (unless (and (integerp status) (zerop status))
       (user-error "Git %s failed%s"
                   (string-join arguments " ")
                   (if (string-empty-p output) "" (format ": %s" output))))
     output))
 
 (defun nsa/research-approval--git-lines (directory &rest arguments)
-  "Run Git with ARGUMENTS in DIRECTORY and return nonempty output lines."
+  "Run Git with ARGUMENTS and return nonempty output lines."
   (split-string
    (apply #'nsa/research-approval--git directory arguments) "\n" t))
 
@@ -41,9 +49,8 @@ Signal a `user-error' when Git fails."
   (car values))
 
 (defun nsa/research-approval--eligible-path-p (path)
-  "Return non-nil when PATH names a research or RAGE Org record."
-  (and (not (string-prefix-p "../" path))
-       (string-match-p nsa/research-approval--path-regexp path)))
+  "Return non-nil when PATH is a tracked research Org record."
+  (string-match-p nsa/research-approval--path-regexp path))
 
 (defun nsa/research-approval--github-url-p (url)
   "Return non-nil when URL is an unambiguous GitHub repository URL."
@@ -56,8 +63,7 @@ Signal a `user-error' when Git fails."
 
 (defun nsa/research-approval--context (&optional require-clean)
   "Return verified Git context for the current buffer.
-When REQUIRE-CLEAN is non-nil, reject every tracked, staged, or untracked
-working-tree change."
+When REQUIRE-CLEAN is non-nil, reject every visible working-tree change."
   (unless (and buffer-file-name (file-regular-p buffer-file-name))
     (user-error "This buffer is not visiting a regular file"))
   (when (file-remote-p buffer-file-name)
@@ -69,21 +75,23 @@ working-tree change."
          (root (file-name-as-directory
                 (file-truename
                  (nsa/research-approval--git directory
-                                             "rev-parse" "--show-toplevel"))))
+                                              "rev-parse" "--show-toplevel"))))
          (path (file-relative-name file root)))
     (unless (nsa/research-approval--eligible-path-p path)
-      (user-error "%s is not a research/ or rage/ Org record" path))
+      (user-error "%s is not a research/*.org record" path))
     (nsa/research-approval--git root "ls-files" "--error-unmatch" "--" path)
     (when require-clean
       (let ((status (nsa/research-approval--git
                      root "status" "--porcelain=v1" "--untracked-files=all")))
         (unless (string-empty-p status)
-          (user-error "Repository has changes beyond this approval:\n%s" status))))
+          (user-error "Repository is dirty; approval requires a clean checkout:\n%s"
+                      status))))
     (let* ((branch-result
             (nsa/research-approval--git-result
              root "symbolic-ref" "--quiet" "--short" "HEAD"))
            (branch (cdr branch-result)))
-      (unless (and (zerop (car branch-result)) (not (string-empty-p branch)))
+      (unless (and (zerop (car branch-result))
+                   (not (string-empty-p branch)))
         (user-error "Detached HEAD: approval requires a named current branch"))
       (let* ((remote
               (nsa/research-approval--one
@@ -124,160 +132,395 @@ working-tree change."
                 :push-url push-url
                 :head (nsa/research-approval--git root "rev-parse" "HEAD")))))))
 
-(defun nsa/research-approval--insert-marker (timestamp)
-  "Insert an explicit approval marker using TIMESTAMP in the current Org file."
-  (let ((case-fold-search t))
+(defun nsa/research-approval--field-regexp (field)
+  "Return the exact canonical keyword regexp for FIELD."
+  (format "^#\\+%s: \\(.*\\)$" (regexp-quote field)))
+
+(defun nsa/research-approval--field-values (field)
+  "Return (LINE . VALUE) entries for canonical FIELD in the buffer."
+  (let ((regexp (nsa/research-approval--field-regexp field))
+        values)
     (save-excursion
       (goto-char (point-min))
-      (when (re-search-forward "^#\\+approval:[ \t]*" nil t)
-        (user-error "This record already contains an approval marker"))
+      (while (re-search-forward regexp nil t)
+        (push (cons (line-number-at-pos (match-beginning 0))
+                    (match-string-no-properties 1))
+              values)))
+    (nreverse values)))
+
+(defun nsa/research-approval--keyword-lines (keyword)
+  "Return line numbers for case-insensitive Org KEYWORD entries."
+  (let (lines)
+    (save-excursion
       (goto-char (point-min))
-      (cond ((re-search-forward "^#\\+status:.*$" nil t) (forward-line 1))
-            ((re-search-forward "^#\\+title:.*$" nil t) (forward-line 1))
-            (t (goto-char (point-min))))
-      (unless (bolp) (insert "\n"))
-      (insert "#+approval: APPROVED\n"
-              "#+approved_at: " timestamp "\n"))))
+      (let ((case-fold-search t))
+        (while (re-search-forward
+                (format "^#\\+%s:[ \\t]*.*$" (regexp-quote keyword))
+                nil t)
+          (push (line-number-at-pos (match-beginning 0)) lines))))
+    (nreverse lines)))
+
+(defun nsa/research-approval--canonical-block-errors (&optional expected-state)
+  "Return human-readable errors for the current record.
+When EXPECTED-STATE is non-nil, require that approval state."
+  (let ((titles (nsa/research-approval--keyword-lines "title"))
+        (statuses (nsa/research-approval--keyword-lines "status"))
+        errors)
+    (unless (= (length titles) 1)
+      (push (format "line 1: expected exactly one #+title keyword, found %d"
+                    (length titles)) errors))
+    (unless (= (length statuses) 1)
+      (push (format "line 1: expected exactly one #+status keyword, found %d"
+                    (length statuses)) errors))
+    (when (and (= (length titles) 1) (= (length statuses) 1)
+               (>= (car titles) (car statuses)))
+      (push (format "line %d: #+title must precede lifecycle #+status"
+                    (car statuses)) errors))
+    (when (= (length statuses) 1)
+      (save-excursion
+        (goto-char (point-min))
+        (forward-line (1- (car statuses)))
+        (let ((case-fold-search t))
+          (when (re-search-forward "^#\\+status:[ \\t]*\\(.*\\)$"
+                                   (line-end-position) t)
+            (let ((lifecycle (upcase (string-trim (match-string-no-properties 1)))))
+              (when (member lifecycle '("APPROVED" "REJECTED"))
+                (push (format "line %d: lifecycle status cannot be %s; use #+approval_state"
+                              (car statuses) lifecycle)
+                      errors)))))))
+    (dolist (field nsa/research-approval--fields)
+      (let ((values (nsa/research-approval--field-values field)))
+        (unless (= (length values) 1)
+          (push (format "line 1: approval field #+%s must occur exactly once, found %d"
+                        field (length values)) errors))))
+    (when (= (length statuses) 1)
+      (let ((status-line (car statuses)))
+        (cl-loop for field in nsa/research-approval--fields
+                 for offset from 1
+                 for expected-line = (+ status-line offset)
+                 for expected =
+                 (if (string= field "approval_schema")
+                     (format "#+%s: %s" field nsa/research-approval--schema)
+                   (let ((value (cdr (car (nsa/research-approval--field-values
+                                           field)))))
+                     (format "#+%s: %s" field (or value ""))))
+                 do (save-excursion
+                      (goto-char (point-min))
+                      (forward-line (1- expected-line))
+                      (let ((actual (buffer-substring-no-properties
+                                     (line-beginning-position)
+                                     (line-end-position))))
+                        (unless (string= actual expected)
+                          (push (format "line %d: canonical approval block expected #+%s immediately after #+status"
+                                        expected-line field)
+                                errors)))))))
+    (let ((case-fold-search t))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*#\\+\\(?:approval\\|approved\\|approve\\|reject\\)[[:alnum:]_-]*:"
+                nil t)
+          (let ((line (line-number-at-pos (match-beginning 0)))
+                (text (buffer-substring-no-properties
+                       (line-beginning-position) (line-end-position))))
+            (unless (or (string-match-p
+                         "\\`#\\+approval_schema: prolog-rlm\\.research-approval\\.v1\\'"
+                         text)
+                        (string-match-p
+                         "\\`#\\+approval_\\(?:state\\|actor\\|evidence\\|base_commit\\|base_blob\\|decided_at\\): "
+                         text))
+              (push (format "line %d: noncanonical approval keyword or layout"
+                            line) errors)))))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*:[^: \\t]*\\(?:approval\\|approve\\|reject\\)[^:]*:"
+                nil t)
+          (push (format "line %d: noncanonical approval property"
+                        (line-number-at-pos (match-beginning 0))) errors)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^#\\+property:.*\\(?:approval\\|approve\\|reject\\)"
+                nil t)
+          (push (format "line %d: noncanonical approval property"
+                        (line-number-at-pos (match-beginning 0))) errors)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*\\(?:[-+*][ \\t]+\\)?\\[[xX]\\][ \\t]+\\(?:APPROVE[D]?\\|REJECT[ED]?\\)\\(?:[ \\t]\\|$\\)"
+                nil t)
+          (push (format "line %d: checked approval box is not authoritative; use #+approval_state"
+                        (line-number-at-pos (match-beginning 0))) errors))))
+    (let* ((state-values (nsa/research-approval--field-values "approval_state"))
+           (state (and state-values (cdr (car state-values)))))
+      (when (= (length state-values) 1)
+        (unless (member state '("PENDING" "APPROVED" "REJECTED"))
+          (push (format "line %d: approval_state must be exactly PENDING, APPROVED, or REJECTED"
+                        (caar state-values)) errors))
+        (when (string= state "PENDING")
+          (dolist (field (cdr (cdr nsa/research-approval--fields)))
+            (let ((values (nsa/research-approval--field-values field)))
+              (when values
+                (let ((value (cdr (car values))))
+                  (unless (string= value "NONE")
+                    (push (format "line %d: PENDING %s must be NONE"
+                                  (car (car values)) field)
+                          errors)))))))
+        (when (and expected-state (not (string= state expected-state)))
+          (push (format "line %d: approval command requires state %s, found %s"
+                        (caar state-values) expected-state state) errors))))
+    (nreverse errors)))
+
+(defun nsa/research-approval--validate-record (&optional expected-state)
+  "Signal a `user-error' unless the current record is canonical."
+  (let ((errors (nsa/research-approval--canonical-block-errors expected-state)))
+    (when errors
+      (user-error "Invalid research approval layout:\n%s"
+                  (string-join errors "\n")))))
+
+(defun nsa/research-approval--only-intended-edit-p (context)
+  "Return non-nil when CONTEXT's file is the sole unstaged edit."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path)))
+    (and (equal (nsa/research-approval--git-lines
+                 root "status" "--porcelain=v1" "--untracked-files=all")
+                (list (concat " M " path)))
+         (equal (nsa/research-approval--git-lines root "diff" "--name-only" "--")
+                (list path))
+         (null (nsa/research-approval--git-lines
+                root "diff" "--cached" "--name-only" "--")))))
+
+(defun nsa/research-approval--approval-diff-p (context)
+  "Return non-nil when only canonical approval fields changed."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (diff (nsa/research-approval--git
+                root "diff" "--no-ext-diff" "--no-color" "--unified=0"
+                "--" path))
+         (lines (split-string diff "\n" t)))
+    (and lines
+         (cl-every
+          (lambda (line)
+            (or (string-prefix-p "@@" line)
+                (string-prefix-p "diff --" line)
+                (string-prefix-p "index " line)
+                (string-prefix-p "---" line)
+                (string-prefix-p "+++" line)
+                (and (string-match-p "^[+-]#\\+approval_[a-z_]+: " line)
+                     (not (string-prefix-p " " line)))))
+          lines))))
 
 (defun nsa/research-approval--same-target-p (before after)
   "Return non-nil when BEFORE and AFTER describe the same checkout target."
   (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
             '(:root :path :branch :remote :merge-ref :upstream :push-url :head)))
 
-(defun nsa/research-approval--only-intended-edit-p (context)
-  "Return non-nil when CONTEXT's file is the sole unstaged repository edit."
-  (let* ((root (plist-get context :root))
-         (path (plist-get context :path)))
-    (and (equal (nsa/research-approval--git-lines
-                 root "status" "--porcelain=v1" "--untracked-files=all")
-                (list (concat " M " path)))
-         (equal (nsa/research-approval--git-lines
-                 root "diff" "--name-only" "--")
-                (list path))
-         (null (nsa/research-approval--git-lines
-                root "diff" "--cached" "--name-only" "--")))))
-
-(defun nsa/research-approval--safe-to-restore-p (context)
-  "Return non-nil when CONTEXT's file is still the sole repository change."
-  (let* ((root (plist-get context :root))
-         (path (plist-get context :path))
-         (status (nsa/research-approval--git-lines
-                  root "status" "--porcelain=v1" "--untracked-files=all")))
-    (and (equal (nsa/research-approval--git root "rev-parse" "HEAD")
-                (plist-get context :head))
-         (= (length status) 1)
-         (string-suffix-p (concat " " path) (car status))
-         (equal (nsa/research-approval--git-lines
-                 root "diff" "HEAD" "--name-only" "--" path)
-                (list path)))))
+(defun nsa/research-approval--same-push-target-p (before after)
+  "Return non-nil when BEFORE and AFTER have the same push target."
+  (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
+            '(:root :path :branch :remote :merge-ref :upstream :push-url)))
 
 (defun nsa/research-approval--restore-buffer (contents point)
-  "Restore current buffer to CONTENTS and POINT, then save it."
+  "Restore the current buffer to CONTENTS and POINT, then save it."
   (let ((inhibit-read-only t))
     (erase-buffer)
     (insert contents)
     (goto-char (min point (point-max)))
     (save-buffer)))
 
-(defun nsa/research-approval--preview (context)
-  "Display the approval diff described by CONTEXT."
+(defun nsa/research-approval--replace-field (field value)
+  "Replace the sole canonical FIELD value with VALUE."
+  (let ((values (nsa/research-approval--field-values field)))
+    (unless (= (length values) 1)
+      (user-error "Cannot replace #+%s: expected one canonical field" field))
+    (goto-char (point-min))
+    (unless (re-search-forward (nsa/research-approval--field-regexp field) nil t)
+      (user-error "Cannot replace missing #+%s" field))
+    (replace-match (format "#+%s: %s" field value) t t)))
+
+(defun nsa/research-approval--safe-value-p (value)
+  "Return non-nil when VALUE is a nonempty, one-line field value."
+  (and (stringp value)
+       (not (string= value "NONE"))
+       (not (string-match-p (string 10) value))
+       (not (string-match-p (string 13) value))
+       (string-match-p "\\`[^ \\t]" value)
+       (string-match-p "[^ \\t]\\'" value)))
+
+(defun nsa/research-approval--verify-binding (context base-commit base-blob)
+  "Verify that BASE-COMMIT:path resolves exactly to BASE-BLOB."
   (let* ((root (plist-get context :root))
          (path (plist-get context :path))
-         (diff (nsa/research-approval--git
-                root "diff" "--no-ext-diff" "--no-color" "--" path))
-         (buffer (get-buffer-create "*Research approval preview*")))
+         (commit-spec (concat base-commit "^{commit}"))
+         (object-spec (concat base-commit ":" path)))
+    (unless (string= (nsa/research-approval--git root "rev-parse" "--verify"
+                                                  commit-spec)
+                     base-commit)
+      (user-error "Base commit is not a proven commit object"))
+    (unless (and (string= (nsa/research-approval--git root "cat-file" "-t"
+                                                       object-spec)
+                          "blob")
+                 (string= (nsa/research-approval--git root "rev-parse" "--verify"
+                                                       object-spec)
+                          base-blob))
+      (user-error "Base commit does not resolve to the recorded file blob"))
+    t))
+
+(defun nsa/research-approval--commit-verified-p (context base-commit)
+  "Return non-nil when HEAD is a verified approval-only child of BASE-COMMIT."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (parent (nsa/research-approval--git root "rev-parse" "HEAD^"))
+         (files (nsa/research-approval--git-lines
+                 root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")))
+    (let ((clean (string-empty-p
+                  (nsa/research-approval--git root "status" "--porcelain=v1"
+                                               "--untracked-files=all"))))
+      (and (string= parent base-commit)
+           (equal files (list path))
+           clean))))
+
+(defun nsa/research-approval--prompt-value (prompt default)
+  "Read a safe nonempty field value for PROMPT, using DEFAULT."
+  (let ((value (read-string prompt default)))
+    (unless (nsa/research-approval--safe-value-p value)
+      (user-error "Approval field must be a nonempty one-line value other than NONE"))
+    value))
+
+(defun nsa/research-approval--preview (context diff base-commit base-blob state)
+  "Display DIFF and its verified approval target before confirmation."
+  (let ((buffer (get-buffer-create "*Research approval preview*")))
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (insert (format "Approval target\n  file: %s\n  branch: %s\n"
-                        path (plist-get context :branch)))
-        (insert (format "  upstream: %s\n  push URL: %s\n\n"
+        (insert (format "Research approval dry-run\n  file: %s\n  state: %s\n  branch: %s\n"
+                        (plist-get context :path) state
+                        (plist-get context :branch)))
+        (insert (format "  upstream: %s\n  push URL: %s\n"
                         (plist-get context :upstream)
                         (plist-get context :push-url)))
+        (insert (format "  base commit: %s\n  base blob: %s\n\n"
+                        base-commit base-blob))
         (insert diff "\n")
         (diff-mode)
         (goto-char (point-min))))
     (display-buffer buffer)))
 
-;;;###autoload
-(defun nsa/research-approve-and-push ()
-  "Approve the current research Org record, commit it alone, and push upstream.
-
-The command refuses existing edits, untracked files, detached HEAD, ambiguous
-branch configuration, non-GitHub push URLs, and any target change during the
-workflow.  It previews the exact Org diff and performs a Git push dry-run
-before asking for final confirmation."
+(defun nsa/research-approval--decide-and-push (state)
+  "Record STATE for the current research record, commit it, and push upstream."
   (interactive)
   (let* ((context (nsa/research-approval--context t))
          (root (plist-get context :root))
          (path (plist-get context :path))
-         (remote (plist-get context :remote))
-         (merge-ref (plist-get context :merge-ref))
+         (_validated (progn
+                       (nsa/research-approval--validate-record "PENDING")
+                       t))
+         (base-commit (plist-get context :head))
+         (base-blob (nsa/research-approval--git
+                     root "rev-parse" "--verify"
+                     (concat base-commit ":" path)))
+         (_binding (progn
+                     (nsa/research-approval--verify-binding
+                      context base-commit base-blob)
+                     t))
+         (actor (nsa/research-approval--prompt-value
+                 "Human decision-maker: "
+                 (nsa/research-approval--git root "config" "user.name")))
+         (evidence (nsa/research-approval--prompt-value
+                    "Durable approval evidence: " ""))
+         (timestamp (format-time-string "%Y-%m-%dT%H:%M:%S%:z"))
          (original (buffer-substring-no-properties (point-min) (point-max)))
          (original-point (point))
-         (timestamp (format-time-string "[%Y-%m-%d %a %H:%M %z]"))
-         (commit-message
-          (format "docs(research): approve %s" (file-name-base path)))
-         approval-contents
-         committed)
+         (approval-contents nil)
+         (committed nil))
     (nsa/research-approval--git
-     root "push" "--dry-run" "--porcelain" remote (concat "HEAD:" merge-ref))
+     root "push" "--dry-run" "--porcelain"
+     (plist-get context :remote) (concat "HEAD:" (plist-get context :merge-ref)))
     (unwind-protect
         (progn
-          (nsa/research-approval--insert-marker timestamp)
+          (dolist (field `(("approval_state" . ,state)
+                           ("approval_actor" . ,actor)
+                           ("approval_evidence" . ,evidence)
+                           ("approval_base_commit" . ,base-commit)
+                           ("approval_base_blob" . ,base-blob)
+                           ("approval_decided_at" . ,timestamp)))
+            (nsa/research-approval--replace-field (car field) (cdr field)))
           (setq approval-contents
                 (buffer-substring-no-properties (point-min) (point-max)))
           (save-buffer)
           (unless (equal approval-contents
-                           (buffer-substring-no-properties (point-min) (point-max)))
-            (user-error "A save hook changed more than the approval marker"))
-          (unless (nsa/research-approval--only-intended-edit-p context)
-            (user-error "Repository changed during approval; refusing to commit"))
-          (nsa/research-approval--preview context)
-          (unless (yes-or-no-p
-                   (format "Commit only %s and push %s to %s? "
-                           path (plist-get context :branch)
-                           (plist-get context :upstream)))
-            (user-error "Approval cancelled; file restored"))
+                         (buffer-substring-no-properties (point-min) (point-max)))
+            (user-error "A save hook changed more than the approval fields"))
+          (nsa/research-approval--validate-record state)
+          (unless (and (nsa/research-approval--only-intended-edit-p context)
+                       (nsa/research-approval--approval-diff-p context))
+            (user-error "Repository changed beyond the canonical approval fields"))
+          (nsa/research-approval--preview
+           context
+           (nsa/research-approval--git
+            root "diff" "--no-ext-diff" "--no-color" "--unified=0" "--" path)
+           base-commit base-blob state)
           (let ((current (nsa/research-approval--context nil)))
-            (unless (and (nsa/research-approval--same-target-p context current)
-                         (nsa/research-approval--only-intended-edit-p context))
-              (user-error "Checkout or working tree changed; refusing to commit")))
+            (unless (nsa/research-approval--same-target-p context current)
+              (user-error "Checkout or push target changed; refusing to commit")))
+          (unless (yes-or-no-p
+                   (format "Commit only %s as %s and push to %s? "
+                           path state (plist-get context :upstream)))
+            (user-error "Approval cancelled; file restored"))
           (nsa/research-approval--git
-           root "commit" "--only" "-m" commit-message "--" path)
+           root "commit" "--only" "-m"
+           (format "docs(research): %s %s"
+                   (downcase state) (file-name-base path))
+           "--" path)
           (setq committed t)
-          (unless (and
-                   (equal (nsa/research-approval--git root "rev-parse" "HEAD^")
-                          (plist-get context :head))
-                   (equal (nsa/research-approval--git-lines
-                           root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")
-                          (list path))
-                   (string-empty-p
-                    (nsa/research-approval--git
-                     root "status" "--porcelain=v1" "--untracked-files=all")))
-            (user-error "Commit verification failed; nothing was pushed"))
+          (unless (and (nsa/research-approval--commit-verified-p
+                        context base-commit)
+                       (nsa/research-approval--verify-binding
+                         context base-commit base-blob))
+            (user-error "Local approval commit verification failed; nothing was pushed"))
           (let ((current (nsa/research-approval--context t)))
-            (unless (and (equal (plist-get context :root) (plist-get current :root))
-                         (equal (plist-get context :path) (plist-get current :path))
-                         (equal (plist-get context :branch) (plist-get current :branch))
-                         (equal (plist-get context :remote) (plist-get current :remote))
-                         (equal (plist-get context :merge-ref) (plist-get current :merge-ref))
-                         (equal (plist-get context :upstream) (plist-get current :upstream))
-                         (equal (plist-get context :push-url) (plist-get current :push-url)))
-              (user-error "Push target changed after commit; nothing was pushed")))
-          (nsa/research-approval--git
-           root "push" "--porcelain" remote (concat "HEAD:" merge-ref))
-          (message "Approved %s, committed it alone, and pushed %s"
-                   path (plist-get context :upstream)))
+            (unless (nsa/research-approval--same-push-target-p context current)
+              (user-error "Push target changed after commit; approval commit remains local")))
+          (condition-case error-data
+              (nsa/research-approval--git
+               root "push" "--porcelain"
+               (plist-get context :remote)
+               (concat "HEAD:" (plist-get context :merge-ref)))
+            (error
+             (user-error "Approval commit %s is verified locally but push failed: %s"
+                         (nsa/research-approval--git root "rev-parse" "HEAD")
+                         (error-message-string error-data))))
+          (message "Recorded %s for %s, verified commit, and pushed %s"
+                   state path (plist-get context :upstream)))
       (unless committed
         (when (and approval-contents
                    (equal (buffer-substring-no-properties (point-min) (point-max))
                           (with-temp-buffer
                             (insert-file-contents buffer-file-name)
                             (buffer-string)))
-                   (nsa/research-approval--safe-to-restore-p context))
+                   (string= (nsa/research-approval--git root "rev-parse" "HEAD")
+                            base-commit)
+                   (equal (nsa/research-approval--git-lines
+                           root "status" "--porcelain=v1" "--untracked-files=all")
+                          (list (concat " M " path)))
+                   (equal (nsa/research-approval--git-lines
+                           root "diff" "--name-only" "--" path)
+                          (list path)))
           (ignore-errors
             (nsa/research-approval--git root "restore" "--staged" "--" path))
           (nsa/research-approval--restore-buffer original original-point))))))
+
+;;;###autoload
+(defun nsa/research-approve-and-push ()
+  "Record APPROVED for the current canonical research record and push it."
+  (interactive)
+  (nsa/research-approval--decide-and-push "APPROVED"))
+
+;;;###autoload
+(defun nsa/research-reject-and-push ()
+  "Record REJECTED for the current canonical research record and push it."
+  (interactive)
+  (nsa/research-approval--decide-and-push "REJECTED"))
 
 (provide 'research-approval)

--- a/.doom.d/autoload/research-approval.el
+++ b/.doom.d/autoload/research-approval.el
@@ -1,0 +1,283 @@
+;;; research-approval.el -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'org)
+(require 'subr-x)
+
+(defconst nsa/research-approval--path-regexp
+  "\\`\\(?:research\\|rage\\)/.+\\.org\\'"
+  "Repository-relative paths accepted by the approval command.")
+
+(defun nsa/research-approval--git-result (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return (STATUS . OUTPUT)."
+  (with-temp-buffer
+    (let ((default-directory (file-name-as-directory directory)))
+      (cons (apply #'process-file
+                   "git" nil (list (current-buffer) t) nil arguments)
+            (string-trim-right (buffer-string))))))
+
+(defun nsa/research-approval--git (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return its output.
+Signal a `user-error' when Git fails."
+  (pcase-let ((`(,status . ,output)
+               (apply #'nsa/research-approval--git-result
+                      directory arguments)))
+    (unless (zerop status)
+      (user-error "Git %s failed%s"
+                  (string-join arguments " ")
+                  (if (string-empty-p output) "" (format ": %s" output))))
+    output))
+
+(defun nsa/research-approval--git-lines (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return nonempty output lines."
+  (split-string
+   (apply #'nsa/research-approval--git directory arguments) "\n" t))
+
+(defun nsa/research-approval--one (description values)
+  "Return the only member of VALUES or reject ambiguous DESCRIPTION."
+  (unless (= (length values) 1)
+    (user-error "Cannot prove %s: expected one value, found %d"
+                description (length values)))
+  (car values))
+
+(defun nsa/research-approval--eligible-path-p (path)
+  "Return non-nil when PATH names a research or RAGE Org record."
+  (and (not (string-prefix-p "../" path))
+       (string-match-p nsa/research-approval--path-regexp path)))
+
+(defun nsa/research-approval--github-url-p (url)
+  "Return non-nil when URL is an unambiguous GitHub repository URL."
+  (string-match-p
+   (concat "\\`\\(?:git@github\\.com:"
+           "\\|ssh://git@github\\.com/"
+           "\\|https://github\\.com/\\)"
+           "[^/[:space:]]+/[^/[:space:]]+\\(?:\\.git\\)?/?\\'")
+   url))
+
+(defun nsa/research-approval--context (&optional require-clean)
+  "Return verified Git context for the current buffer.
+When REQUIRE-CLEAN is non-nil, reject every tracked, staged, or untracked
+working-tree change."
+  (unless (and buffer-file-name (file-regular-p buffer-file-name))
+    (user-error "This buffer is not visiting a regular file"))
+  (when (file-remote-p buffer-file-name)
+    (user-error "Remote files are not supported"))
+  (when (buffer-modified-p)
+    (user-error "Save or discard existing buffer edits before approval"))
+  (let* ((file (file-truename buffer-file-name))
+         (directory (file-name-directory file))
+         (root (file-name-as-directory
+                (file-truename
+                 (nsa/research-approval--git directory
+                                             "rev-parse" "--show-toplevel"))))
+         (path (file-relative-name file root)))
+    (unless (nsa/research-approval--eligible-path-p path)
+      (user-error "%s is not a research/ or rage/ Org record" path))
+    (nsa/research-approval--git root "ls-files" "--error-unmatch" "--" path)
+    (when require-clean
+      (let ((status (nsa/research-approval--git
+                     root "status" "--porcelain=v1" "--untracked-files=all")))
+        (unless (string-empty-p status)
+          (user-error "Repository has changes beyond this approval:\n%s" status))))
+    (let* ((branch-result
+            (nsa/research-approval--git-result
+             root "symbolic-ref" "--quiet" "--short" "HEAD"))
+           (branch (cdr branch-result)))
+      (unless (and (zerop (car branch-result)) (not (string-empty-p branch)))
+        (user-error "Detached HEAD: approval requires a named current branch"))
+      (let* ((remote
+              (nsa/research-approval--one
+               (format "remote for branch %s" branch)
+               (nsa/research-approval--git-lines
+                root "config" "--get-all" (format "branch.%s.remote" branch))))
+             (merge-ref
+              (nsa/research-approval--one
+               (format "upstream branch for %s" branch)
+               (nsa/research-approval--git-lines
+                root "config" "--get-all" (format "branch.%s.merge" branch)))))
+        (when (string= remote ".")
+          (user-error "Branch %s tracks a local branch, not GitHub" branch))
+        (unless (string-prefix-p "refs/heads/" merge-ref)
+          (user-error "Upstream %s is not a remote branch" merge-ref))
+        (let* ((upstream-branch (string-remove-prefix "refs/heads/" merge-ref))
+               (upstream
+                (nsa/research-approval--git
+                 root "rev-parse" "--abbrev-ref" "--symbolic-full-name"
+                 "@{upstream}"))
+               (expected-upstream (concat remote "/" upstream-branch))
+               (push-url
+                (nsa/research-approval--one
+                 (format "push URL for remote %s" remote)
+                 (nsa/research-approval--git-lines
+                  root "remote" "get-url" "--push" "--all" remote))))
+          (unless (string= upstream expected-upstream)
+            (user-error "Upstream mismatch: configured %s, resolved %s"
+                        expected-upstream upstream))
+          (unless (nsa/research-approval--github-url-p push-url)
+            (user-error "Push URL is not a proven GitHub repository: %s" push-url))
+          (list :root root
+                :path path
+                :branch branch
+                :remote remote
+                :merge-ref merge-ref
+                :upstream upstream
+                :push-url push-url
+                :head (nsa/research-approval--git root "rev-parse" "HEAD")))))))
+
+(defun nsa/research-approval--insert-marker (timestamp)
+  "Insert an explicit approval marker using TIMESTAMP in the current Org file."
+  (let ((case-fold-search t))
+    (save-excursion
+      (goto-char (point-min))
+      (when (re-search-forward "^#\\+approval:[ \t]*" nil t)
+        (user-error "This record already contains an approval marker"))
+      (goto-char (point-min))
+      (cond ((re-search-forward "^#\\+status:.*$" nil t) (forward-line 1))
+            ((re-search-forward "^#\\+title:.*$" nil t) (forward-line 1))
+            (t (goto-char (point-min))))
+      (unless (bolp) (insert "\n"))
+      (insert "#+approval: APPROVED\n"
+              "#+approved_at: " timestamp "\n"))))
+
+(defun nsa/research-approval--same-target-p (before after)
+  "Return non-nil when BEFORE and AFTER describe the same checkout target."
+  (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
+            '(:root :path :branch :remote :merge-ref :upstream :push-url :head)))
+
+(defun nsa/research-approval--only-intended-edit-p (context)
+  "Return non-nil when CONTEXT's file is the sole unstaged repository edit."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path)))
+    (and (equal (nsa/research-approval--git-lines
+                 root "status" "--porcelain=v1" "--untracked-files=all")
+                (list (concat " M " path)))
+         (equal (nsa/research-approval--git-lines
+                 root "diff" "--name-only" "--")
+                (list path))
+         (null (nsa/research-approval--git-lines
+                root "diff" "--cached" "--name-only" "--")))))
+
+(defun nsa/research-approval--safe-to-restore-p (context)
+  "Return non-nil when CONTEXT's file is still the sole repository change."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (status (nsa/research-approval--git-lines
+                  root "status" "--porcelain=v1" "--untracked-files=all")))
+    (and (equal (nsa/research-approval--git root "rev-parse" "HEAD")
+                (plist-get context :head))
+         (= (length status) 1)
+         (string-suffix-p (concat " " path) (car status))
+         (equal (nsa/research-approval--git-lines
+                 root "diff" "HEAD" "--name-only" "--" path)
+                (list path)))))
+
+(defun nsa/research-approval--restore-buffer (contents point)
+  "Restore current buffer to CONTENTS and POINT, then save it."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert contents)
+    (goto-char (min point (point-max)))
+    (save-buffer)))
+
+(defun nsa/research-approval--preview (context)
+  "Display the approval diff described by CONTEXT."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (diff (nsa/research-approval--git
+                root "diff" "--no-ext-diff" "--no-color" "--" path))
+         (buffer (get-buffer-create "*Research approval preview*")))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "Approval target\n  file: %s\n  branch: %s\n"
+                        path (plist-get context :branch)))
+        (insert (format "  upstream: %s\n  push URL: %s\n\n"
+                        (plist-get context :upstream)
+                        (plist-get context :push-url)))
+        (insert diff "\n")
+        (diff-mode)
+        (goto-char (point-min))))
+    (display-buffer buffer)))
+
+;;;###autoload
+(defun nsa/research-approve-and-push ()
+  "Approve the current research Org record, commit it alone, and push upstream.
+
+The command refuses existing edits, untracked files, detached HEAD, ambiguous
+branch configuration, non-GitHub push URLs, and any target change during the
+workflow.  It previews the exact Org diff and performs a Git push dry-run
+before asking for final confirmation."
+  (interactive)
+  (let* ((context (nsa/research-approval--context t))
+         (root (plist-get context :root))
+         (path (plist-get context :path))
+         (remote (plist-get context :remote))
+         (merge-ref (plist-get context :merge-ref))
+         (original (buffer-substring-no-properties (point-min) (point-max)))
+         (original-point (point))
+         (timestamp (format-time-string "[%Y-%m-%d %a %H:%M %z]"))
+         (commit-message
+          (format "docs(research): approve %s" (file-name-base path)))
+         approval-contents
+         committed)
+    (nsa/research-approval--git
+     root "push" "--dry-run" "--porcelain" remote (concat "HEAD:" merge-ref))
+    (unwind-protect
+        (progn
+          (nsa/research-approval--insert-marker timestamp)
+          (setq approval-contents
+                (buffer-substring-no-properties (point-min) (point-max)))
+          (save-buffer)
+          (unless (equal approval-contents
+                           (buffer-substring-no-properties (point-min) (point-max)))
+            (user-error "A save hook changed more than the approval marker"))
+          (unless (nsa/research-approval--only-intended-edit-p context)
+            (user-error "Repository changed during approval; refusing to commit"))
+          (nsa/research-approval--preview context)
+          (unless (yes-or-no-p
+                   (format "Commit only %s and push %s to %s? "
+                           path (plist-get context :branch)
+                           (plist-get context :upstream)))
+            (user-error "Approval cancelled; file restored"))
+          (let ((current (nsa/research-approval--context nil)))
+            (unless (and (nsa/research-approval--same-target-p context current)
+                         (nsa/research-approval--only-intended-edit-p context))
+              (user-error "Checkout or working tree changed; refusing to commit")))
+          (nsa/research-approval--git
+           root "commit" "--only" "-m" commit-message "--" path)
+          (setq committed t)
+          (unless (and
+                   (equal (nsa/research-approval--git root "rev-parse" "HEAD^")
+                          (plist-get context :head))
+                   (equal (nsa/research-approval--git-lines
+                           root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")
+                          (list path))
+                   (string-empty-p
+                    (nsa/research-approval--git
+                     root "status" "--porcelain=v1" "--untracked-files=all")))
+            (user-error "Commit verification failed; nothing was pushed"))
+          (let ((current (nsa/research-approval--context t)))
+            (unless (and (equal (plist-get context :root) (plist-get current :root))
+                         (equal (plist-get context :path) (plist-get current :path))
+                         (equal (plist-get context :branch) (plist-get current :branch))
+                         (equal (plist-get context :remote) (plist-get current :remote))
+                         (equal (plist-get context :merge-ref) (plist-get current :merge-ref))
+                         (equal (plist-get context :upstream) (plist-get current :upstream))
+                         (equal (plist-get context :push-url) (plist-get current :push-url)))
+              (user-error "Push target changed after commit; nothing was pushed")))
+          (nsa/research-approval--git
+           root "push" "--porcelain" remote (concat "HEAD:" merge-ref))
+          (message "Approved %s, committed it alone, and pushed %s"
+                   path (plist-get context :upstream)))
+      (unless committed
+        (when (and approval-contents
+                   (equal (buffer-substring-no-properties (point-min) (point-max))
+                          (with-temp-buffer
+                            (insert-file-contents buffer-file-name)
+                            (buffer-string)))
+                   (nsa/research-approval--safe-to-restore-p context))
+          (ignore-errors
+            (nsa/research-approval--git root "restore" "--staged" "--" path))
+          (nsa/research-approval--restore-buffer original original-point))))))
+
+(provide 'research-approval)

--- a/.doom.d/autoload/research-approval.org
+++ b/.doom.d/autoload/research-approval.org
@@ -1,20 +1,32 @@
-#+title: Fail-safe research approval
+#+title: Canonical research approval workflow
 #+property: header-args :emacs-lisp :tangle ./research-approval.el :results none
 
-This command records human approval in a project research record and publishes
-only that marker.  It deliberately uses the current branch's configured
-upstream instead of selecting or creating a branch.
+This command records an explicit human decision in a canonical project research
+record. It never infers approval from prose, lifecycle status, checkboxes, or
+model output. It proves the current Git checkout and configured GitHub upstream,
+binds the decision to the exact pre-approval commit and file blob, previews the
+field-only diff and push target, asks for confirmation, and leaves a verified
+local approval commit if pushing fails.
 
 #+begin_src emacs-lisp
 ;;; research-approval.el -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
-(require 'org)
 (require 'subr-x)
 
 (defconst nsa/research-approval--path-regexp
-  "\\`\\(?:research\\|rage\\)/.+\\.org\\'"
+  "\\`research/[^/]+\\.org\\'"
   "Repository-relative paths accepted by the approval command.")
+
+(defconst nsa/research-approval--fields
+  '("approval_schema" "approval_state" "approval_actor"
+    "approval_evidence" "approval_base_commit" "approval_base_blob"
+    "approval_decided_at")
+  "Approval fields in their required order.")
+
+(defconst nsa/research-approval--schema
+  "prolog-rlm.research-approval.v1"
+  "Canonical research approval schema identifier.")
 
 (defun nsa/research-approval--git-result (directory &rest arguments)
   "Run Git with ARGUMENTS in DIRECTORY and return (STATUS . OUTPUT)."
@@ -25,19 +37,18 @@ upstream instead of selecting or creating a branch.
             (string-trim-right (buffer-string))))))
 
 (defun nsa/research-approval--git (directory &rest arguments)
-  "Run Git with ARGUMENTS in DIRECTORY and return its output.
-Signal a `user-error' when Git fails."
+  "Run Git with ARGUMENTS and signal a `user-error' on failure."
   (pcase-let ((`(,status . ,output)
                (apply #'nsa/research-approval--git-result
                       directory arguments)))
-    (unless (zerop status)
+    (unless (and (integerp status) (zerop status))
       (user-error "Git %s failed%s"
                   (string-join arguments " ")
                   (if (string-empty-p output) "" (format ": %s" output))))
     output))
 
 (defun nsa/research-approval--git-lines (directory &rest arguments)
-  "Run Git with ARGUMENTS in DIRECTORY and return nonempty output lines."
+  "Run Git with ARGUMENTS and return nonempty output lines."
   (split-string
    (apply #'nsa/research-approval--git directory arguments) "\n" t))
 
@@ -49,9 +60,8 @@ Signal a `user-error' when Git fails."
   (car values))
 
 (defun nsa/research-approval--eligible-path-p (path)
-  "Return non-nil when PATH names a research or RAGE Org record."
-  (and (not (string-prefix-p "../" path))
-       (string-match-p nsa/research-approval--path-regexp path)))
+  "Return non-nil when PATH is a tracked research Org record."
+  (string-match-p nsa/research-approval--path-regexp path))
 
 (defun nsa/research-approval--github-url-p (url)
   "Return non-nil when URL is an unambiguous GitHub repository URL."
@@ -64,8 +74,7 @@ Signal a `user-error' when Git fails."
 
 (defun nsa/research-approval--context (&optional require-clean)
   "Return verified Git context for the current buffer.
-When REQUIRE-CLEAN is non-nil, reject every tracked, staged, or untracked
-working-tree change."
+When REQUIRE-CLEAN is non-nil, reject every visible working-tree change."
   (unless (and buffer-file-name (file-regular-p buffer-file-name))
     (user-error "This buffer is not visiting a regular file"))
   (when (file-remote-p buffer-file-name)
@@ -77,21 +86,23 @@ working-tree change."
          (root (file-name-as-directory
                 (file-truename
                  (nsa/research-approval--git directory
-                                             "rev-parse" "--show-toplevel"))))
+                                              "rev-parse" "--show-toplevel"))))
          (path (file-relative-name file root)))
     (unless (nsa/research-approval--eligible-path-p path)
-      (user-error "%s is not a research/ or rage/ Org record" path))
+      (user-error "%s is not a research/*.org record" path))
     (nsa/research-approval--git root "ls-files" "--error-unmatch" "--" path)
     (when require-clean
       (let ((status (nsa/research-approval--git
                      root "status" "--porcelain=v1" "--untracked-files=all")))
         (unless (string-empty-p status)
-          (user-error "Repository has changes beyond this approval:\n%s" status))))
+          (user-error "Repository is dirty; approval requires a clean checkout:\n%s"
+                      status))))
     (let* ((branch-result
             (nsa/research-approval--git-result
              root "symbolic-ref" "--quiet" "--short" "HEAD"))
            (branch (cdr branch-result)))
-      (unless (and (zerop (car branch-result)) (not (string-empty-p branch)))
+      (unless (and (zerop (car branch-result))
+                   (not (string-empty-p branch)))
         (user-error "Detached HEAD: approval requires a named current branch"))
       (let* ((remote
               (nsa/research-approval--one
@@ -132,161 +143,396 @@ working-tree change."
                 :push-url push-url
                 :head (nsa/research-approval--git root "rev-parse" "HEAD")))))))
 
-(defun nsa/research-approval--insert-marker (timestamp)
-  "Insert an explicit approval marker using TIMESTAMP in the current Org file."
-  (let ((case-fold-search t))
+(defun nsa/research-approval--field-regexp (field)
+  "Return the exact canonical keyword regexp for FIELD."
+  (format "^#\\+%s: \\(.*\\)$" (regexp-quote field)))
+
+(defun nsa/research-approval--field-values (field)
+  "Return (LINE . VALUE) entries for canonical FIELD in the buffer."
+  (let ((regexp (nsa/research-approval--field-regexp field))
+        values)
     (save-excursion
       (goto-char (point-min))
-      (when (re-search-forward "^#\\+approval:[ \t]*" nil t)
-        (user-error "This record already contains an approval marker"))
+      (while (re-search-forward regexp nil t)
+        (push (cons (line-number-at-pos (match-beginning 0))
+                    (match-string-no-properties 1))
+              values)))
+    (nreverse values)))
+
+(defun nsa/research-approval--keyword-lines (keyword)
+  "Return line numbers for case-insensitive Org KEYWORD entries."
+  (let (lines)
+    (save-excursion
       (goto-char (point-min))
-      (cond ((re-search-forward "^#\\+status:.*$" nil t) (forward-line 1))
-            ((re-search-forward "^#\\+title:.*$" nil t) (forward-line 1))
-            (t (goto-char (point-min))))
-      (unless (bolp) (insert "\n"))
-      (insert "#+approval: APPROVED\n"
-              "#+approved_at: " timestamp "\n"))))
+      (let ((case-fold-search t))
+        (while (re-search-forward
+                (format "^#\\+%s:[ \\t]*.*$" (regexp-quote keyword))
+                nil t)
+          (push (line-number-at-pos (match-beginning 0)) lines))))
+    (nreverse lines)))
+
+(defun nsa/research-approval--canonical-block-errors (&optional expected-state)
+  "Return human-readable errors for the current record.
+When EXPECTED-STATE is non-nil, require that approval state."
+  (let ((titles (nsa/research-approval--keyword-lines "title"))
+        (statuses (nsa/research-approval--keyword-lines "status"))
+        errors)
+    (unless (= (length titles) 1)
+      (push (format "line 1: expected exactly one #+title keyword, found %d"
+                    (length titles)) errors))
+    (unless (= (length statuses) 1)
+      (push (format "line 1: expected exactly one #+status keyword, found %d"
+                    (length statuses)) errors))
+    (when (and (= (length titles) 1) (= (length statuses) 1)
+               (>= (car titles) (car statuses)))
+      (push (format "line %d: #+title must precede lifecycle #+status"
+                    (car statuses)) errors))
+    (when (= (length statuses) 1)
+      (save-excursion
+        (goto-char (point-min))
+        (forward-line (1- (car statuses)))
+        (let ((case-fold-search t))
+          (when (re-search-forward "^#\\+status:[ \\t]*\\(.*\\)$"
+                                   (line-end-position) t)
+            (let ((lifecycle (upcase (string-trim (match-string-no-properties 1)))))
+              (when (member lifecycle '("APPROVED" "REJECTED"))
+                (push (format "line %d: lifecycle status cannot be %s; use #+approval_state"
+                              (car statuses) lifecycle)
+                      errors)))))))
+    (dolist (field nsa/research-approval--fields)
+      (let ((values (nsa/research-approval--field-values field)))
+        (unless (= (length values) 1)
+          (push (format "line 1: approval field #+%s must occur exactly once, found %d"
+                        field (length values)) errors))))
+    (when (= (length statuses) 1)
+      (let ((status-line (car statuses)))
+        (cl-loop for field in nsa/research-approval--fields
+                 for offset from 1
+                 for expected-line = (+ status-line offset)
+                 for expected =
+                 (if (string= field "approval_schema")
+                     (format "#+%s: %s" field nsa/research-approval--schema)
+                   (let ((value (cdr (car (nsa/research-approval--field-values
+                                           field)))))
+                     (format "#+%s: %s" field (or value ""))))
+                 do (save-excursion
+                      (goto-char (point-min))
+                      (forward-line (1- expected-line))
+                      (let ((actual (buffer-substring-no-properties
+                                     (line-beginning-position)
+                                     (line-end-position))))
+                        (unless (string= actual expected)
+                          (push (format "line %d: canonical approval block expected #+%s immediately after #+status"
+                                        expected-line field)
+                                errors)))))))
+    (let ((case-fold-search t))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*#\\+\\(?:approval\\|approved\\|approve\\|reject\\)[[:alnum:]_-]*:"
+                nil t)
+          (let ((line (line-number-at-pos (match-beginning 0)))
+                (text (buffer-substring-no-properties
+                       (line-beginning-position) (line-end-position))))
+            (unless (or (string-match-p
+                         "\\`#\\+approval_schema: prolog-rlm\\.research-approval\\.v1\\'"
+                         text)
+                        (string-match-p
+                         "\\`#\\+approval_\\(?:state\\|actor\\|evidence\\|base_commit\\|base_blob\\|decided_at\\): "
+                         text))
+              (push (format "line %d: noncanonical approval keyword or layout"
+                            line) errors)))))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*:[^: \\t]*\\(?:approval\\|approve\\|reject\\)[^:]*:"
+                nil t)
+          (push (format "line %d: noncanonical approval property"
+                        (line-number-at-pos (match-beginning 0))) errors)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^#\\+property:.*\\(?:approval\\|approve\\|reject\\)"
+                nil t)
+          (push (format "line %d: noncanonical approval property"
+                        (line-number-at-pos (match-beginning 0))) errors)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward
+                "^[ \\t]*\\(?:[-+*][ \\t]+\\)?\\[[xX]\\][ \\t]+\\(?:APPROVE[D]?\\|REJECT[ED]?\\)\\(?:[ \\t]\\|$\\)"
+                nil t)
+          (push (format "line %d: checked approval box is not authoritative; use #+approval_state"
+                        (line-number-at-pos (match-beginning 0))) errors))))
+    (let* ((state-values (nsa/research-approval--field-values "approval_state"))
+           (state (and state-values (cdr (car state-values)))))
+      (when (= (length state-values) 1)
+        (unless (member state '("PENDING" "APPROVED" "REJECTED"))
+          (push (format "line %d: approval_state must be exactly PENDING, APPROVED, or REJECTED"
+                        (caar state-values)) errors))
+        (when (string= state "PENDING")
+          (dolist (field (cdr (cdr nsa/research-approval--fields)))
+            (let ((values (nsa/research-approval--field-values field)))
+              (when values
+                (let ((value (cdr (car values))))
+                  (unless (string= value "NONE")
+                    (push (format "line %d: PENDING %s must be NONE"
+                                  (car (car values)) field)
+                          errors)))))))
+        (when (and expected-state (not (string= state expected-state)))
+          (push (format "line %d: approval command requires state %s, found %s"
+                        (caar state-values) expected-state state) errors))))
+    (nreverse errors)))
+
+(defun nsa/research-approval--validate-record (&optional expected-state)
+  "Signal a `user-error' unless the current record is canonical."
+  (let ((errors (nsa/research-approval--canonical-block-errors expected-state)))
+    (when errors
+      (user-error "Invalid research approval layout:\n%s"
+                  (string-join errors "\n")))))
+
+(defun nsa/research-approval--only-intended-edit-p (context)
+  "Return non-nil when CONTEXT's file is the sole unstaged edit."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path)))
+    (and (equal (nsa/research-approval--git-lines
+                 root "status" "--porcelain=v1" "--untracked-files=all")
+                (list (concat " M " path)))
+         (equal (nsa/research-approval--git-lines root "diff" "--name-only" "--")
+                (list path))
+         (null (nsa/research-approval--git-lines
+                root "diff" "--cached" "--name-only" "--")))))
+
+(defun nsa/research-approval--approval-diff-p (context)
+  "Return non-nil when only canonical approval fields changed."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (diff (nsa/research-approval--git
+                root "diff" "--no-ext-diff" "--no-color" "--unified=0"
+                "--" path))
+         (lines (split-string diff "\n" t)))
+    (and lines
+         (cl-every
+          (lambda (line)
+            (or (string-prefix-p "@@" line)
+                (string-prefix-p "diff --" line)
+                (string-prefix-p "index " line)
+                (string-prefix-p "---" line)
+                (string-prefix-p "+++" line)
+                (and (string-match-p "^[+-]#\\+approval_[a-z_]+: " line)
+                     (not (string-prefix-p " " line)))))
+          lines))))
 
 (defun nsa/research-approval--same-target-p (before after)
   "Return non-nil when BEFORE and AFTER describe the same checkout target."
   (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
             '(:root :path :branch :remote :merge-ref :upstream :push-url :head)))
 
-(defun nsa/research-approval--only-intended-edit-p (context)
-  "Return non-nil when CONTEXT's file is the sole unstaged repository edit."
-  (let* ((root (plist-get context :root))
-         (path (plist-get context :path)))
-    (and (equal (nsa/research-approval--git-lines
-                 root "status" "--porcelain=v1" "--untracked-files=all")
-                (list (concat " M " path)))
-         (equal (nsa/research-approval--git-lines
-                 root "diff" "--name-only" "--")
-                (list path))
-         (null (nsa/research-approval--git-lines
-                root "diff" "--cached" "--name-only" "--")))))
-
-(defun nsa/research-approval--safe-to-restore-p (context)
-  "Return non-nil when CONTEXT's file is still the sole repository change."
-  (let* ((root (plist-get context :root))
-         (path (plist-get context :path))
-         (status (nsa/research-approval--git-lines
-                  root "status" "--porcelain=v1" "--untracked-files=all")))
-    (and (equal (nsa/research-approval--git root "rev-parse" "HEAD")
-                (plist-get context :head))
-         (= (length status) 1)
-         (string-suffix-p (concat " " path) (car status))
-         (equal (nsa/research-approval--git-lines
-                 root "diff" "HEAD" "--name-only" "--" path)
-                (list path)))))
+(defun nsa/research-approval--same-push-target-p (before after)
+  "Return non-nil when BEFORE and AFTER have the same push target."
+  (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
+            '(:root :path :branch :remote :merge-ref :upstream :push-url)))
 
 (defun nsa/research-approval--restore-buffer (contents point)
-  "Restore current buffer to CONTENTS and POINT, then save it."
+  "Restore the current buffer to CONTENTS and POINT, then save it."
   (let ((inhibit-read-only t))
     (erase-buffer)
     (insert contents)
     (goto-char (min point (point-max)))
     (save-buffer)))
 
-(defun nsa/research-approval--preview (context)
-  "Display the approval diff described by CONTEXT."
+(defun nsa/research-approval--replace-field (field value)
+  "Replace the sole canonical FIELD value with VALUE."
+  (let ((values (nsa/research-approval--field-values field)))
+    (unless (= (length values) 1)
+      (user-error "Cannot replace #+%s: expected one canonical field" field))
+    (goto-char (point-min))
+    (unless (re-search-forward (nsa/research-approval--field-regexp field) nil t)
+      (user-error "Cannot replace missing #+%s" field))
+    (replace-match (format "#+%s: %s" field value) t t)))
+
+(defun nsa/research-approval--safe-value-p (value)
+  "Return non-nil when VALUE is a nonempty, one-line field value."
+  (and (stringp value)
+       (not (string= value "NONE"))
+       (not (string-match-p (string 10) value))
+       (not (string-match-p (string 13) value))
+       (string-match-p "\\`[^ \\t]" value)
+       (string-match-p "[^ \\t]\\'" value)))
+
+(defun nsa/research-approval--verify-binding (context base-commit base-blob)
+  "Verify that BASE-COMMIT:path resolves exactly to BASE-BLOB."
   (let* ((root (plist-get context :root))
          (path (plist-get context :path))
-         (diff (nsa/research-approval--git
-                root "diff" "--no-ext-diff" "--no-color" "--" path))
-         (buffer (get-buffer-create "*Research approval preview*")))
+         (commit-spec (concat base-commit "^{commit}"))
+         (object-spec (concat base-commit ":" path)))
+    (unless (string= (nsa/research-approval--git root "rev-parse" "--verify"
+                                                  commit-spec)
+                     base-commit)
+      (user-error "Base commit is not a proven commit object"))
+    (unless (and (string= (nsa/research-approval--git root "cat-file" "-t"
+                                                       object-spec)
+                          "blob")
+                 (string= (nsa/research-approval--git root "rev-parse" "--verify"
+                                                       object-spec)
+                          base-blob))
+      (user-error "Base commit does not resolve to the recorded file blob"))
+    t))
+
+(defun nsa/research-approval--commit-verified-p (context base-commit)
+  "Return non-nil when HEAD is a verified approval-only child of BASE-COMMIT."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (parent (nsa/research-approval--git root "rev-parse" "HEAD^"))
+         (files (nsa/research-approval--git-lines
+                 root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")))
+    (let ((clean (string-empty-p
+                  (nsa/research-approval--git root "status" "--porcelain=v1"
+                                               "--untracked-files=all"))))
+      (and (string= parent base-commit)
+           (equal files (list path))
+           clean))))
+
+(defun nsa/research-approval--prompt-value (prompt default)
+  "Read a safe nonempty field value for PROMPT, using DEFAULT."
+  (let ((value (read-string prompt default)))
+    (unless (nsa/research-approval--safe-value-p value)
+      (user-error "Approval field must be a nonempty one-line value other than NONE"))
+    value))
+
+(defun nsa/research-approval--preview (context diff base-commit base-blob state)
+  "Display DIFF and its verified approval target before confirmation."
+  (let ((buffer (get-buffer-create "*Research approval preview*")))
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (insert (format "Approval target\n  file: %s\n  branch: %s\n"
-                        path (plist-get context :branch)))
-        (insert (format "  upstream: %s\n  push URL: %s\n\n"
+        (insert (format "Research approval dry-run\n  file: %s\n  state: %s\n  branch: %s\n"
+                        (plist-get context :path) state
+                        (plist-get context :branch)))
+        (insert (format "  upstream: %s\n  push URL: %s\n"
                         (plist-get context :upstream)
                         (plist-get context :push-url)))
+        (insert (format "  base commit: %s\n  base blob: %s\n\n"
+                        base-commit base-blob))
         (insert diff "\n")
         (diff-mode)
         (goto-char (point-min))))
     (display-buffer buffer)))
 
-;;;###autoload
-(defun nsa/research-approve-and-push ()
-  "Approve the current research Org record, commit it alone, and push upstream.
-
-The command refuses existing edits, untracked files, detached HEAD, ambiguous
-branch configuration, non-GitHub push URLs, and any target change during the
-workflow.  It previews the exact Org diff and performs a Git push dry-run
-before asking for final confirmation."
+(defun nsa/research-approval--decide-and-push (state)
+  "Record STATE for the current research record, commit it, and push upstream."
   (interactive)
   (let* ((context (nsa/research-approval--context t))
          (root (plist-get context :root))
          (path (plist-get context :path))
-         (remote (plist-get context :remote))
-         (merge-ref (plist-get context :merge-ref))
+         (_validated (progn
+                       (nsa/research-approval--validate-record "PENDING")
+                       t))
+         (base-commit (plist-get context :head))
+         (base-blob (nsa/research-approval--git
+                     root "rev-parse" "--verify"
+                     (concat base-commit ":" path)))
+         (_binding (progn
+                     (nsa/research-approval--verify-binding
+                      context base-commit base-blob)
+                     t))
+         (actor (nsa/research-approval--prompt-value
+                 "Human decision-maker: "
+                 (nsa/research-approval--git root "config" "user.name")))
+         (evidence (nsa/research-approval--prompt-value
+                    "Durable approval evidence: " ""))
+         (timestamp (format-time-string "%Y-%m-%dT%H:%M:%S%:z"))
          (original (buffer-substring-no-properties (point-min) (point-max)))
          (original-point (point))
-         (timestamp (format-time-string "[%Y-%m-%d %a %H:%M %z]"))
-         (commit-message
-          (format "docs(research): approve %s" (file-name-base path)))
-         approval-contents
-         committed)
+         (approval-contents nil)
+         (committed nil))
     (nsa/research-approval--git
-     root "push" "--dry-run" "--porcelain" remote (concat "HEAD:" merge-ref))
+     root "push" "--dry-run" "--porcelain"
+     (plist-get context :remote) (concat "HEAD:" (plist-get context :merge-ref)))
     (unwind-protect
         (progn
-          (nsa/research-approval--insert-marker timestamp)
+          (dolist (field `(("approval_state" . ,state)
+                           ("approval_actor" . ,actor)
+                           ("approval_evidence" . ,evidence)
+                           ("approval_base_commit" . ,base-commit)
+                           ("approval_base_blob" . ,base-blob)
+                           ("approval_decided_at" . ,timestamp)))
+            (nsa/research-approval--replace-field (car field) (cdr field)))
           (setq approval-contents
                 (buffer-substring-no-properties (point-min) (point-max)))
           (save-buffer)
           (unless (equal approval-contents
-                           (buffer-substring-no-properties (point-min) (point-max)))
-            (user-error "A save hook changed more than the approval marker"))
-          (unless (nsa/research-approval--only-intended-edit-p context)
-            (user-error "Repository changed during approval; refusing to commit"))
-          (nsa/research-approval--preview context)
-          (unless (yes-or-no-p
-                   (format "Commit only %s and push %s to %s? "
-                           path (plist-get context :branch)
-                           (plist-get context :upstream)))
-            (user-error "Approval cancelled; file restored"))
+                         (buffer-substring-no-properties (point-min) (point-max)))
+            (user-error "A save hook changed more than the approval fields"))
+          (nsa/research-approval--validate-record state)
+          (unless (and (nsa/research-approval--only-intended-edit-p context)
+                       (nsa/research-approval--approval-diff-p context))
+            (user-error "Repository changed beyond the canonical approval fields"))
+          (nsa/research-approval--preview
+           context
+           (nsa/research-approval--git
+            root "diff" "--no-ext-diff" "--no-color" "--unified=0" "--" path)
+           base-commit base-blob state)
           (let ((current (nsa/research-approval--context nil)))
-            (unless (and (nsa/research-approval--same-target-p context current)
-                         (nsa/research-approval--only-intended-edit-p context))
-              (user-error "Checkout or working tree changed; refusing to commit")))
+            (unless (nsa/research-approval--same-target-p context current)
+              (user-error "Checkout or push target changed; refusing to commit")))
+          (unless (yes-or-no-p
+                   (format "Commit only %s as %s and push to %s? "
+                           path state (plist-get context :upstream)))
+            (user-error "Approval cancelled; file restored"))
           (nsa/research-approval--git
-           root "commit" "--only" "-m" commit-message "--" path)
+           root "commit" "--only" "-m"
+           (format "docs(research): %s %s"
+                   (downcase state) (file-name-base path))
+           "--" path)
           (setq committed t)
-          (unless (and
-                   (equal (nsa/research-approval--git root "rev-parse" "HEAD^")
-                          (plist-get context :head))
-                   (equal (nsa/research-approval--git-lines
-                           root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")
-                          (list path))
-                   (string-empty-p
-                    (nsa/research-approval--git
-                     root "status" "--porcelain=v1" "--untracked-files=all")))
-            (user-error "Commit verification failed; nothing was pushed"))
+          (unless (and (nsa/research-approval--commit-verified-p
+                        context base-commit)
+                       (nsa/research-approval--verify-binding
+                         context base-commit base-blob))
+            (user-error "Local approval commit verification failed; nothing was pushed"))
           (let ((current (nsa/research-approval--context t)))
-            (unless (and (equal (plist-get context :root) (plist-get current :root))
-                         (equal (plist-get context :path) (plist-get current :path))
-                         (equal (plist-get context :branch) (plist-get current :branch))
-                         (equal (plist-get context :remote) (plist-get current :remote))
-                         (equal (plist-get context :merge-ref) (plist-get current :merge-ref))
-                         (equal (plist-get context :upstream) (plist-get current :upstream))
-                         (equal (plist-get context :push-url) (plist-get current :push-url)))
-              (user-error "Push target changed after commit; nothing was pushed")))
-          (nsa/research-approval--git
-           root "push" "--porcelain" remote (concat "HEAD:" merge-ref))
-          (message "Approved %s, committed it alone, and pushed %s"
-                   path (plist-get context :upstream)))
+            (unless (nsa/research-approval--same-push-target-p context current)
+              (user-error "Push target changed after commit; approval commit remains local")))
+          (condition-case error-data
+              (nsa/research-approval--git
+               root "push" "--porcelain"
+               (plist-get context :remote)
+               (concat "HEAD:" (plist-get context :merge-ref)))
+            (error
+             (user-error "Approval commit %s is verified locally but push failed: %s"
+                         (nsa/research-approval--git root "rev-parse" "HEAD")
+                         (error-message-string error-data))))
+          (message "Recorded %s for %s, verified commit, and pushed %s"
+                   state path (plist-get context :upstream)))
       (unless committed
         (when (and approval-contents
                    (equal (buffer-substring-no-properties (point-min) (point-max))
                           (with-temp-buffer
                             (insert-file-contents buffer-file-name)
                             (buffer-string)))
-                   (nsa/research-approval--safe-to-restore-p context))
+                   (string= (nsa/research-approval--git root "rev-parse" "HEAD")
+                            base-commit)
+                   (equal (nsa/research-approval--git-lines
+                           root "status" "--porcelain=v1" "--untracked-files=all")
+                          (list (concat " M " path)))
+                   (equal (nsa/research-approval--git-lines
+                           root "diff" "--name-only" "--" path)
+                          (list path)))
           (ignore-errors
             (nsa/research-approval--git root "restore" "--staged" "--" path))
           (nsa/research-approval--restore-buffer original original-point))))))
+
+;;;###autoload
+(defun nsa/research-approve-and-push ()
+  "Record APPROVED for the current canonical research record and push it."
+  (interactive)
+  (nsa/research-approval--decide-and-push "APPROVED"))
+
+;;;###autoload
+(defun nsa/research-reject-and-push ()
+  "Record REJECTED for the current canonical research record and push it."
+  (interactive)
+  (nsa/research-approval--decide-and-push "REJECTED"))
 
 (provide 'research-approval)
 #+end_src

--- a/.doom.d/autoload/research-approval.org
+++ b/.doom.d/autoload/research-approval.org
@@ -1,0 +1,292 @@
+#+title: Fail-safe research approval
+#+property: header-args :emacs-lisp :tangle ./research-approval.el :results none
+
+This command records human approval in a project research record and publishes
+only that marker.  It deliberately uses the current branch's configured
+upstream instead of selecting or creating a branch.
+
+#+begin_src emacs-lisp
+;;; research-approval.el -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'org)
+(require 'subr-x)
+
+(defconst nsa/research-approval--path-regexp
+  "\\`\\(?:research\\|rage\\)/.+\\.org\\'"
+  "Repository-relative paths accepted by the approval command.")
+
+(defun nsa/research-approval--git-result (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return (STATUS . OUTPUT)."
+  (with-temp-buffer
+    (let ((default-directory (file-name-as-directory directory)))
+      (cons (apply #'process-file
+                   "git" nil (list (current-buffer) t) nil arguments)
+            (string-trim-right (buffer-string))))))
+
+(defun nsa/research-approval--git (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return its output.
+Signal a `user-error' when Git fails."
+  (pcase-let ((`(,status . ,output)
+               (apply #'nsa/research-approval--git-result
+                      directory arguments)))
+    (unless (zerop status)
+      (user-error "Git %s failed%s"
+                  (string-join arguments " ")
+                  (if (string-empty-p output) "" (format ": %s" output))))
+    output))
+
+(defun nsa/research-approval--git-lines (directory &rest arguments)
+  "Run Git with ARGUMENTS in DIRECTORY and return nonempty output lines."
+  (split-string
+   (apply #'nsa/research-approval--git directory arguments) "\n" t))
+
+(defun nsa/research-approval--one (description values)
+  "Return the only member of VALUES or reject ambiguous DESCRIPTION."
+  (unless (= (length values) 1)
+    (user-error "Cannot prove %s: expected one value, found %d"
+                description (length values)))
+  (car values))
+
+(defun nsa/research-approval--eligible-path-p (path)
+  "Return non-nil when PATH names a research or RAGE Org record."
+  (and (not (string-prefix-p "../" path))
+       (string-match-p nsa/research-approval--path-regexp path)))
+
+(defun nsa/research-approval--github-url-p (url)
+  "Return non-nil when URL is an unambiguous GitHub repository URL."
+  (string-match-p
+   (concat "\\`\\(?:git@github\\.com:"
+           "\\|ssh://git@github\\.com/"
+           "\\|https://github\\.com/\\)"
+           "[^/[:space:]]+/[^/[:space:]]+\\(?:\\.git\\)?/?\\'")
+   url))
+
+(defun nsa/research-approval--context (&optional require-clean)
+  "Return verified Git context for the current buffer.
+When REQUIRE-CLEAN is non-nil, reject every tracked, staged, or untracked
+working-tree change."
+  (unless (and buffer-file-name (file-regular-p buffer-file-name))
+    (user-error "This buffer is not visiting a regular file"))
+  (when (file-remote-p buffer-file-name)
+    (user-error "Remote files are not supported"))
+  (when (buffer-modified-p)
+    (user-error "Save or discard existing buffer edits before approval"))
+  (let* ((file (file-truename buffer-file-name))
+         (directory (file-name-directory file))
+         (root (file-name-as-directory
+                (file-truename
+                 (nsa/research-approval--git directory
+                                             "rev-parse" "--show-toplevel"))))
+         (path (file-relative-name file root)))
+    (unless (nsa/research-approval--eligible-path-p path)
+      (user-error "%s is not a research/ or rage/ Org record" path))
+    (nsa/research-approval--git root "ls-files" "--error-unmatch" "--" path)
+    (when require-clean
+      (let ((status (nsa/research-approval--git
+                     root "status" "--porcelain=v1" "--untracked-files=all")))
+        (unless (string-empty-p status)
+          (user-error "Repository has changes beyond this approval:\n%s" status))))
+    (let* ((branch-result
+            (nsa/research-approval--git-result
+             root "symbolic-ref" "--quiet" "--short" "HEAD"))
+           (branch (cdr branch-result)))
+      (unless (and (zerop (car branch-result)) (not (string-empty-p branch)))
+        (user-error "Detached HEAD: approval requires a named current branch"))
+      (let* ((remote
+              (nsa/research-approval--one
+               (format "remote for branch %s" branch)
+               (nsa/research-approval--git-lines
+                root "config" "--get-all" (format "branch.%s.remote" branch))))
+             (merge-ref
+              (nsa/research-approval--one
+               (format "upstream branch for %s" branch)
+               (nsa/research-approval--git-lines
+                root "config" "--get-all" (format "branch.%s.merge" branch)))))
+        (when (string= remote ".")
+          (user-error "Branch %s tracks a local branch, not GitHub" branch))
+        (unless (string-prefix-p "refs/heads/" merge-ref)
+          (user-error "Upstream %s is not a remote branch" merge-ref))
+        (let* ((upstream-branch (string-remove-prefix "refs/heads/" merge-ref))
+               (upstream
+                (nsa/research-approval--git
+                 root "rev-parse" "--abbrev-ref" "--symbolic-full-name"
+                 "@{upstream}"))
+               (expected-upstream (concat remote "/" upstream-branch))
+               (push-url
+                (nsa/research-approval--one
+                 (format "push URL for remote %s" remote)
+                 (nsa/research-approval--git-lines
+                  root "remote" "get-url" "--push" "--all" remote))))
+          (unless (string= upstream expected-upstream)
+            (user-error "Upstream mismatch: configured %s, resolved %s"
+                        expected-upstream upstream))
+          (unless (nsa/research-approval--github-url-p push-url)
+            (user-error "Push URL is not a proven GitHub repository: %s" push-url))
+          (list :root root
+                :path path
+                :branch branch
+                :remote remote
+                :merge-ref merge-ref
+                :upstream upstream
+                :push-url push-url
+                :head (nsa/research-approval--git root "rev-parse" "HEAD")))))))
+
+(defun nsa/research-approval--insert-marker (timestamp)
+  "Insert an explicit approval marker using TIMESTAMP in the current Org file."
+  (let ((case-fold-search t))
+    (save-excursion
+      (goto-char (point-min))
+      (when (re-search-forward "^#\\+approval:[ \t]*" nil t)
+        (user-error "This record already contains an approval marker"))
+      (goto-char (point-min))
+      (cond ((re-search-forward "^#\\+status:.*$" nil t) (forward-line 1))
+            ((re-search-forward "^#\\+title:.*$" nil t) (forward-line 1))
+            (t (goto-char (point-min))))
+      (unless (bolp) (insert "\n"))
+      (insert "#+approval: APPROVED\n"
+              "#+approved_at: " timestamp "\n"))))
+
+(defun nsa/research-approval--same-target-p (before after)
+  "Return non-nil when BEFORE and AFTER describe the same checkout target."
+  (cl-every (lambda (key) (equal (plist-get before key) (plist-get after key)))
+            '(:root :path :branch :remote :merge-ref :upstream :push-url :head)))
+
+(defun nsa/research-approval--only-intended-edit-p (context)
+  "Return non-nil when CONTEXT's file is the sole unstaged repository edit."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path)))
+    (and (equal (nsa/research-approval--git-lines
+                 root "status" "--porcelain=v1" "--untracked-files=all")
+                (list (concat " M " path)))
+         (equal (nsa/research-approval--git-lines
+                 root "diff" "--name-only" "--")
+                (list path))
+         (null (nsa/research-approval--git-lines
+                root "diff" "--cached" "--name-only" "--")))))
+
+(defun nsa/research-approval--safe-to-restore-p (context)
+  "Return non-nil when CONTEXT's file is still the sole repository change."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (status (nsa/research-approval--git-lines
+                  root "status" "--porcelain=v1" "--untracked-files=all")))
+    (and (equal (nsa/research-approval--git root "rev-parse" "HEAD")
+                (plist-get context :head))
+         (= (length status) 1)
+         (string-suffix-p (concat " " path) (car status))
+         (equal (nsa/research-approval--git-lines
+                 root "diff" "HEAD" "--name-only" "--" path)
+                (list path)))))
+
+(defun nsa/research-approval--restore-buffer (contents point)
+  "Restore current buffer to CONTENTS and POINT, then save it."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert contents)
+    (goto-char (min point (point-max)))
+    (save-buffer)))
+
+(defun nsa/research-approval--preview (context)
+  "Display the approval diff described by CONTEXT."
+  (let* ((root (plist-get context :root))
+         (path (plist-get context :path))
+         (diff (nsa/research-approval--git
+                root "diff" "--no-ext-diff" "--no-color" "--" path))
+         (buffer (get-buffer-create "*Research approval preview*")))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "Approval target\n  file: %s\n  branch: %s\n"
+                        path (plist-get context :branch)))
+        (insert (format "  upstream: %s\n  push URL: %s\n\n"
+                        (plist-get context :upstream)
+                        (plist-get context :push-url)))
+        (insert diff "\n")
+        (diff-mode)
+        (goto-char (point-min))))
+    (display-buffer buffer)))
+
+;;;###autoload
+(defun nsa/research-approve-and-push ()
+  "Approve the current research Org record, commit it alone, and push upstream.
+
+The command refuses existing edits, untracked files, detached HEAD, ambiguous
+branch configuration, non-GitHub push URLs, and any target change during the
+workflow.  It previews the exact Org diff and performs a Git push dry-run
+before asking for final confirmation."
+  (interactive)
+  (let* ((context (nsa/research-approval--context t))
+         (root (plist-get context :root))
+         (path (plist-get context :path))
+         (remote (plist-get context :remote))
+         (merge-ref (plist-get context :merge-ref))
+         (original (buffer-substring-no-properties (point-min) (point-max)))
+         (original-point (point))
+         (timestamp (format-time-string "[%Y-%m-%d %a %H:%M %z]"))
+         (commit-message
+          (format "docs(research): approve %s" (file-name-base path)))
+         approval-contents
+         committed)
+    (nsa/research-approval--git
+     root "push" "--dry-run" "--porcelain" remote (concat "HEAD:" merge-ref))
+    (unwind-protect
+        (progn
+          (nsa/research-approval--insert-marker timestamp)
+          (setq approval-contents
+                (buffer-substring-no-properties (point-min) (point-max)))
+          (save-buffer)
+          (unless (equal approval-contents
+                           (buffer-substring-no-properties (point-min) (point-max)))
+            (user-error "A save hook changed more than the approval marker"))
+          (unless (nsa/research-approval--only-intended-edit-p context)
+            (user-error "Repository changed during approval; refusing to commit"))
+          (nsa/research-approval--preview context)
+          (unless (yes-or-no-p
+                   (format "Commit only %s and push %s to %s? "
+                           path (plist-get context :branch)
+                           (plist-get context :upstream)))
+            (user-error "Approval cancelled; file restored"))
+          (let ((current (nsa/research-approval--context nil)))
+            (unless (and (nsa/research-approval--same-target-p context current)
+                         (nsa/research-approval--only-intended-edit-p context))
+              (user-error "Checkout or working tree changed; refusing to commit")))
+          (nsa/research-approval--git
+           root "commit" "--only" "-m" commit-message "--" path)
+          (setq committed t)
+          (unless (and
+                   (equal (nsa/research-approval--git root "rev-parse" "HEAD^")
+                          (plist-get context :head))
+                   (equal (nsa/research-approval--git-lines
+                           root "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")
+                          (list path))
+                   (string-empty-p
+                    (nsa/research-approval--git
+                     root "status" "--porcelain=v1" "--untracked-files=all")))
+            (user-error "Commit verification failed; nothing was pushed"))
+          (let ((current (nsa/research-approval--context t)))
+            (unless (and (equal (plist-get context :root) (plist-get current :root))
+                         (equal (plist-get context :path) (plist-get current :path))
+                         (equal (plist-get context :branch) (plist-get current :branch))
+                         (equal (plist-get context :remote) (plist-get current :remote))
+                         (equal (plist-get context :merge-ref) (plist-get current :merge-ref))
+                         (equal (plist-get context :upstream) (plist-get current :upstream))
+                         (equal (plist-get context :push-url) (plist-get current :push-url)))
+              (user-error "Push target changed after commit; nothing was pushed")))
+          (nsa/research-approval--git
+           root "push" "--porcelain" remote (concat "HEAD:" merge-ref))
+          (message "Approved %s, committed it alone, and pushed %s"
+                   path (plist-get context :upstream)))
+      (unless committed
+        (when (and approval-contents
+                   (equal (buffer-substring-no-properties (point-min) (point-max))
+                          (with-temp-buffer
+                            (insert-file-contents buffer-file-name)
+                            (buffer-string)))
+                   (nsa/research-approval--safe-to-restore-p context))
+          (ignore-errors
+            (nsa/research-approval--git root "restore" "--staged" "--" path))
+          (nsa/research-approval--restore-buffer original original-point))))))
+
+(provide 'research-approval)
+#+end_src

--- a/.doom.d/autoload/research-dashboard.el
+++ b/.doom.d/autoload/research-dashboard.el
@@ -1,0 +1,416 @@
+;;; research-dashboard.el --- Cross-repository research review UI -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(require 'subr-x)
+(require 'tabulated-list)
+(require 'url-util)
+
+(defgroup nsa/research-dashboard nil
+  "Review research across GitHub repositories."
+  :group 'tools)
+
+(defcustom nsa/research-dashboard-owners nil
+  "Owners to scan.  Nil means the authenticated `gh' user plus visible orgs."
+  :type '(repeat string))
+
+(defconst nsa/research-dashboard--schema "prolog-rlm.research-approval.v1")
+(defconst nsa/research-dashboard--fields
+  '("approval_schema" "approval_state" "approval_actor"
+    "approval_evidence" "approval_base_commit" "approval_base_blob"
+    "approval_decided_at"))
+
+(cl-defstruct (nsa/research-item (:constructor nsa/research-item-create))
+  repo branch path blob title lifecycle approval content)
+
+(defvar-local nsa/research-dashboard--items nil)
+(defvar-local nsa/research-dashboard--errors nil)
+(defvar-local nsa/research-dashboard--generation 0)
+(defvar-local nsa/research-dashboard--scanning nil)
+
+(defvar nsa/research-dashboard-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "g") #'nsa/research-dashboard-refresh)
+    (define-key map (kbd "RET") #'nsa/research-dashboard-view)
+    (define-key map (kbd "a") #'nsa/research-dashboard-approve)
+    (define-key map (kbd "r") #'nsa/research-dashboard-reject)
+    (define-key map (kbd "e") #'nsa/research-dashboard-errors)
+    map))
+
+(defun nsa/research-dashboard--gh (&rest args)
+  "Run `gh' with ARGS and return stdout."
+  (unless (executable-find "gh")
+    (user-error "GitHub CLI `gh' is required"))
+  (with-temp-buffer
+    (let ((status (apply #'process-file "gh" nil (list (current-buffer) t) nil args)))
+      (unless (and (integerp status) (zerop status))
+        (error "gh %s failed: %s" (string-join args " ")
+               (string-trim (buffer-string))))
+      (buffer-string))))
+
+(defun nsa/research-dashboard--json (text)
+  (json-parse-string text :object-type 'alist :array-type 'list
+                     :null-object nil :false-object nil))
+
+(defun nsa/research-dashboard--get (key object)
+  (alist-get key object nil nil #'string=))
+
+(defun nsa/research-dashboard--keyword (content keyword)
+  "Return the first Org KEYWORD before the first heading."
+  (with-temp-buffer
+    (insert content)
+    (goto-char (point-min))
+    (let ((case-fold-search t)
+          (limit (or (and (re-search-forward "^\\*" nil t)
+                          (line-beginning-position))
+                     (point-max))))
+      (goto-char (point-min))
+      (when (re-search-forward
+             (format "^#\\+%s:[ \\t]*\\(.*\\)$" (regexp-quote keyword))
+             limit t)
+        (string-trim (match-string-no-properties 1))))))
+
+(defun nsa/research-dashboard--candidate-path-p (path)
+  (and (stringp path)
+       (string-suffix-p ".org" path t)
+       (not (string-prefix-p "../" path))
+       (or (string-prefix-p "research/" path)
+           (string-match-p "/research/" path))))
+
+(defun nsa/research-dashboard--legacy-open-p (repo lifecycle)
+  (let ((state (upcase (or lifecycle ""))))
+    (if (string= repo "lost-rob0t/starintel-auto-research")
+        (not (member state '("DONE" "REJECTED")))
+      (not (member state '("DONE" "REJECTED" "CLOSED" "ARCHIVED"))))))
+
+(defun nsa/research-dashboard--item (repo branch path blob content)
+  (let* ((title (or (nsa/research-dashboard--keyword content "title")
+                    (file-name-base path)))
+         (lifecycle (or (nsa/research-dashboard--keyword content "status") "MISSING"))
+         (approval (upcase (or (nsa/research-dashboard--keyword
+                                content "approval_state") "LEGACY"))))
+    (when (or (string= approval "PENDING")
+              (and (string= approval "LEGACY")
+                   (nsa/research-dashboard--legacy-open-p repo lifecycle)))
+      (nsa/research-item-create :repo repo :branch branch :path path :blob blob
+                                :title title :lifecycle lifecycle
+                                :approval approval :content content))))
+
+(defun nsa/research-dashboard--owners ()
+  (or nsa/research-dashboard-owners
+      (let* ((login (string-trim
+                     (nsa/research-dashboard--gh "api" "user" "--jq" ".login")))
+             (orgs (split-string
+                    (nsa/research-dashboard--gh
+                     "api" "--paginate" "user/orgs" "--jq" ".[].login")
+                    "\n" t)))
+        (delete-dups (cons login orgs)))))
+
+(defun nsa/research-dashboard--search (scope)
+  "Return code-search items for research paths in SCOPE."
+  (let* ((query (format "research in:path extension:org %s" scope))
+         (pages (nsa/research-dashboard--json
+                 (nsa/research-dashboard--gh
+                  "api" "--method" "GET" "--paginate" "--slurp"
+                  "search/code" "-f" (concat "q=" query) "-f" "per_page=100"))))
+    (apply #'append
+           (mapcar (lambda (page) (nsa/research-dashboard--get "items" page))
+                   pages))))
+
+(defun nsa/research-dashboard--blob-content (repo blob)
+  (let* ((object (nsa/research-dashboard--json
+                  (nsa/research-dashboard--gh
+                   "api" (format "repos/%s/git/blobs/%s" repo blob))))
+         (encoding (nsa/research-dashboard--get "encoding" object))
+         (content (nsa/research-dashboard--get "content" object)))
+    (unless (and (string= encoding "base64") (stringp content))
+      (error "unsupported blob encoding for %s:%s" repo blob))
+    (decode-coding-string (base64-decode-string content) 'utf-8)))
+
+(defun nsa/research-dashboard--repo-branch (repo-object repo)
+  (or (nsa/research-dashboard--get "default_branch" repo-object)
+      (string-trim
+       (nsa/research-dashboard--gh
+        "repo" "view" repo "--json" "defaultBranchRef"
+        "--jq" ".defaultBranchRef.name"))))
+
+(defun nsa/research-dashboard--scan ()
+  "Scan all configured GitHub owners and return (ITEMS ERRORS)."
+  (let (items errors seen)
+    (dolist (owner (nsa/research-dashboard--owners))
+      (let* ((login (string-trim
+                     (nsa/research-dashboard--gh "api" "user" "--jq" ".login")))
+             (scope (if (string= owner login)
+                        (concat "user:" owner)
+                      (concat "org:" owner))))
+        (condition-case error-data
+            (dolist (hit (nsa/research-dashboard--search scope))
+              (let* ((path (nsa/research-dashboard--get "path" hit))
+                     (blob (nsa/research-dashboard--get "sha" hit))
+                     (repo-object (nsa/research-dashboard--get "repository" hit))
+                     (repo (nsa/research-dashboard--get "full_name" repo-object))
+                     (id (and repo path (concat repo ":" path))))
+                (when (and id (not (member id seen))
+                           (nsa/research-dashboard--candidate-path-p path))
+                  (push id seen)
+                  (condition-case file-error
+                      (let* ((branch (nsa/research-dashboard--repo-branch
+                                      repo-object repo))
+                             (content (nsa/research-dashboard--blob-content repo blob))
+                             (item (nsa/research-dashboard--item
+                                    repo branch path blob content)))
+                        (when item (push item items)))
+                    (error
+                     (push (format "%s: %s" id
+                                   (error-message-string file-error)) errors))))))
+          (error
+           (push (format "%s: %s" owner (error-message-string error-data)) errors)))))
+    (list items errors)))
+
+(defun nsa/research-dashboard--row (item)
+  (let* ((path (nsa/research-item-path item))
+         (parts (split-string path "/" t))
+         (project (or (cadr (member "research" parts)) "(root)")))
+    (list (concat (nsa/research-item-repo item) ":" path)
+          (vector (nsa/research-item-approval item)
+                  (nsa/research-item-repo item)
+                  project
+                  (nsa/research-item-lifecycle item)
+                  (nsa/research-item-title item)
+                  path))))
+
+(defun nsa/research-dashboard--render ()
+  (setq tabulated-list-entries
+        (mapcar #'nsa/research-dashboard--row nsa/research-dashboard--items))
+  (setq header-line-format
+        (format "Open research: %d%s   errors: %d"
+                (length nsa/research-dashboard--items)
+                (if nsa/research-dashboard--scanning "   [scanning]" "")
+                (length nsa/research-dashboard--errors)))
+  (tabulated-list-print t))
+
+(defun nsa/research-dashboard-refresh ()
+  "Refresh open research without blocking the Emacs UI."
+  (interactive)
+  (cl-incf nsa/research-dashboard--generation)
+  (let ((generation nsa/research-dashboard--generation)
+        (buffer (current-buffer)))
+    (setq nsa/research-dashboard--scanning t
+          nsa/research-dashboard--items nil
+          nsa/research-dashboard--errors nil)
+    (nsa/research-dashboard--render)
+    (make-thread
+     (lambda ()
+       (condition-case error-data
+           (let ((result (nsa/research-dashboard--scan)))
+             (run-at-time
+              0 nil
+              (lambda ()
+                (when (and (buffer-live-p buffer)
+                           (with-current-buffer buffer
+                             (= generation nsa/research-dashboard--generation)))
+                  (with-current-buffer buffer
+                    (setq nsa/research-dashboard--items (car result)
+                          nsa/research-dashboard--errors (cadr result)
+                          nsa/research-dashboard--scanning nil)
+                    (nsa/research-dashboard--render))))))
+         (error
+          (run-at-time
+           0 nil
+           (lambda ()
+             (when (buffer-live-p buffer)
+               (with-current-buffer buffer
+                 (setq nsa/research-dashboard--errors
+                       (list (error-message-string error-data))
+                       nsa/research-dashboard--scanning nil)
+                 (nsa/research-dashboard--render)))))))))))
+
+(defun nsa/research-dashboard--at-point ()
+  (let ((id (tabulated-list-get-id)))
+    (or (seq-find (lambda (item)
+                    (string= id (concat (nsa/research-item-repo item) ":"
+                                        (nsa/research-item-path item))))
+                  nsa/research-dashboard--items)
+        (user-error "No research item on this row"))))
+
+(defun nsa/research-dashboard-view ()
+  "Read the selected research item."
+  (interactive)
+  (let* ((item (nsa/research-dashboard--at-point))
+         (buffer (get-buffer-create (format "*Research: %s*"
+                                            (nsa/research-item-title item)))))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (nsa/research-item-content item))
+        (org-mode)
+        (read-only-mode 1)
+        (setq-local header-line-format
+                    (format "%s — %s" (nsa/research-item-repo item)
+                            (nsa/research-item-path item)))))
+    (pop-to-buffer buffer)))
+
+(defun nsa/research-dashboard-errors ()
+  "Show scan errors."
+  (interactive)
+  (with-output-to-temp-buffer "*Research Dashboard Errors*"
+    (princ (if nsa/research-dashboard--errors
+               (string-join (reverse nsa/research-dashboard--errors) "\n")
+             "No scan errors."))))
+
+(defun nsa/research-dashboard--encode-path (path)
+  (mapconcat #'url-hexify-string (split-string path "/" t) "/"))
+
+(defun nsa/research-dashboard--branch-head (repo branch)
+  (let* ((object (nsa/research-dashboard--json
+                  (nsa/research-dashboard--gh
+                   "api" (format "repos/%s/branches/%s"
+                                 repo (url-hexify-string branch)))))
+         (commit (nsa/research-dashboard--get "commit" object)))
+    (nsa/research-dashboard--get "sha" commit)))
+
+(defun nsa/research-dashboard--remote-file (repo path commit)
+  (let* ((object (nsa/research-dashboard--json
+                  (nsa/research-dashboard--gh
+                   "api" "--method" "GET"
+                   (format "repos/%s/contents/%s"
+                           repo (nsa/research-dashboard--encode-path path))
+                   "-f" (concat "ref=" commit))))
+         (blob (nsa/research-dashboard--get "sha" object))
+         (content (nsa/research-dashboard--get "content" object)))
+    (cons blob (decode-coding-string (base64-decode-string content) 'utf-8))))
+
+(defun nsa/research-dashboard--field-regexp (field)
+  (format "^#\\+%s:[ \\t]*.*$" (regexp-quote field)))
+
+(defun nsa/research-dashboard--has-approval-field-p (content)
+  (seq-some (lambda (field)
+              (string-match-p (nsa/research-dashboard--field-regexp field) content))
+            nsa/research-dashboard--fields))
+
+(defun nsa/research-dashboard--canonical-p (content)
+  (string-match-p
+   (concat "^#\\+status:.*\n"
+           "#\\+approval_schema: " (regexp-quote nsa/research-dashboard--schema) "\n"
+           "#\\+approval_state: PENDING\n"
+           "#\\+approval_actor: .*\n"
+           "#\\+approval_evidence: .*\n"
+           "#\\+approval_base_commit: .*\n"
+           "#\\+approval_base_blob: .*\n"
+           "#\\+approval_decided_at: .*$")
+   content))
+
+(defun nsa/research-dashboard--replace-field (content field value)
+  (with-temp-buffer
+    (insert content)
+    (goto-char (point-min))
+    (unless (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
+      (user-error "Missing #+%s" field))
+    (replace-match (format "#+%s: %s" field value) t t)
+    (when (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
+      (user-error "Duplicate #+%s" field))
+    (buffer-string)))
+
+(defun nsa/research-dashboard--decision-content
+    (content state actor evidence commit blob timestamp)
+  (let ((values `(("approval_schema" . ,nsa/research-dashboard--schema)
+                  ("approval_state" . ,state)
+                  ("approval_actor" . ,actor)
+                  ("approval_evidence" . ,evidence)
+                  ("approval_base_commit" . ,commit)
+                  ("approval_base_blob" . ,blob)
+                  ("approval_decided_at" . ,timestamp))))
+    (cond
+     ((nsa/research-dashboard--canonical-p content)
+      (dolist (pair values content)
+        (setq content (nsa/research-dashboard--replace-field
+                       content (car pair) (cdr pair)))))
+     ((nsa/research-dashboard--has-approval-field-p content)
+      (user-error "Partial/noncanonical approval metadata exists"))
+     (t
+      (with-temp-buffer
+        (insert content)
+        (goto-char (point-min))
+        (let ((case-fold-search t))
+          (unless (re-search-forward "^#\\+status:.*$" nil t)
+            (user-error "Missing #+status; lifecycle will not be invented"))
+          (end-of-line)
+          (insert "\n" (mapconcat
+                        (lambda (field)
+                          (format "#+%s: %s" field
+                                  (alist-get field values nil nil #'string=)))
+                        nsa/research-dashboard--fields "\n")))
+        (buffer-string))))))
+
+(defun nsa/research-dashboard--decide (state)
+  (let* ((item (nsa/research-dashboard--at-point))
+         (repo (nsa/research-item-repo item))
+         (branch (nsa/research-item-branch item))
+         (path (nsa/research-item-path item))
+         (commit (nsa/research-dashboard--branch-head repo branch))
+         (remote (nsa/research-dashboard--remote-file repo path commit))
+         (blob (car remote))
+         (content (cdr remote))
+         (actor (read-string "Human decision-maker: "
+                             (string-trim (nsa/research-dashboard--gh
+                                           "api" "user" "--jq" ".login"))))
+         (evidence (read-string "Durable approval evidence: "
+                                "human:emacs-research-dashboard"))
+         (timestamp (format-time-string "%Y-%m-%dT%H:%M:%S%:z"))
+         (updated (nsa/research-dashboard--decision-content
+                   content state actor evidence commit blob timestamp)))
+    (unless (and (not (string-empty-p (string-trim actor)))
+                 (not (string-empty-p (string-trim evidence))))
+      (user-error "Actor and evidence must be nonempty"))
+    (with-output-to-temp-buffer "*Research Approval Preview*"
+      (princ (format "%s\n%s\n%s\n\n%s"
+                     repo path commit
+                     (mapconcat
+                      (lambda (field)
+                        (format "#+%s: %s" field
+                                (nsa/research-dashboard--keyword updated field)))
+                      nsa/research-dashboard--fields "\n"))))
+    (unless (yes-or-no-p (format "%s %s:%s? " state repo path))
+      (user-error "Decision cancelled"))
+    (let* ((head2 (nsa/research-dashboard--branch-head repo branch))
+           (remote2 (nsa/research-dashboard--remote-file repo path head2)))
+      (unless (and (string= commit head2) (string= blob (car remote2))
+                   (string= content (cdr remote2)))
+        (user-error "Research changed during review; refresh first")))
+    (nsa/research-dashboard--gh
+     "api" "--method" "PUT"
+     (format "repos/%s/contents/%s" repo (nsa/research-dashboard--encode-path path))
+     "-f" (format "message=docs(research): %s %s"
+                  (downcase state) (file-name-base path))
+     "-f" (concat "content=" (base64-encode-string updated t))
+     "-f" (concat "sha=" blob) "-f" (concat "branch=" branch))
+    (message "%s %s:%s via gh API" state repo path)
+    (nsa/research-dashboard-refresh)))
+
+(defun nsa/research-dashboard-approve () (interactive)
+  (nsa/research-dashboard--decide "APPROVED"))
+(defun nsa/research-dashboard-reject () (interactive)
+  (nsa/research-dashboard--decide "REJECTED"))
+
+(define-derived-mode nsa/research-dashboard-mode tabulated-list-mode "Research"
+  "Cross-repository human research approval."
+  (setq tabulated-list-format
+        [("Approval" 10 t) ("Repository" 30 t) ("Project" 18 t)
+         ("Lifecycle" 12 t) ("Title" 48 t) ("Path" 60 t)])
+  (setq tabulated-list-sort-key '("Repository" . nil))
+  (tabulated-list-init-header))
+
+;;;###autoload
+(defun nsa/research-dashboard ()
+  "Show open research across the authenticated GitHub account and organizations."
+  (interactive)
+  (let ((buffer (get-buffer-create "*Research Dashboard*")))
+    (with-current-buffer buffer
+      (nsa/research-dashboard-mode)
+      (nsa/research-dashboard-refresh))
+    (pop-to-buffer buffer)))
+
+(provide 'research-dashboard)
+;;; research-dashboard.el ends here

--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -87,6 +87,13 @@ The optional argument NEW-WINDOW is not used."
       time-stamp-format "\[%Y-%02m-%02d %3a %02H:%02M\]")
 (add-hook 'before-save-hook 'time-stamp nil)
 
+(autoload #'nsa/research-approve-and-push "research-approval" nil t)
+
+(map! :after org
+      :localleader
+      :map org-mode-map
+      :desc "Approve research and push" "A" #'nsa/research-approve-and-push)
+
 (defun org-ask-location ()
   (let* ((org-refile-targets '((nil :maxlevel . 9)))
          (hd (condition-case nil

--- a/.doom.d/config.el
+++ b/.doom.d/config.el
@@ -88,11 +88,13 @@ The optional argument NEW-WINDOW is not used."
 (add-hook 'before-save-hook 'time-stamp nil)
 
 (autoload #'nsa/research-approve-and-push "research-approval" nil t)
+(autoload #'nsa/research-reject-and-push "research-approval" nil t)
 
 (map! :after org
       :localleader
       :map org-mode-map
-      :desc "Approve research and push" "A" #'nsa/research-approve-and-push)
+      :desc "Approve research and push" "A" #'nsa/research-approve-and-push
+      :desc "Reject research and push" "R" #'nsa/research-reject-and-push)
 
 (defun org-ask-location ()
   (let* ((org-refile-targets '((nil :maxlevel . 9)))

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -362,11 +362,13 @@ upstream before it commits or pushes anything.
 
 #+begin_src emacs-lisp
 (autoload #'nsa/research-approve-and-push "research-approval" nil t)
+(autoload #'nsa/research-reject-and-push "research-approval" nil t)
 
 (map! :after org
       :localleader
       :map org-mode-map
-      :desc "Approve research and push" "A" #'nsa/research-approve-and-push)
+      :desc "Approve research and push" "A" #'nsa/research-approve-and-push
+      :desc "Reject research and push" "R" #'nsa/research-reject-and-push)
 #+end_src
 *** org capture
 Ask me where to place a capture at [[https://stackoverflow.com/a/24787118][source.]]

--- a/.doom.d/config.org
+++ b/.doom.d/config.org
@@ -355,6 +355,19 @@ i needed this to keep track of when i modify an org roam file so when i export i
       time-stamp-format "\[%Y-%02m-%02d %3a %02H:%02M\]")
 (add-hook 'before-save-hook 'time-stamp nil)
 #+end_src
+*** Research approval
+Approve a tracked =research/*.org= or =rage/*.org= record from its current
+checkout.  The command previews the marker diff and proves the current GitHub
+upstream before it commits or pushes anything.
+
+#+begin_src emacs-lisp
+(autoload #'nsa/research-approve-and-push "research-approval" nil t)
+
+(map! :after org
+      :localleader
+      :map org-mode-map
+      :desc "Approve research and push" "A" #'nsa/research-approve-and-push)
+#+end_src
 *** org capture
 Ask me where to place a capture at [[https://stackoverflow.com/a/24787118][source.]]
 #+begin_src emacs-lisp

--- a/.doom.d/tests/research-approval-test.el
+++ b/.doom.d/tests/research-approval-test.el
@@ -1,8 +1,10 @@
-;;; research-approval-test.el --- Tests for research approval  -*- lexical-binding: t; -*-
+;;; research-approval-test.el --- Tests for canonical research approval -*- lexical-binding: t; -*-
 
 (require 'ert)
-(require 'org)
 (require 'research-approval)
+
+(defconst nsa/research-approval-test--pending
+  "#+title: Example research\n#+status: RESEARCHED\n#+approval_schema: prolog-rlm.research-approval.v1\n#+approval_state: PENDING\n#+approval_actor: NONE\n#+approval_evidence: NONE\n#+approval_base_commit: NONE\n#+approval_base_blob: NONE\n#+approval_decided_at: NONE\n")
 
 (defun nsa/research-approval-test--git (directory &rest arguments)
   (let ((default-directory (file-name-as-directory directory)))
@@ -15,7 +17,7 @@
          (let ((record (expand-file-name "research/example.org" directory)))
            (make-directory (file-name-directory record) t)
            (with-temp-file record
-             (insert "#+title: Example\n#+status: RESEARCHED\n"))
+             (insert nsa/research-approval-test--pending))
            (nsa/research-approval-test--git directory "init" "-q" "-b" "topic")
            (nsa/research-approval-test--git
             directory "config" "user.name" "Research Test")
@@ -35,37 +37,53 @@
            ,@body)
        (delete-directory directory t))))
 
-(ert-deftest nsa/research-approval-adds-explicit-keywords ()
+(ert-deftest nsa/research-approval-canonical-pending-is-accepted ()
   (with-temp-buffer
-    (org-mode)
-    (insert ":PROPERTIES:\n:ID: example\n:END:\n"
-            "#+title: Example research\n"
-            "#+status: RESEARCHED\n\n"
-            "* Finding\n")
-    (nsa/research-approval--insert-marker "[2026-08-27 Thu 12:00 -0400]")
-    (should
-     (equal (buffer-string)
-            (concat ":PROPERTIES:\n:ID: example\n:END:\n"
-                    "#+title: Example research\n"
-                    "#+status: RESEARCHED\n"
-                    "#+approval: APPROVED\n"
-                    "#+approved_at: [2026-08-27 Thu 12:00 -0400]\n\n"
-                    "* Finding\n")))))
+    (insert nsa/research-approval-test--pending)
+    (should-not
+     (nsa/research-approval--validate-record "PENDING"))))
 
-(ert-deftest nsa/research-approval-refuses-existing-marker ()
+(ert-deftest nsa/research-approval-requires-canonical-order ()
   (with-temp-buffer
-    (org-mode)
-    (insert "#+title: Example\n#+approval: APPROVED\n")
-    (should-error
-     (nsa/research-approval--insert-marker "[2026-08-27 Thu 12:00 -0400]")
-     :type 'user-error)))
+    (insert (string-replace
+             "#+approval_schema: prolog-rlm.research-approval.v1\n"
+             "#+approval_state: PENDING\n#+approval_schema: prolog-rlm.research-approval.v1\n"
+             nsa/research-approval-test--pending))
+    (should-error (nsa/research-approval--validate-record "PENDING")
+                  :type 'user-error)))
+
+(ert-deftest nsa/research-approval-rejects-legacy-and-checked-layouts ()
+  (with-temp-buffer
+    (insert (concat nsa/research-approval-test--pending
+                    "#+approval: APPROVED\n"
+                    "- [X] APPROVE\n"))
+    (should-error (nsa/research-approval--validate-record "PENDING")
+                  :type 'user-error)))
+
+(ert-deftest nsa/research-approval-keeps-lifecycle-separate ()
+  (with-temp-buffer
+    (insert (string-replace
+             "#+status: RESEARCHED" "#+status: DONE"
+             nsa/research-approval-test--pending))
+    (should-not (nsa/research-approval--validate-record "PENDING")))
+  (with-temp-buffer
+    (insert (string-replace
+             "#+status: RESEARCHED" "#+status: APPROVED"
+             nsa/research-approval-test--pending))
+    (should-error (nsa/research-approval--validate-record "PENDING")
+                  :type 'user-error)))
+
+(ert-deftest nsa/research-approval-rejects-duplicate-fields ()
+  (with-temp-buffer
+    (insert (concat nsa/research-approval-test--pending
+                    "#+approval_state: PENDING\n"))
+    (should-error (nsa/research-approval--validate-record "PENDING")
+                  :type 'user-error)))
 
 (ert-deftest nsa/research-approval-limits-paths-to-research-records ()
   (should (nsa/research-approval--eligible-path-p
            "research/RLM-RESEARCH-010-example.org"))
-  (should (nsa/research-approval--eligible-path-p
-           "rage/219-retrieval-expert.org"))
-  (should-not (nsa/research-approval--eligible-path-p "README.org"))
+  (should-not (nsa/research-approval--eligible-path-p "rage/219-example.org"))
   (should-not (nsa/research-approval--eligible-path-p "research/notes.txt"))
   (should-not (nsa/research-approval--eligible-path-p "../research/example.org")))
 
@@ -79,7 +97,7 @@
                  "github.com/lost-rob0t/prolog-rlm"))
     (should-not (nsa/research-approval--github-url-p url))))
 
-(ert-deftest nsa/research-approval-verifies-checkout-and-upstream ()
+(ert-deftest nsa/research-approval-verifies-clean-checkout-and-upstream ()
   (nsa/research-approval-test--with-repository
     (let ((buffer (find-file-noselect record)))
       (unwind-protect
@@ -91,13 +109,63 @@
               (should (equal (plist-get context :merge-ref) "refs/heads/topic"))))
         (kill-buffer buffer)))))
 
-(ert-deftest nsa/research-approval-refuses-unrelated-dirt-and-detached-head ()
+(ert-deftest nsa/research-approval-commits-and-pushes-only-canonical-fields ()
+  (nsa/research-approval-test--with-repository
+    (let ((bare (make-temp-file "research-approval-remote-" t))
+          (buffer (find-file-noselect record))
+          answers)
+      (unwind-protect
+          (progn
+            (nsa/research-approval-test--git bare "init" "-q" "--bare")
+            (nsa/research-approval-test--git
+             directory "config"
+             (format "url.file://%s.insteadOf" bare)
+             "git@github.com:lost-rob0t/prolog-rlm.git")
+            (nsa/research-approval-test--git
+             directory "push" "-q" "origin" "HEAD:refs/heads/topic")
+            (nsa/research-approval-test--git
+             directory "update-ref" "refs/remotes/origin/topic" "HEAD")
+            (setq answers '("Alice Example" "https://github.com/lost-rob0t/prolog-rlm/issues/1"))
+            (with-current-buffer buffer
+              (cl-letf (((symbol-function 'read-string)
+                         (lambda (prompt &rest _)
+                           (ignore prompt)
+                           (pop answers)))
+                        ((symbol-function 'yes-or-no-p)
+                         (lambda (&rest _) t))
+                        ((symbol-function 'display-buffer)
+                         (lambda (displayed &rest _) displayed))
+                        ;; The fixture uses a local bare remote; URL policy is
+                        ;; covered independently by the GitHub URL test.
+                        ((symbol-function 'nsa/research-approval--github-url-p)
+                         (lambda (_url) t)))
+                (nsa/research-approve-and-push))
+              (should (string-match-p "^#\\+approval_state: APPROVED\n"
+                                      (buffer-string)))
+              (should (string-match-p
+                       "^#\\+approval_base_commit: [0-9a-f][0-9a-f]*\n"
+                       (buffer-string)))
+              (let ((status (nsa/research-approval--git
+                             directory "status" "--porcelain=v1")))
+                (should (string-empty-p status)))
+              (should (equal
+                       (nsa/research-approval--git-lines
+                        directory "diff-tree" "--no-commit-id" "--name-only" "-r" "HEAD")
+                       (list "research/example.org"))))
+            (should (zerop
+                     (let ((default-directory bare))
+                       (process-file "git" nil nil nil
+                                    "show-ref" "--verify" "refs/heads/topic")))))
+        (kill-buffer buffer)
+        (delete-directory bare t)))))
+
+(ert-deftest nsa/research-approval-refuses-dirty-and-detached-checkouts ()
   (nsa/research-approval-test--with-repository
     (let ((buffer (find-file-noselect record))
-          (untracked (expand-file-name ".env" directory)))
+          (untracked (expand-file-name ".local-note" directory)))
       (unwind-protect
           (with-current-buffer buffer
-            (with-temp-file untracked (insert "SECRET=test\n"))
+            (with-temp-file untracked (insert "local\n"))
             (should-error (nsa/research-approval--context t) :type 'user-error)
             (delete-file untracked)
             (nsa/research-approval-test--git directory "checkout" "--detach" "-q")

--- a/.doom.d/tests/research-approval-test.el
+++ b/.doom.d/tests/research-approval-test.el
@@ -1,0 +1,108 @@
+;;; research-approval-test.el --- Tests for research approval  -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'org)
+(require 'research-approval)
+
+(defun nsa/research-approval-test--git (directory &rest arguments)
+  (let ((default-directory (file-name-as-directory directory)))
+    (should (zerop (apply #'process-file "git" nil nil nil arguments)))))
+
+(defmacro nsa/research-approval-test--with-repository (&rest body)
+  (declare (indent 0) (debug t))
+  `(let ((directory (make-temp-file "research-approval-test-" t)))
+     (unwind-protect
+         (let ((record (expand-file-name "research/example.org" directory)))
+           (make-directory (file-name-directory record) t)
+           (with-temp-file record
+             (insert "#+title: Example\n#+status: RESEARCHED\n"))
+           (nsa/research-approval-test--git directory "init" "-q" "-b" "topic")
+           (nsa/research-approval-test--git
+            directory "config" "user.name" "Research Test")
+           (nsa/research-approval-test--git
+            directory "config" "user.email" "test@example.invalid")
+           (nsa/research-approval-test--git directory "add" "research/example.org")
+           (nsa/research-approval-test--git directory "commit" "-q" "-m" "fixture")
+           (nsa/research-approval-test--git
+            directory "remote" "add" "origin"
+            "git@github.com:lost-rob0t/prolog-rlm.git")
+           (nsa/research-approval-test--git
+            directory "update-ref" "refs/remotes/origin/topic" "HEAD")
+           (nsa/research-approval-test--git
+            directory "config" "branch.topic.remote" "origin")
+           (nsa/research-approval-test--git
+            directory "config" "branch.topic.merge" "refs/heads/topic")
+           ,@body)
+       (delete-directory directory t))))
+
+(ert-deftest nsa/research-approval-adds-explicit-keywords ()
+  (with-temp-buffer
+    (org-mode)
+    (insert ":PROPERTIES:\n:ID: example\n:END:\n"
+            "#+title: Example research\n"
+            "#+status: RESEARCHED\n\n"
+            "* Finding\n")
+    (nsa/research-approval--insert-marker "[2026-08-27 Thu 12:00 -0400]")
+    (should
+     (equal (buffer-string)
+            (concat ":PROPERTIES:\n:ID: example\n:END:\n"
+                    "#+title: Example research\n"
+                    "#+status: RESEARCHED\n"
+                    "#+approval: APPROVED\n"
+                    "#+approved_at: [2026-08-27 Thu 12:00 -0400]\n\n"
+                    "* Finding\n")))))
+
+(ert-deftest nsa/research-approval-refuses-existing-marker ()
+  (with-temp-buffer
+    (org-mode)
+    (insert "#+title: Example\n#+approval: APPROVED\n")
+    (should-error
+     (nsa/research-approval--insert-marker "[2026-08-27 Thu 12:00 -0400]")
+     :type 'user-error)))
+
+(ert-deftest nsa/research-approval-limits-paths-to-research-records ()
+  (should (nsa/research-approval--eligible-path-p
+           "research/RLM-RESEARCH-010-example.org"))
+  (should (nsa/research-approval--eligible-path-p
+           "rage/219-retrieval-expert.org"))
+  (should-not (nsa/research-approval--eligible-path-p "README.org"))
+  (should-not (nsa/research-approval--eligible-path-p "research/notes.txt"))
+  (should-not (nsa/research-approval--eligible-path-p "../research/example.org")))
+
+(ert-deftest nsa/research-approval-recognizes-only-github-push-urls ()
+  (dolist (url '("git@github.com:lost-rob0t/prolog-rlm.git"
+                 "ssh://git@github.com/lost-rob0t/prolog-rlm.git"
+                 "https://github.com/lost-rob0t/prolog-rlm.git"))
+    (should (nsa/research-approval--github-url-p url)))
+  (dolist (url '("https://gitlab.com/lost-rob0t/prolog-rlm.git"
+                 "file:///tmp/prolog-rlm.git"
+                 "github.com/lost-rob0t/prolog-rlm"))
+    (should-not (nsa/research-approval--github-url-p url))))
+
+(ert-deftest nsa/research-approval-verifies-checkout-and-upstream ()
+  (nsa/research-approval-test--with-repository
+    (let ((buffer (find-file-noselect record)))
+      (unwind-protect
+          (with-current-buffer buffer
+            (let ((context (nsa/research-approval--context t)))
+              (should (equal (plist-get context :path) "research/example.org"))
+              (should (equal (plist-get context :branch) "topic"))
+              (should (equal (plist-get context :upstream) "origin/topic"))
+              (should (equal (plist-get context :merge-ref) "refs/heads/topic"))))
+        (kill-buffer buffer)))))
+
+(ert-deftest nsa/research-approval-refuses-unrelated-dirt-and-detached-head ()
+  (nsa/research-approval-test--with-repository
+    (let ((buffer (find-file-noselect record))
+          (untracked (expand-file-name ".env" directory)))
+      (unwind-protect
+          (with-current-buffer buffer
+            (with-temp-file untracked (insert "SECRET=test\n"))
+            (should-error (nsa/research-approval--context t) :type 'user-error)
+            (delete-file untracked)
+            (nsa/research-approval-test--git directory "checkout" "--detach" "-q")
+            (should-error (nsa/research-approval--context t) :type 'user-error))
+        (kill-buffer buffer)))))
+
+(provide 'research-approval-test)
+;;; research-approval-test.el ends here

--- a/.doom.d/tests/research-dashboard-test.el
+++ b/.doom.d/tests/research-dashboard-test.el
@@ -1,0 +1,72 @@
+;;; research-dashboard-test.el --- Tests for research dashboard -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'research-dashboard)
+
+(defconst nsa/research-dashboard-test--canonical
+  "#+title: Canonical research\n#+status: RESEARCHED\n#+approval_schema: prolog-rlm.research-approval.v1\n#+approval_state: PENDING\n#+approval_actor: NONE\n#+approval_evidence: NONE\n#+approval_base_commit: NONE\n#+approval_base_blob: NONE\n#+approval_decided_at: NONE\n\n* Findings\nBody\n")
+
+(defconst nsa/research-dashboard-test--legacy
+  "#+title: Legacy StarIntel research\n#+status: REVIEW\n#+filetags: :research:\n\n* Findings\nBody\n")
+
+(ert-deftest nsa/research-dashboard-recognizes-research-paths ()
+  (dolist (path '("research/example.org"
+                  "roam/research/star-server/example.org"
+                  "nested/research/topic/example.org"))
+    (should (nsa/research-dashboard--candidate-path-p path)))
+  (dolist (path '("roam/indexes/research.org"
+                  "docs/research-notes.org"
+                  "research/example.md"
+                  "../research/example.org"))
+    (should-not (nsa/research-dashboard--candidate-path-p path))))
+
+(ert-deftest nsa/research-dashboard-canonical-pending-is-open ()
+  (let ((item (nsa/research-dashboard--item
+               "lost-rob0t/prolog-rlm" "main" "research/example.org"
+               "deadbeef" nsa/research-dashboard-test--canonical)))
+    (should item)
+    (should (equal (nsa/research-item-approval item) "PENDING"))
+    (should (equal (nsa/research-item-lifecycle item) "RESEARCHED"))))
+
+(ert-deftest nsa/research-dashboard-starintel-auto-research-adapter ()
+  (should (nsa/research-dashboard--item
+           "lost-rob0t/starintel-auto-research" "main"
+           "roam/research/star-server/example.org" "deadbeef"
+           nsa/research-dashboard-test--legacy))
+  (should-not
+   (nsa/research-dashboard--item
+    "lost-rob0t/starintel-auto-research" "main"
+    "roam/research/star-server/example.org" "deadbeef"
+    (string-replace "#+status: REVIEW" "#+status: DONE"
+                    nsa/research-dashboard-test--legacy))))
+
+(ert-deftest nsa/research-dashboard-migrates-legacy-without-changing-lifecycle ()
+  (let ((updated (nsa/research-dashboard--decision-content
+                  nsa/research-dashboard-test--legacy "APPROVED"
+                  "lost-rob0t" "human:test" "aaaa" "bbbb"
+                  "2026-08-27T04:00:00-04:00")))
+    (should (string-match-p "^#\\+status: REVIEW$" updated))
+    (should (string-match-p "^#\\+approval_state: APPROVED$" updated))
+    (should (string-match-p "^#\\+approval_base_commit: aaaa$" updated))
+    (should (string-match-p "^#\\+approval_base_blob: bbbb$" updated))))
+
+(ert-deftest nsa/research-dashboard-updates-canonical-fields-only ()
+  (let ((updated (nsa/research-dashboard--decision-content
+                  nsa/research-dashboard-test--canonical "APPROVED"
+                  "lost-rob0t" "human:test" "aaaa" "bbbb"
+                  "2026-08-27T04:00:00-04:00")))
+    (should (string-match-p "^#\\+status: RESEARCHED$" updated))
+    (should (string-match-p "^#\\+approval_state: APPROVED$" updated))
+    (should (string-match-p "^\\* Findings$" updated))
+    (should (string-match-p "^Body$" updated))))
+
+(ert-deftest nsa/research-dashboard-rejects-partial-approval-metadata ()
+  (should-error
+   (nsa/research-dashboard--decision-content
+    (concat nsa/research-dashboard-test--legacy "#+approval_actor: somebody\n")
+    "APPROVED" "lost-rob0t" "human:test" "aaaa" "bbbb"
+    "2026-08-27T04:00:00-04:00")
+   :type 'user-error))
+
+(provide 'research-dashboard-test)
+;;; research-dashboard-test.el ends here

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,6 +49,12 @@ jobs:
         run: bash tests/home-manager-updater.sh
       - name: Run GPT TODO bidirectional sync tests
         run: bash tests/gpt-todos-sync.sh
+      - name: Run research approval ERT tests
+        run: >-
+          emacs -Q --batch
+          -L .doom.d/autoload
+          -l .doom.d/tests/research-approval-test.el
+          -f ert-run-tests-batch-and-exit
       - name: Run OpenCode YOLO tmpfs tests
         run: bash tests/opencode-yolo.sh
       - name: Run Brave MCP protocol tests

--- a/.github/workflows/research-dashboard.yml
+++ b/.github/workflows/research-dashboard.yml
@@ -1,0 +1,30 @@
+name: Research dashboard
+
+on:
+  pull_request:
+    paths:
+      - '.doom.d/autoload/research-dashboard.el'
+      - '.doom.d/tests/research-dashboard-test.el'
+      - '.github/workflows/research-dashboard.yml'
+  push:
+    branches: [master]
+    paths:
+      - '.doom.d/autoload/research-dashboard.el'
+      - '.doom.d/tests/research-dashboard-test.el'
+
+permissions:
+  contents: read
+
+jobs:
+  ert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Emacs
+        run: sudo apt-get update && sudo apt-get install -y emacs-nox
+      - name: Run dashboard tests
+        run: >-
+          emacs -Q --batch
+          -L .doom.d/autoload
+          -l .doom.d/tests/research-dashboard-test.el
+          -f ert-run-tests-batch-and-exit

--- a/docs/wiki/emacs.org
+++ b/docs/wiki/emacs.org
@@ -10,6 +10,7 @@ The Doom configuration is literate.
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/config.el][config.el]] | Main Emacs/Doom behavior. |
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][init.el]] | Doom module selection from an explicitly tangled block. |
 | [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][packages.el]] | Doom package declarations. |
+| [[file:../../.doom.d/autoload/research-approval.org][.doom.d/autoload/research-approval.org]] | [[file:../../.doom.d/autoload/research-approval.el][research-approval.el]] | Fail-safe research/RAGE approval, commit, and push workflow. |
 | [[file:../../.doom.d/snippets/][.doom.d/snippets/]] | n/a | Yasnippet and Org helper snippets. |
 
 The top of =config.org= declares =config.el= as its default tangle target, while individual blocks may override the target.  Read block-level =:tangle= arguments before assuming one Org file produces only one output.
@@ -54,6 +55,22 @@ For package/module changes:
 #+begin_src shell
   doom sync
 #+end_src
+
+* Approving a project research record
+From a tracked =research/*.org= or =rage/*.org= buffer, invoke
+=M-x nsa/research-approve-and-push= or use =SPC m A=.  The command adds:
+
+#+begin_example
+#+approval: APPROVED
+#+approved_at: [YYYY-MM-DD Day HH:MM ZONE]
+#+end_example
+
+Before changing the file, it requires a completely clean repository, a named
+current branch, one configured upstream branch, and one GitHub push URL.  It
+runs =git push --dry-run= against that exact upstream, displays the exact Org
+diff, and asks for confirmation before creating a file-only commit and pushing.
+It never checks out, creates, or guesses a branch.  A failed push leaves the
+verified approval commit local and reports the Git error.
 
 * Documentation discipline
 Put configuration rationale next to the executable Org source whenever it explains a specific setting.  Use this wiki for architecture, ownership, workflow, and navigation.  This keeps the literate config genuinely literate instead of making readers hunt through two competing manuals.

--- a/docs/wiki/emacs.org
+++ b/docs/wiki/emacs.org
@@ -56,21 +56,29 @@ For package/module changes:
   doom sync
 #+end_src
 
-* Approving a project research record
-From a tracked =research/*.org= or =rage/*.org= buffer, invoke
-=M-x nsa/research-approve-and-push= or use =SPC m A=.  The command adds:
+* Deciding a project research record
+From a tracked =research/*.org= buffer, invoke
+=M-x nsa/research-approve-and-push= or =M-x nsa/research-reject-and-push=,
+or use =SPC m A= / =SPC m R=.  The command updates only these canonical fields:
 
 #+begin_example
-#+approval: APPROVED
-#+approved_at: [YYYY-MM-DD Day HH:MM ZONE]
+#+approval_schema: prolog-rlm.research-approval.v1
+#+approval_state: APPROVED
+#+approval_actor: HUMAN
+#+approval_evidence: DURABLE-REFERENCE
+#+approval_base_commit: 40-HEX-COMMIT
+#+approval_base_blob: 40-HEX-BLOB
+#+approval_decided_at: 2026-08-27T12:00:00Z
 #+end_example
 
-Before changing the file, it requires a completely clean repository, a named
-current branch, one configured upstream branch, and one GitHub push URL.  It
-runs =git push --dry-run= against that exact upstream, displays the exact Org
-diff, and asks for confirmation before creating a file-only commit and pushing.
-It never checks out, creates, or guesses a branch.  A failed push leaves the
-verified approval commit local and reports the Git error.
+The command rejects dirty repositories, detached HEAD, ambiguous upstreams,
+non-GitHub push URLs, noncanonical or duplicate approval layouts, lifecycle
+statuses used as approval, and checked legacy markers.  It records
+the current HEAD and its exact file blob before editing, runs =git push
+--dry-run=, displays the field-only diff and push target, and asks for explicit
+confirmation before creating a file-only commit.  It never checks out, creates,
+or guesses a branch.  A failed push leaves the verified local commit in place
+and reports the error.  Prose and model output never supply approval state.
 
 * Documentation discipline
 Put configuration rationale next to the executable Org source whenever it explains a specific setting.  Use this wiki for architecture, ownership, workflow, and navigation.  This keeps the literate config genuinely literate instead of making readers hunt through two competing manuals.


### PR DESCRIPTION
## Summary

- enforce the canonical `research-approval.v1` field layout for explicit human decisions
- keep research lifecycle (`#+status`) separate from approval state
- bind decisions to the exact pre-approval commit and file blob
- add `nsa/research-dashboard`, a tabulated Emacs UI for open research across the authenticated GitHub user and visible organizations
- use GitHub CLI `gh` for repository discovery, reads, authentication, and approval writes
- discover Org research under `research/**` and nested `**/research/**`, including `lost-rob0t/starintel-auto-research/roam/research/**`
- adapt legacy `starintel-auto-research` lifecycle semantics: `DONE`/`REJECTED` are terminal; other legacy research is reviewable and receives the canonical approval block when decided
- dashboard keys: `RET` read, `a` approve, `r` reject, `g` refresh, `e` scan errors
- re-read the branch head, blob, and exact file contents immediately before `gh api` writes; refuse stale decisions
- preserve existing strict local approval behavior and push-target verification

## Verification

- existing research approval ERT suite remains in the Nix workflow
- new `Research dashboard` workflow runs `.doom.d/tests/research-dashboard-test.el`
- dashboard ERT workflow: PASS on `c4e20bd416fc53749ca142811225a1aade227494`
- tests cover nested research paths, canonical pending records, `starintel-auto-research` legacy handling, lifecycle preservation, canonical field updates, and rejection of partial approval metadata
- Nix workflow is still running on the updated head

No merge performed.