### PR TITLE
fix(emacs): clean research queue and add dashboard filters

### DIFF
--- a/.doom.d/autoload/research-dashboard.el
+++ b/.doom.d/autoload/research-dashboard.el
@@ -8,16 +8,58 @@
 (require 'url-util)
 
 (defgroup nsa/research-dashboard nil "Research review UI." :group 'tools)
+
 (defcustom nsa/research-dashboard-owners nil
   "Owners to scan. Nil means the authenticated `gh' user plus visible orgs."
   :type '(repeat string))
+
 (defcustom nsa/research-dashboard-max-workers 6
-  "Maximum concurrent research-file fetches." :type 'integer)
+  "Maximum concurrent research-file fetches."
+  :type 'integer)
+
+(defcustom nsa/research-dashboard-show-legacy-default nil
+  "Whether unmigrated research is visible when the dashboard opens."
+  :type 'boolean)
 
 (defconst nsa/research-dashboard--schema "prolog-rlm.research-approval.v1")
 (defconst nsa/research-dashboard--fields
   '("approval_schema" "approval_state" "approval_actor" "approval_evidence"
     "approval_base_commit" "approval_base_blob" "approval_decided_at"))
+(defconst nsa/research-dashboard--auxiliary-files
+  '("index.org" "sources.org" "search-log.org"))
+(defconst nsa/research-dashboard--legacy-reviewable-lifecycles
+  '("REVIEW" "RESEARCHED" "VERIFIED"))
+
+(defface nsa/research-dashboard-pending-face
+  '((t :inherit font-lock-warning-face :weight bold))
+  "Face for pending approval state."
+  :group 'nsa/research-dashboard)
+(defface nsa/research-dashboard-unmigrated-face
+  '((t :inherit shadow :slant italic))
+  "Face for old-format reviewable research."
+  :group 'nsa/research-dashboard)
+(defface nsa/research-dashboard-repo-face
+  '((t :inherit font-lock-constant-face :weight semi-bold))
+  "Face for repository names."
+  :group 'nsa/research-dashboard)
+(defface nsa/research-dashboard-project-face
+  '((t :inherit font-lock-type-face))
+  "Face for project names."
+  :group 'nsa/research-dashboard)
+(defface nsa/research-dashboard-lifecycle-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for lifecycle states."
+  :group 'nsa/research-dashboard)
+(defface nsa/research-dashboard-path-face
+  '((t :inherit shadow))
+  "Face for research paths."
+  :group 'nsa/research-dashboard)
+
+(defconst nsa/research-dashboard-font-lock-keywords
+  '(("\\_<PENDING\\_>" . 'nsa/research-dashboard-pending-face)
+    ("\\_<UNMIGRATED\\_>" . 'nsa/research-dashboard-unmigrated-face)
+    ("\\_<\\(REVIEW\\|RESEARCHED\\|VERIFIED\\|DONE\\)\\_>"
+     . 'nsa/research-dashboard-lifecycle-face)))
 
 (cl-defstruct (nsa/research-item (:constructor nsa/research-item-create))
   repo branch path blob title lifecycle approval content busy)
@@ -35,6 +77,19 @@
 (defvar-local nsa/research-dashboard--searches-left 0)
 (defvar-local nsa/research-dashboard--seen nil)
 (defvar-local nsa/research-dashboard--render-timer nil)
+(defvar-local nsa/research-dashboard--query "")
+(defvar-local nsa/research-dashboard--repo-filter nil)
+(defvar-local nsa/research-dashboard--project-filter nil)
+(defvar-local nsa/research-dashboard--lifecycle-filter nil)
+(defvar-local nsa/research-dashboard--show-legacy nil)
+
+(defvar nsa/research-dashboard-filter-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "r") #'nsa/research-dashboard-filter-repository)
+    (define-key map (kbd "p") #'nsa/research-dashboard-filter-project)
+    (define-key map (kbd "l") #'nsa/research-dashboard-filter-lifecycle)
+    (define-key map (kbd "c") #'nsa/research-dashboard-clear-filters)
+    map))
 
 (defvar nsa/research-dashboard-mode-map
   (let ((map (make-sparse-keymap)))
@@ -44,13 +99,25 @@
     (define-key map (kbd "a") #'nsa/research-dashboard-approve)
     (define-key map (kbd "r") #'nsa/research-dashboard-reject)
     (define-key map (kbd "e") #'nsa/research-dashboard-errors)
+    (define-key map (kbd "/") #'nsa/research-dashboard-search)
+    (define-key map (kbd "s") #'nsa/research-dashboard-search)
+    (define-key map (kbd "f") nsa/research-dashboard-filter-map)
+    (define-key map (kbd "c") #'nsa/research-dashboard-clear-filters)
+    (define-key map (kbd "L") #'nsa/research-dashboard-toggle-legacy)
+    (define-key map (kbd "?") #'nsa/research-dashboard-help)
     map))
 
 (defun nsa/research-dashboard--json (text)
   (json-parse-string text :object-type 'alist :array-type 'list
                      :null-object nil :false-object nil))
+
 (defun nsa/research-dashboard--get (key object)
   (alist-get key object nil nil #'string=))
+
+(defun nsa/research-dashboard--project (item)
+  (let* ((parts (split-string (nsa/research-item-path item) "/" t))
+         (tail (cdr (member "research" parts))))
+    (or (car tail) "(root)")))
 
 (defun nsa/research-dashboard--cancel ()
   (dolist (process nsa/research-dashboard--processes)
@@ -71,16 +138,19 @@
           (setq process
                 (make-process
                  :name (make-temp-name "research-gh-")
-                 :buffer buffer :command (cons "gh" args)
-                 :connection-type 'pipe :coding 'utf-8-unix :noquery t
+                 :buffer buffer
+                 :command (cons "gh" args)
+                 :connection-type 'pipe
+                 :coding 'utf-8-unix
+                 :noquery t
                  :sentinel
                  (lambda (proc _event)
                    (when (memq (process-status proc) '(exit signal))
                      (let ((ok (and (eq (process-status proc) 'exit)
                                     (zerop (process-exit-status proc))))
                            (output (if (buffer-live-p buffer)
-                                       (with-current-buffer buffer
-                                         (buffer-string)) "")))
+                                       (with-current-buffer buffer (buffer-string))
+                                     "")))
                        (when (buffer-live-p dashboard)
                          (with-current-buffer dashboard
                            (setq nsa/research-dashboard--processes
@@ -97,7 +167,9 @@
           (push process nsa/research-dashboard--processes))
         (when input
           (condition-case error-data
-              (progn (process-send-string process input) (process-send-eof process))
+              (progn
+                (process-send-string process input)
+                (process-send-eof process))
             (error
              (process-put process 'nsa-cancelled t)
              (when (process-live-p process) (delete-process process))
@@ -108,84 +180,168 @@
   (nsa/research-dashboard--gh
    dashboard
    (lambda (ok output)
-     (if (not ok) (funcall callback nil (string-trim output))
-       (condition-case e (funcall callback t (nsa/research-dashboard--json output))
-         (error (funcall callback nil (error-message-string e))))))
+     (if (not ok)
+         (funcall callback nil (string-trim output))
+       (condition-case error-data
+           (funcall callback t (nsa/research-dashboard--json output))
+         (error
+          (funcall callback nil (error-message-string error-data))))))
    args))
 
 (defun nsa/research-dashboard--keyword (content keyword)
   (with-temp-buffer
-    (insert content) (goto-char (point-min))
+    (insert content)
+    (goto-char (point-min))
     (let ((case-fold-search t)
-          (limit (or (and (re-search-forward "^\\*" nil t) (line-beginning-position))
+          (limit (or (and (re-search-forward "^\\*" nil t)
+                          (line-beginning-position))
                      (point-max))))
       (goto-char (point-min))
       (when (re-search-forward
-             (format "^#\\+%s:[ \\t]*\\(.*\\)$" (regexp-quote keyword)) limit t)
+             (format "^#\\+%s:[ \\t]*\\(.*\\)$" (regexp-quote keyword))
+             limit t)
         (string-trim (match-string-no-properties 1))))))
 
+(defun nsa/research-dashboard--auxiliary-path-p (path)
+  (member (downcase (file-name-nondirectory path))
+          nsa/research-dashboard--auxiliary-files))
+
 (defun nsa/research-dashboard--candidate-path-p (path)
-  (and (stringp path) (string-suffix-p ".org" path t)
+  (and (stringp path)
+       (string-suffix-p ".org" path t)
        (not (string-prefix-p "../" path))
-       (or (string-prefix-p "research/" path) (string-match-p "/research/" path))))
+       (not (nsa/research-dashboard--auxiliary-path-p path))
+       (or (string-prefix-p "research/" path)
+           (string-match-p "/research/" path))))
+
+(defun nsa/research-dashboard--legacy-reviewable-p (lifecycle)
+  (member (upcase (or lifecycle ""))
+          nsa/research-dashboard--legacy-reviewable-lifecycles))
 
 (defun nsa/research-dashboard--item (repo branch path blob content)
   (let* ((title (or (nsa/research-dashboard--keyword content "title")
                     (file-name-base path)))
          (lifecycle (or (nsa/research-dashboard--keyword content "status") "MISSING"))
-         (approval (upcase (or (nsa/research-dashboard--keyword content "approval_state")
-                               "LEGACY")))
-         (terminal (if (string= repo "lost-rob0t/starintel-auto-research")
-                       '("DONE" "REJECTED")
-                     '("DONE" "REJECTED" "CLOSED" "ARCHIVED"))))
-    (when (or (string= approval "PENDING")
-              (and (string= approval "LEGACY")
-                   (not (member (upcase lifecycle) terminal))))
+         (raw-approval (nsa/research-dashboard--keyword content "approval_state"))
+         (approval (and raw-approval (upcase raw-approval))))
+    (cond
+     ((string= approval "PENDING")
       (nsa/research-item-create
        :repo repo :branch branch :path path :blob blob :title title
-       :lifecycle lifecycle :approval approval :content content))))
+       :lifecycle lifecycle :approval "PENDING" :content content))
+     ((and (null approval)
+           (nsa/research-dashboard--legacy-reviewable-p lifecycle))
+      (nsa/research-item-create
+       :repo repo :branch branch :path path :blob blob :title title
+       :lifecycle lifecycle :approval "LEGACY" :content content))
+     (t nil))))
+
+(defun nsa/research-dashboard--matches-text-p (item)
+  (let ((query (downcase (string-trim nsa/research-dashboard--query))))
+    (or (string-empty-p query)
+        (seq-some
+         (lambda (value)
+           (and value (string-match-p (regexp-quote query) (downcase value))))
+         (list (nsa/research-item-repo item)
+               (nsa/research-dashboard--project item)
+               (nsa/research-item-lifecycle item)
+               (nsa/research-item-title item)
+               (nsa/research-item-path item))))))
+
+(defun nsa/research-dashboard--visible-p (item)
+  (and (or nsa/research-dashboard--show-legacy
+           (not (string= (nsa/research-item-approval item) "LEGACY")))
+       (or (null nsa/research-dashboard--repo-filter)
+           (string= nsa/research-dashboard--repo-filter
+                    (nsa/research-item-repo item)))
+       (or (null nsa/research-dashboard--project-filter)
+           (string= nsa/research-dashboard--project-filter
+                    (nsa/research-dashboard--project item)))
+       (or (null nsa/research-dashboard--lifecycle-filter)
+           (string-equal-ignore-case nsa/research-dashboard--lifecycle-filter
+                                     (nsa/research-item-lifecycle item)))
+       (nsa/research-dashboard--matches-text-p item)))
+
+(defun nsa/research-dashboard--visible-items ()
+  (seq-filter #'nsa/research-dashboard--visible-p
+              nsa/research-dashboard--items))
+
+(defun nsa/research-dashboard--approval-cell (item)
+  (let* ((legacy (string= (nsa/research-item-approval item) "LEGACY"))
+         (label (if legacy "UNMIGRATED" "PENDING"))
+         (face (if legacy
+                   'nsa/research-dashboard-unmigrated-face
+                 'nsa/research-dashboard-pending-face)))
+    (when (nsa/research-item-busy item)
+      (setq label (concat label " …")))
+    (propertize label 'face face)))
 
 (defun nsa/research-dashboard--row (item)
-  (let* ((path (nsa/research-item-path item))
-         (parts (split-string path "/" t))
-         (project (or (cadr (member "research" parts)) "(root)")))
+  (let ((path (nsa/research-item-path item)))
     (list (concat (nsa/research-item-repo item) ":" path)
-          (vector (if (nsa/research-item-busy item)
-                      (concat (nsa/research-item-approval item) " …")
-                    (nsa/research-item-approval item))
-                  (nsa/research-item-repo item) project
-                  (nsa/research-item-lifecycle item)
-                  (nsa/research-item-title item) path))))
+          (vector
+           (nsa/research-dashboard--approval-cell item)
+           (propertize (nsa/research-item-repo item)
+                       'face 'nsa/research-dashboard-repo-face)
+           (propertize (nsa/research-dashboard--project item)
+                       'face 'nsa/research-dashboard-project-face)
+           (propertize (nsa/research-item-lifecycle item)
+                       'face 'nsa/research-dashboard-lifecycle-face)
+           (nsa/research-item-title item)
+           (propertize path 'face 'nsa/research-dashboard-path-face)))))
+
+(defun nsa/research-dashboard--filter-summary ()
+  (string-join
+   (delq nil
+         (list
+          (unless (string-empty-p nsa/research-dashboard--query)
+            (format "search:%S" nsa/research-dashboard--query))
+          (and nsa/research-dashboard--repo-filter
+               (format "repo:%s" nsa/research-dashboard--repo-filter))
+          (and nsa/research-dashboard--project-filter
+               (format "project:%s" nsa/research-dashboard--project-filter))
+          (and nsa/research-dashboard--lifecycle-filter
+               (format "state:%s" nsa/research-dashboard--lifecycle-filter))
+          (if nsa/research-dashboard--show-legacy
+              "unmigrated:shown"
+            "unmigrated:hidden")))
+   "  "))
 
 (defun nsa/research-dashboard--render ()
-  (setq tabulated-list-entries
-        (mapcar #'nsa/research-dashboard--row nsa/research-dashboard--items)
-        header-line-format
-        (format "Open: %d%s  queued: %d  active: %d  errors: %d"
-                (length nsa/research-dashboard--items)
-                (if nsa/research-dashboard--scanning " [scanning]" "")
-                (length nsa/research-dashboard--queue)
-                nsa/research-dashboard--active
-                (length nsa/research-dashboard--errors)))
-  (tabulated-list-print t))
+  (let ((visible (nsa/research-dashboard--visible-items)))
+    (setq tabulated-list-entries
+          (mapcar #'nsa/research-dashboard--row visible)
+          header-line-format
+          (format "Research review  %d/%d shown%s  queued:%d active:%d errors:%d  |  %s"
+                  (length visible)
+                  (length nsa/research-dashboard--items)
+                  (if nsa/research-dashboard--scanning " [scanning]" "")
+                  (length nsa/research-dashboard--queue)
+                  nsa/research-dashboard--active
+                  (length nsa/research-dashboard--errors)
+                  (nsa/research-dashboard--filter-summary)))
+    (tabulated-list-print t)))
 
 (defun nsa/research-dashboard--schedule-render ()
   (unless (timerp nsa/research-dashboard--render-timer)
     (let ((dashboard (current-buffer)))
       (setq nsa/research-dashboard--render-timer
-            (run-at-time 0.05 nil
-                         (lambda ()
-                           (when (buffer-live-p dashboard)
-                             (with-current-buffer dashboard
-                               (setq nsa/research-dashboard--render-timer nil)
-                               (nsa/research-dashboard--render)))))))))
+            (run-at-time
+             0.05 nil
+             (lambda ()
+               (when (buffer-live-p dashboard)
+                 (with-current-buffer dashboard
+                   (setq nsa/research-dashboard--render-timer nil)
+                   (nsa/research-dashboard--render)))))))))
 
 (defun nsa/research-dashboard--done-p ()
   (and (zerop nsa/research-dashboard--searches-left)
        (zerop nsa/research-dashboard--active)
        (null nsa/research-dashboard--queue)))
+
 (defun nsa/research-dashboard--finish ()
-  (when (and nsa/research-dashboard--scanning (nsa/research-dashboard--done-p))
+  (when (and nsa/research-dashboard--scanning
+             (nsa/research-dashboard--done-p))
     (setq nsa/research-dashboard--scanning nil)
     (nsa/research-dashboard--render)))
 
@@ -199,15 +355,20 @@
     (nsa/research-dashboard--finish)))
 
 (defun nsa/research-dashboard--blob-job (generation repo branch path blob)
-  (let ((dashboard (current-buffer)) (id (concat repo ":" path)))
+  (let ((dashboard (current-buffer))
+        (id (concat repo ":" path)))
     (nsa/research-dashboard--gh-json
      dashboard
      (lambda (ok result)
        (when (and (buffer-live-p dashboard)
-                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
+                  (= generation
+                     (buffer-local-value
+                      'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
-           (if (not ok) (nsa/research-dashboard--job-done generation nil (format "%s: %s" id result))
-             (condition-case e
+           (if (not ok)
+               (nsa/research-dashboard--job-done
+                generation nil (format "%s: %s" id result))
+             (condition-case error-data
                  (let ((encoding (nsa/research-dashboard--get "encoding" result))
                        (content (nsa/research-dashboard--get "content" result)))
                    (unless (and (string= encoding "base64") (stringp content))
@@ -216,9 +377,13 @@
                     generation
                     (nsa/research-dashboard--item
                      repo branch path blob
-                     (decode-coding-string (base64-decode-string content) 'utf-8))))
-               (error (nsa/research-dashboard--job-done
-                       generation nil (format "%s: %s" id (error-message-string e)))))))))
+                     (decode-coding-string
+                      (base64-decode-string content) 'utf-8))))
+               (error
+                (nsa/research-dashboard--job-done
+                 generation nil
+                 (format "%s: %s" id
+                         (error-message-string error-data)))))))))
      (list "api" (format "repos/%s/git/blobs/%s" repo blob)))))
 
 (defun nsa/research-dashboard--start-job (generation hit)
@@ -230,40 +395,56 @@
          dashboard
          (lambda (ok result)
            (when (and (buffer-live-p dashboard)
-                      (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
+                      (= generation
+                         (buffer-local-value
+                          'nsa/research-dashboard--generation dashboard)))
              (with-current-buffer dashboard
                (if ok
-                   (let ((resolved (nsa/research-dashboard--get "default_branch" result)))
-                     (if resolved (nsa/research-dashboard--blob-job generation repo resolved path blob)
-                       (nsa/research-dashboard--job-done generation nil
-                                                         (format "%s:%s: no default branch" repo path))))
-                 (nsa/research-dashboard--job-done generation nil
-                                                   (format "%s:%s: %s" repo path result))))))
+                   (let ((resolved
+                          (nsa/research-dashboard--get "default_branch" result)))
+                     (if resolved
+                         (nsa/research-dashboard--blob-job
+                          generation repo resolved path blob)
+                       (nsa/research-dashboard--job-done
+                        generation nil
+                        (format "%s:%s: no default branch" repo path))))
+                 (nsa/research-dashboard--job-done
+                  generation nil (format "%s:%s: %s" repo path result))))))
          (list "api" (format "repos/%s" repo)))))))
 
 (defun nsa/research-dashboard--pump (generation)
   (while (and (= generation nsa/research-dashboard--generation)
-              (< nsa/research-dashboard--active (max 1 nsa/research-dashboard-max-workers))
+              (< nsa/research-dashboard--active
+                 (max 1 nsa/research-dashboard-max-workers))
               nsa/research-dashboard--queue)
     (cl-incf nsa/research-dashboard--active)
-    (nsa/research-dashboard--start-job generation (pop nsa/research-dashboard--queue)))
+    (nsa/research-dashboard--start-job
+     generation (pop nsa/research-dashboard--queue)))
   (nsa/research-dashboard--schedule-render))
 
 (defun nsa/research-dashboard--search-owner (generation owner login)
   (let* ((dashboard (current-buffer))
-         (scope (if (string= owner login) (concat "user:" owner) (concat "org:" owner)))
+         (scope (if (string= owner login)
+                    (concat "user:" owner)
+                  (concat "org:" owner)))
          (query (format "research in:path extension:org %s" scope)))
     (nsa/research-dashboard--gh
      dashboard
      (lambda (ok output)
        (when (and (buffer-live-p dashboard)
-                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
+                  (= generation
+                     (buffer-local-value
+                      'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
-           (if (not ok) (push (format "%s: %s" owner (string-trim output)) nsa/research-dashboard--errors)
+           (if (not ok)
+               (push (format "%s: %s" owner (string-trim output))
+                     nsa/research-dashboard--errors)
              (dolist (line (split-string output "\n" t))
-               (pcase-let ((`(,repo ,branch ,path ,blob) (split-string line "\t" nil)))
+               (pcase-let ((`(,repo ,branch ,path ,blob)
+                            (split-string line "\t" nil)))
                  (let ((id (and repo path (concat repo ":" path))))
-                   (when (and id (nsa/research-dashboard--candidate-path-p path)
+                   (when (and id
+                              (nsa/research-dashboard--candidate-path-p path)
                               (not (gethash id nsa/research-dashboard--seen)))
                      (puthash id t nsa/research-dashboard--seen)
                      (setq nsa/research-dashboard--queue
@@ -273,12 +454,15 @@
            (nsa/research-dashboard--pump generation)
            (nsa/research-dashboard--finish))))
      (list "api" "--method" "GET" "--paginate" "search/code"
-           "-f" (concat "q=" query) "-f" "per_page=100"
-           "--jq" ".items[] | [.repository.full_name, (.repository.default_branch // \"\"), .path, .sha] | @tsv"))))
+           "-f" (concat "q=" query)
+           "-f" "per_page=100"
+           "--jq"
+           ".items[] | [.repository.full_name, (.repository.default_branch // \"\"), .path, .sha] | @tsv"))))
 
 (defun nsa/research-dashboard--start-searches (generation login owners)
   (setq nsa/research-dashboard--searches-left (length owners))
-  (dolist (owner owners) (nsa/research-dashboard--search-owner generation owner login))
+  (dolist (owner owners)
+    (nsa/research-dashboard--search-owner generation owner login))
   (nsa/research-dashboard--finish))
 
 (defun nsa/research-dashboard--discover (generation)
@@ -287,27 +471,39 @@
      dashboard
      (lambda (ok output)
        (when (and (buffer-live-p dashboard)
-                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
+                  (= generation
+                     (buffer-local-value
+                      'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
            (if (not ok)
-               (progn (push (string-trim output) nsa/research-dashboard--errors)
-                      (setq nsa/research-dashboard--scanning nil)
-                      (nsa/research-dashboard--render))
+               (progn
+                 (push (string-trim output) nsa/research-dashboard--errors)
+                 (setq nsa/research-dashboard--scanning nil)
+                 (nsa/research-dashboard--render))
              (let ((login (string-trim output)))
                (setq nsa/research-dashboard--login login)
                (if nsa/research-dashboard-owners
                    (nsa/research-dashboard--start-searches
-                    generation login (delete-dups (copy-sequence nsa/research-dashboard-owners)))
+                    generation login
+                    (delete-dups
+                     (copy-sequence nsa/research-dashboard-owners)))
                  (nsa/research-dashboard--gh
                   dashboard
                   (lambda (org-ok org-output)
                     (when (buffer-live-p dashboard)
                       (with-current-buffer dashboard
-                        (unless org-ok (push (string-trim org-output) nsa/research-dashboard--errors))
+                        (unless org-ok
+                          (push (string-trim org-output)
+                                nsa/research-dashboard--errors))
                         (nsa/research-dashboard--start-searches
                          generation login
-                         (delete-dups (cons login (if org-ok (split-string org-output "\n" t) nil)))))))
-                  (list "api" "--paginate" "user/orgs" "--jq" ".[].login"))))))))
+                         (delete-dups
+                          (cons login
+                                (if org-ok
+                                    (split-string org-output "\n" t)
+                                  nil)))))))
+                  (list "api" "--paginate" "user/orgs"
+                        "--jq" ".[].login"))))))))
      (list "api" "user" "--jq" ".login"))))
 
 (defun nsa/research-dashboard-refresh ()
@@ -316,88 +512,204 @@
   (cl-incf nsa/research-dashboard--generation)
   (nsa/research-dashboard--cancel)
   (let ((generation nsa/research-dashboard--generation))
-    (setq nsa/research-dashboard--items nil nsa/research-dashboard--errors nil
-          nsa/research-dashboard--queue nil nsa/research-dashboard--active 0
-          nsa/research-dashboard--searches-left 0 nsa/research-dashboard--scanning t
+    (setq nsa/research-dashboard--items nil
+          nsa/research-dashboard--errors nil
+          nsa/research-dashboard--queue nil
+          nsa/research-dashboard--active 0
+          nsa/research-dashboard--searches-left 0
+          nsa/research-dashboard--scanning t
           nsa/research-dashboard--seen (make-hash-table :test #'equal))
     (nsa/research-dashboard--render)
     (nsa/research-dashboard--discover generation)))
 
+(defun nsa/research-dashboard-search ()
+  "Set a local text filter without hitting GitHub."
+  (interactive)
+  (setq nsa/research-dashboard--query
+        (string-trim
+         (read-string "Search research: " nsa/research-dashboard--query)))
+  (nsa/research-dashboard--render))
+
+(defun nsa/research-dashboard--filter-values (kind)
+  (sort
+   (delete-dups
+    (delq nil
+          (mapcar
+           (lambda (item)
+             (pcase kind
+               ('repo (nsa/research-item-repo item))
+               ('project (nsa/research-dashboard--project item))
+               ('lifecycle (nsa/research-item-lifecycle item))))
+           nsa/research-dashboard--items)))
+   #'string-lessp))
+
+(defun nsa/research-dashboard--read-filter (prompt kind current)
+  (let* ((choices (nsa/research-dashboard--filter-values kind))
+         (value (completing-read prompt (cons "" choices) nil t nil nil current)))
+    (unless (string-empty-p value) value)))
+
+(defun nsa/research-dashboard-filter-repository ()
+  (interactive)
+  (setq nsa/research-dashboard--repo-filter
+        (nsa/research-dashboard--read-filter
+         "Repository (blank clears): " 'repo nsa/research-dashboard--repo-filter))
+  (nsa/research-dashboard--render))
+
+(defun nsa/research-dashboard-filter-project ()
+  (interactive)
+  (setq nsa/research-dashboard--project-filter
+        (nsa/research-dashboard--read-filter
+         "Project (blank clears): " 'project nsa/research-dashboard--project-filter))
+  (nsa/research-dashboard--render))
+
+(defun nsa/research-dashboard-filter-lifecycle ()
+  (interactive)
+  (setq nsa/research-dashboard--lifecycle-filter
+        (nsa/research-dashboard--read-filter
+         "Lifecycle (blank clears): " 'lifecycle
+         nsa/research-dashboard--lifecycle-filter))
+  (nsa/research-dashboard--render))
+
+(defun nsa/research-dashboard-clear-filters ()
+  (interactive)
+  (setq nsa/research-dashboard--query ""
+        nsa/research-dashboard--repo-filter nil
+        nsa/research-dashboard--project-filter nil
+        nsa/research-dashboard--lifecycle-filter nil
+        nsa/research-dashboard--show-legacy
+        nsa/research-dashboard-show-legacy-default)
+  (nsa/research-dashboard--render))
+
+(defun nsa/research-dashboard-toggle-legacy ()
+  "Toggle review-ready unmigrated research."
+  (interactive)
+  (setq nsa/research-dashboard--show-legacy
+        (not nsa/research-dashboard--show-legacy))
+  (nsa/research-dashboard--render)
+  (message "Unmigrated research %s"
+           (if nsa/research-dashboard--show-legacy "shown" "hidden")))
+
+(defun nsa/research-dashboard-help ()
+  (interactive)
+  (with-help-window "*Research Dashboard Help*"
+    (princ "Research Dashboard\n\n")
+    (princ "RET  view research\n")
+    (princ "a    approve\n")
+    (princ "r    reject\n")
+    (princ "g    async refresh\n")
+    (princ "/ s  search locally\n")
+    (princ "f r  filter repository\n")
+    (princ "f p  filter project\n")
+    (princ "f l  filter lifecycle\n")
+    (princ "c    clear filters\n")
+    (princ "L    show/hide unmigrated legacy research\n")
+    (princ "e    show scan/decision errors\n")
+    (princ "?    this help\n\n")
+    (princ "By default only canonical PENDING research is visible.\n")
+    (princ "UNMIGRATED means the file is review-ready but lacks the canonical approval block.\n")))
+
 (defun nsa/research-dashboard--at-point ()
   (let ((id (tabulated-list-get-id)))
-    (or (seq-find (lambda (item)
-                    (string= id (concat (nsa/research-item-repo item) ":"
-                                        (nsa/research-item-path item))))
-                  nsa/research-dashboard--items)
+    (or (seq-find
+         (lambda (item)
+           (string= id
+                    (concat (nsa/research-item-repo item) ":"
+                            (nsa/research-item-path item))))
+         nsa/research-dashboard--items)
         (user-error "No research item on this row"))))
 
 (defun nsa/research-dashboard-view ()
   (interactive)
   (let* ((item (nsa/research-dashboard--at-point))
-         (buffer (get-buffer-create (format "*Research: %s*" (nsa/research-item-title item)))))
+         (buffer
+          (get-buffer-create
+           (format "*Research: %s*" (nsa/research-item-title item)))))
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
-        (erase-buffer) (insert (nsa/research-item-content item))
-        (org-mode) (read-only-mode 1)
+        (erase-buffer)
+        (insert (nsa/research-item-content item))
+        (org-mode)
+        (read-only-mode 1)
         (setq-local header-line-format
-                    (format "%s — %s" (nsa/research-item-repo item)
+                    (format "%s — %s"
+                            (nsa/research-item-repo item)
                             (nsa/research-item-path item)))))
     (pop-to-buffer buffer)))
 
 (defun nsa/research-dashboard-errors ()
   (interactive)
   (with-output-to-temp-buffer "*Research Dashboard Errors*"
-    (princ (if nsa/research-dashboard--errors
-               (string-join (reverse nsa/research-dashboard--errors) "\n")
-             "No errors."))))
+    (princ
+     (if nsa/research-dashboard--errors
+         (string-join (reverse nsa/research-dashboard--errors) "\n")
+       "No errors."))))
 
 (defun nsa/research-dashboard--encode-path (path)
   (mapconcat #'url-hexify-string (split-string path "/" t) "/"))
+
 (defun nsa/research-dashboard--field-regexp (field)
   (format "^#\\+%s:[ \\t]*.*$" (regexp-quote field)))
+
 (defun nsa/research-dashboard--has-field-p (content)
-  (seq-some (lambda (field)
-              (string-match-p (nsa/research-dashboard--field-regexp field) content))
-            nsa/research-dashboard--fields))
+  (seq-some
+   (lambda (field)
+     (string-match-p (nsa/research-dashboard--field-regexp field) content))
+   nsa/research-dashboard--fields))
+
 (defun nsa/research-dashboard--canonical-p (content)
   (string-match-p
    (concat "^#\\+status:.*\n#\\+approval_schema: "
            (regexp-quote nsa/research-dashboard--schema)
            "\n#\\+approval_state: PENDING\n#\\+approval_actor: .*\n"
            "#\\+approval_evidence: .*\n#\\+approval_base_commit: .*\n"
-           "#\\+approval_base_blob: .*\n#\\+approval_decided_at: .*$") content))
+           "#\\+approval_base_blob: .*\n#\\+approval_decided_at: .*$")
+   content))
 
 (defun nsa/research-dashboard--replace-field (content field value)
   (with-temp-buffer
-    (insert content) (goto-char (point-min))
-    (unless (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
+    (insert content)
+    (goto-char (point-min))
+    (unless (re-search-forward
+             (nsa/research-dashboard--field-regexp field) nil t)
       (user-error "Missing #+%s" field))
     (replace-match (format "#+%s: %s" field value) t t)
-    (when (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
+    (when (re-search-forward
+           (nsa/research-dashboard--field-regexp field) nil t)
       (user-error "Duplicate #+%s" field))
     (buffer-string)))
 
-(defun nsa/research-dashboard--decision-content (content state actor evidence commit blob timestamp)
-  (let ((values `(("approval_schema" . ,nsa/research-dashboard--schema)
-                  ("approval_state" . ,state) ("approval_actor" . ,actor)
-                  ("approval_evidence" . ,evidence) ("approval_base_commit" . ,commit)
-                  ("approval_base_blob" . ,blob) ("approval_decided_at" . ,timestamp))))
+(defun nsa/research-dashboard--decision-content
+    (content state actor evidence commit blob timestamp)
+  (let ((values
+         `(("approval_schema" . ,nsa/research-dashboard--schema)
+           ("approval_state" . ,state)
+           ("approval_actor" . ,actor)
+           ("approval_evidence" . ,evidence)
+           ("approval_base_commit" . ,commit)
+           ("approval_base_blob" . ,blob)
+           ("approval_decided_at" . ,timestamp))))
     (cond
      ((nsa/research-dashboard--canonical-p content)
       (dolist (pair values content)
-        (setq content (nsa/research-dashboard--replace-field content (car pair) (cdr pair)))))
+        (setq content
+              (nsa/research-dashboard--replace-field
+               content (car pair) (cdr pair)))))
      ((nsa/research-dashboard--has-field-p content)
       (user-error "Partial/noncanonical approval metadata exists"))
      (t
       (with-temp-buffer
-        (insert content) (goto-char (point-min))
+        (insert content)
+        (goto-char (point-min))
         (unless (re-search-forward "^#\\+status:.*$" nil t)
           (user-error "Missing #+status; lifecycle will not be invented"))
         (end-of-line)
-        (insert "\n" (mapconcat (lambda (field)
-                                  (format "#+%s: %s" field
-                                          (alist-get field values nil nil #'string=)))
-                                nsa/research-dashboard--fields "\n"))
+        (insert
+         "\n"
+         (mapconcat
+          (lambda (field)
+            (format "#+%s: %s" field
+                    (alist-get field values nil nil #'string=)))
+          nsa/research-dashboard--fields "\n"))
         (buffer-string))))))
 
 (defun nsa/research-dashboard--branch-head (decision callback)
@@ -406,12 +718,15 @@
     (nsa/research-dashboard--gh-json
      dashboard
      (lambda (ok result)
-       (if ok (funcall callback t (nsa/research-dashboard--get
-                                   "sha" (nsa/research-dashboard--get "commit" result)))
+       (if ok
+           (funcall callback t
+                    (nsa/research-dashboard--get
+                     "sha" (nsa/research-dashboard--get "commit" result)))
          (funcall callback nil result)))
-     (list "api" (format "repos/%s/branches/%s"
-                         (nsa/research-item-repo item)
-                         (url-hexify-string (nsa/research-item-branch item)))))))
+     (list "api"
+           (format "repos/%s/branches/%s"
+                   (nsa/research-item-repo item)
+                   (url-hexify-string (nsa/research-item-branch item)))))))
 
 (defun nsa/research-dashboard--remote-file (decision commit callback)
   (let* ((item (nsa/research-decision-item decision))
@@ -419,17 +734,23 @@
     (nsa/research-dashboard--gh-json
      dashboard
      (lambda (ok result)
-       (if (not ok) (funcall callback nil result)
+       (if (not ok)
+           (funcall callback nil result)
          (let ((content (nsa/research-dashboard--get "content" result))
                (encoding (nsa/research-dashboard--get "encoding" result)))
            (if (not (and (string= encoding "base64") (stringp content)))
                (funcall callback nil "unsupported contents encoding")
-             (funcall callback t
-                      (cons (nsa/research-dashboard--get "sha" result)
-                            (decode-coding-string (base64-decode-string content) 'utf-8)))))))
+             (funcall callback
+                      t
+                      (cons
+                       (nsa/research-dashboard--get "sha" result)
+                       (decode-coding-string
+                        (base64-decode-string content) 'utf-8)))))))
      (list "api" "--method" "GET"
-           (format "repos/%s/contents/%s" (nsa/research-item-repo item)
-                   (nsa/research-dashboard--encode-path (nsa/research-item-path item)))
+           (format "repos/%s/contents/%s"
+                   (nsa/research-item-repo item)
+                   (nsa/research-dashboard--encode-path
+                    (nsa/research-item-path item)))
            "-f" (concat "ref=" commit)))))
 
 (defun nsa/research-dashboard--fail (decision text)
@@ -445,37 +766,52 @@
 (defun nsa/research-dashboard--write (decision)
   (let* ((dashboard (nsa/research-decision-dashboard decision))
          (item (nsa/research-decision-item decision))
-         (payload (json-encode
-                   `((message . ,(format "docs(research): %s %s"
-                                         (downcase (nsa/research-decision-state decision))
-                                         (file-name-base (nsa/research-item-path item))))
-                     (content . ,(base64-encode-string
-                                  (nsa/research-decision-updated decision) t))
-                     (sha . ,(nsa/research-decision-blob decision))
-                     (branch . ,(nsa/research-item-branch item))))))
+         (payload
+          (json-encode
+           `((message
+              . ,(format "docs(research): %s %s"
+                         (downcase (nsa/research-decision-state decision))
+                         (file-name-base (nsa/research-item-path item))))
+             (content
+              . ,(base64-encode-string
+                  (nsa/research-decision-updated decision) t))
+             (sha . ,(nsa/research-decision-blob decision))
+             (branch . ,(nsa/research-item-branch item))))))
     (nsa/research-dashboard--gh
      dashboard
      (lambda (ok output)
-       (if ok (with-current-buffer dashboard (nsa/research-dashboard-refresh))
+       (if ok
+           (with-current-buffer dashboard
+             (nsa/research-dashboard-refresh))
          (nsa/research-dashboard--fail decision (string-trim output))))
      (list "api" "--method" "PUT"
-           (format "repos/%s/contents/%s" (nsa/research-item-repo item)
-                   (nsa/research-dashboard--encode-path (nsa/research-item-path item)))
-           "--input" "-") :input payload)))
+           (format "repos/%s/contents/%s"
+                   (nsa/research-item-repo item)
+                   (nsa/research-dashboard--encode-path
+                    (nsa/research-item-path item)))
+           "--input" "-")
+     :input payload)))
 
 (defun nsa/research-dashboard--recheck-file (decision ok remote)
-  (if (not ok) (nsa/research-dashboard--fail decision remote)
-    (if (not (and (string= (nsa/research-decision-blob decision) (car remote))
-                  (string= (nsa/research-decision-content decision) (cdr remote))))
-        (nsa/research-dashboard--fail decision "Research changed during review; refresh first")
+  (if (not ok)
+      (nsa/research-dashboard--fail decision remote)
+    (if (not (and
+              (string= (nsa/research-decision-blob decision) (car remote))
+              (string= (nsa/research-decision-content decision) (cdr remote))))
+        (nsa/research-dashboard--fail
+         decision "Research changed during review; refresh first")
       (nsa/research-dashboard--write decision))))
 
 (defun nsa/research-dashboard--recheck-head (decision ok head)
-  (if (not ok) (nsa/research-dashboard--fail decision head)
+  (if (not ok)
+      (nsa/research-dashboard--fail decision head)
     (if (not (string= head (nsa/research-decision-commit decision)))
-        (nsa/research-dashboard--fail decision "Branch changed during review; refresh first")
+        (nsa/research-dashboard--fail
+         decision "Branch changed during review; refresh first")
       (nsa/research-dashboard--remote-file
-       decision head (lambda (ok remote) (nsa/research-dashboard--recheck-file decision ok remote))))))
+       decision head
+       (lambda (file-ok remote)
+         (nsa/research-dashboard--recheck-file decision file-ok remote))))))
 
 (defun nsa/research-dashboard--confirm (decision)
   (let* ((item (nsa/research-decision-item decision))
@@ -484,73 +820,119 @@
       (let ((inhibit-read-only t))
         (erase-buffer)
         (dolist (field nsa/research-dashboard--fields)
-          (insert (format "#+%s: %s\n" field
-                          (nsa/research-dashboard--keyword
-                           (nsa/research-decision-updated decision) field))))
+          (insert
+           (format "#+%s: %s\n"
+                   field
+                   (nsa/research-dashboard--keyword
+                    (nsa/research-decision-updated decision) field))))
         (special-mode)))
     (display-buffer buffer)
-    (if (not (yes-or-no-p
-              (format "%s %s:%s? " (nsa/research-decision-state decision)
-                      (nsa/research-item-repo item) (nsa/research-item-path item))))
+    (if (not
+         (yes-or-no-p
+          (format "%s %s:%s? "
+                  (nsa/research-decision-state decision)
+                  (nsa/research-item-repo item)
+                  (nsa/research-item-path item))))
         (let ((dashboard (nsa/research-decision-dashboard decision)))
           (with-current-buffer dashboard
             (setf (nsa/research-item-busy item) nil)
             (nsa/research-dashboard--render)))
       (nsa/research-dashboard--branch-head
-       decision (lambda (ok head) (nsa/research-dashboard--recheck-head decision ok head))))))
+       decision
+       (lambda (ok head)
+         (nsa/research-dashboard--recheck-head decision ok head))))))
 
 (defun nsa/research-dashboard--got-file (decision ok remote)
-  (if (not ok) (nsa/research-dashboard--fail decision remote)
+  (if (not ok)
+      (nsa/research-dashboard--fail decision remote)
     (let* ((item (nsa/research-decision-item decision))
-           (blob (car remote)) (content (cdr remote)))
-      (if (not (and (string= blob (nsa/research-item-blob item))
-                    (string= content (nsa/research-item-content item))))
-          (nsa/research-dashboard--fail decision "Research changed since refresh; refresh first")
-        (condition-case e
+           (blob (car remote))
+           (content (cdr remote)))
+      (if (not
+           (and (string= blob (nsa/research-item-blob item))
+                (string= content (nsa/research-item-content item))))
+          (nsa/research-dashboard--fail
+           decision "Research changed since refresh; refresh first")
+        (condition-case error-data
             (progn
               (setf (nsa/research-decision-blob decision) blob
                     (nsa/research-decision-content decision) content
                     (nsa/research-decision-updated decision)
                     (nsa/research-dashboard--decision-content
-                     content (nsa/research-decision-state decision)
+                     content
+                     (nsa/research-decision-state decision)
                      (nsa/research-decision-actor decision)
                      (nsa/research-decision-evidence decision)
-                     (nsa/research-decision-commit decision) blob
+                     (nsa/research-decision-commit decision)
+                     blob
                      (format-time-string "%Y-%m-%dT%H:%M:%S%:z")))
               (nsa/research-dashboard--confirm decision))
-          (error (nsa/research-dashboard--fail decision (error-message-string e))))))))
+          (error
+           (nsa/research-dashboard--fail
+            decision (error-message-string error-data))))))))
 
 (defun nsa/research-dashboard--got-head (decision ok commit)
-  (if (not ok) (nsa/research-dashboard--fail decision commit)
+  (if (not ok)
+      (nsa/research-dashboard--fail decision commit)
     (setf (nsa/research-decision-commit decision) commit)
     (nsa/research-dashboard--remote-file
-     decision commit (lambda (ok remote) (nsa/research-dashboard--got-file decision ok remote)))))
+     decision commit
+     (lambda (file-ok remote)
+       (nsa/research-dashboard--got-file decision file-ok remote)))))
 
 (defun nsa/research-dashboard--decide (state)
-  (let* ((dashboard (current-buffer)) (item (nsa/research-dashboard--at-point)))
-    (when (nsa/research-item-busy item) (user-error "Decision already running"))
-    (let ((actor (read-string "Human decision-maker: " (or nsa/research-dashboard--login "")))
-          (evidence (read-string "Durable approval evidence: " "human:emacs-research-dashboard")))
-      (when (or (string-empty-p (string-trim actor)) (string-empty-p (string-trim evidence)))
+  (let* ((dashboard (current-buffer))
+         (item (nsa/research-dashboard--at-point)))
+    (when (nsa/research-item-busy item)
+      (user-error "Decision already running"))
+    (let ((actor
+           (read-string "Human decision-maker: "
+                        (or nsa/research-dashboard--login "")))
+          (evidence
+           (read-string "Durable approval evidence: "
+                        "human:emacs-research-dashboard")))
+      (when (or (string-empty-p (string-trim actor))
+                (string-empty-p (string-trim evidence)))
         (user-error "Actor and evidence must be nonempty"))
       (setf (nsa/research-item-busy item) t)
       (nsa/research-dashboard--render)
-      (let ((decision (nsa/research-decision-create
-                       :dashboard dashboard :item item :state state
-                       :actor actor :evidence evidence)))
+      (let ((decision
+             (nsa/research-decision-create
+              :dashboard dashboard
+              :item item
+              :state state
+              :actor actor
+              :evidence evidence)))
         (nsa/research-dashboard--branch-head
-         decision (lambda (ok commit) (nsa/research-dashboard--got-head decision ok commit)))))))
+         decision
+         (lambda (ok commit)
+           (nsa/research-dashboard--got-head decision ok commit)))))))
 
-(defun nsa/research-dashboard-approve () (interactive) (nsa/research-dashboard--decide "APPROVED"))
-(defun nsa/research-dashboard-reject () (interactive) (nsa/research-dashboard--decide "REJECTED"))
+(defun nsa/research-dashboard-approve ()
+  (interactive)
+  (nsa/research-dashboard--decide "APPROVED"))
 
-(define-derived-mode nsa/research-dashboard-mode tabulated-list-mode "Research"
-  "Cross-repository human research approval."
+(defun nsa/research-dashboard-reject ()
+  (interactive)
+  (nsa/research-dashboard--decide "REJECTED"))
+
+(define-derived-mode nsa/research-dashboard-mode tabulated-list-mode "Research-Review"
+  "Major mode for cross-repository human research approval."
+  (setq-local truncate-lines t)
+  (setq-local tabulated-list-padding 2)
+  (setq-local font-lock-defaults '(nsa/research-dashboard-font-lock-keywords))
   (setq tabulated-list-format
-        [("Approval" 12 t) ("Repository" 30 t) ("Project" 18 t)
-         ("Lifecycle" 12 t) ("Title" 48 t) ("Path" 60 t)]
+        [("Approval" 12 t)
+         ("Repository" 30 t)
+         ("Project" 22 t)
+         ("Lifecycle" 20 t)
+         ("Title" 56 t)
+         ("Path" 72 t)]
         tabulated-list-sort-key '("Repository" . nil))
+  (setq nsa/research-dashboard--show-legacy
+        nsa/research-dashboard-show-legacy-default)
   (tabulated-list-init-header)
+  (hl-line-mode 1)
   (add-hook 'kill-buffer-hook #'nsa/research-dashboard--cancel nil t))
 
 ;;;###autoload

--- a/.doom.d/tests/research-dashboard-test.el
+++ b/.doom.d/tests/research-dashboard-test.el
@@ -6,10 +6,15 @@
 (defconst nsa/research-dashboard-test--canonical
   "#+title: Canonical research\n#+status: RESEARCHED\n#+approval_schema: prolog-rlm.research-approval.v1\n#+approval_state: PENDING\n#+approval_actor: NONE\n#+approval_evidence: NONE\n#+approval_base_commit: NONE\n#+approval_base_blob: NONE\n#+approval_decided_at: NONE\n\n* Findings\nBody\n")
 
-(defconst nsa/research-dashboard-test--legacy
+(defconst nsa/research-dashboard-test--legacy-review
   "#+title: Legacy StarIntel research\n#+status: REVIEW\n#+filetags: :research:\n\n* Findings\nBody\n")
 
-(ert-deftest nsa/research-dashboard-recognizes-research-paths ()
+(defun nsa/research-dashboard-test--legacy-with-status (status)
+  (string-replace "#+status: REVIEW"
+                  (format "#+status: %s" status)
+                  nsa/research-dashboard-test--legacy-review))
+
+(ert-deftest nsa/research-dashboard-recognizes-only-review-artifact-paths ()
   (dolist (path '("research/example.org"
                   "roam/research/star-server/example.org"
                   "nested/research/topic/example.org"))
@@ -17,32 +22,96 @@
   (dolist (path '("roam/indexes/research.org"
                   "docs/research-notes.org"
                   "research/example.md"
-                  "../research/example.org"))
+                  "../research/example.org"
+                  "books/prolog/research/index.org"
+                  "books/prolog/research/sources.org"
+                  "books/prolog/research/search-log.org"))
     (should-not (nsa/research-dashboard--candidate-path-p path))))
 
-(ert-deftest nsa/research-dashboard-canonical-pending-is-open ()
+(ert-deftest nsa/research-dashboard-canonical-pending-is-open-even-when-lifecycle-done ()
   (let ((item (nsa/research-dashboard--item
                "lost-rob0t/prolog-rlm" "main" "research/example.org"
-               "deadbeef" nsa/research-dashboard-test--canonical)))
+               "deadbeef"
+               (string-replace "#+status: RESEARCHED" "#+status: DONE"
+                               nsa/research-dashboard-test--canonical))))
     (should item)
     (should (equal (nsa/research-item-approval item) "PENDING"))
-    (should (equal (nsa/research-item-lifecycle item) "RESEARCHED"))))
+    (should (equal (nsa/research-item-lifecycle item) "DONE"))))
 
-(ert-deftest nsa/research-dashboard-starintel-auto-research-adapter ()
-  (should (nsa/research-dashboard--item
-           "lost-rob0t/starintel-auto-research" "main"
-           "roam/research/star-server/example.org" "deadbeef"
-           nsa/research-dashboard-test--legacy))
+(ert-deftest nsa/research-dashboard-unmigrated-review-ready-is-retained ()
+  (let ((item (nsa/research-dashboard--item
+               "lost-rob0t/starintel-auto-research" "main"
+               "roam/research/star-server/example.org" "deadbeef"
+               nsa/research-dashboard-test--legacy-review)))
+    (should item)
+    (should (equal (nsa/research-item-approval item) "LEGACY"))))
+
+(ert-deftest nsa/research-dashboard-unmigrated-nonreview-states-are-not-queued ()
+  (dolist (status '("DRAFT" "RESEARCHING" "APPROVED" "DONE" "REJECTED"
+                    "SUPERSEDED" "implemented-prototype" "accepted-for-realization"))
+    (should-not
+     (nsa/research-dashboard--item
+      "lost-rob0t/starintel-auto-research" "main"
+      "roam/research/star-server/example.org" "deadbeef"
+      (nsa/research-dashboard-test--legacy-with-status status))))
   (should-not
    (nsa/research-dashboard--item
-    "lost-rob0t/starintel-auto-research" "main"
-    "roam/research/star-server/example.org" "deadbeef"
-    (string-replace "#+status: REVIEW" "#+status: DONE"
-                    nsa/research-dashboard-test--legacy))))
+    "lost-rob0t/chatgpt-books" "main"
+    "research/publishing-pipeline.org" "deadbeef"
+    "#+title: Publishing Pipeline Decision\n* Findings\nBody\n")))
 
-(ert-deftest nsa/research-dashboard-migrates-legacy-without-changing-lifecycle ()
+(ert-deftest nsa/research-dashboard-default-view-hides-unmigrated ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (let ((canonical (nsa/research-dashboard--item
+                      "lost-rob0t/prolog-rlm" "main" "research/a.org"
+                      "a" nsa/research-dashboard-test--canonical))
+          (legacy (nsa/research-dashboard--item
+                   "lost-rob0t/starintel-auto-research" "main"
+                   "roam/research/star-server/b.org" "b"
+                   nsa/research-dashboard-test--legacy-review)))
+      (setq nsa/research-dashboard--items (list canonical legacy))
+      (should-not nsa/research-dashboard--show-legacy)
+      (should (equal (nsa/research-dashboard--visible-items)
+                     (list canonical)))
+      (setq nsa/research-dashboard--show-legacy t)
+      (should (= (length (nsa/research-dashboard--visible-items)) 2)))))
+
+(ert-deftest nsa/research-dashboard-search-and-filters-are-local ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (let ((a (nsa/research-dashboard--item
+              "lost-rob0t/prolog-rlm" "main"
+              "research/RLM-RESEARCH-020-ui.org" "a"
+              (string-replace "Canonical research" "Emacs UI contract"
+                              nsa/research-dashboard-test--canonical)))
+          (b (nsa/research-dashboard--item
+              "lost-rob0t/prolog-rlm" "main"
+              "research/RLM-RESEARCH-010-prompt.org" "b"
+              (string-replace "Canonical research" "Prompt compiler"
+                              nsa/research-dashboard-test--canonical))))
+      (setq nsa/research-dashboard--items (list a b)
+            nsa/research-dashboard--query "emacs")
+      (should (equal (nsa/research-dashboard--visible-items) (list a)))
+      (setq nsa/research-dashboard--query ""
+            nsa/research-dashboard--lifecycle-filter "RESEARCHED")
+      (should (= (length (nsa/research-dashboard--visible-items)) 2))
+      (setq nsa/research-dashboard--repo-filter "lost-rob0t/other")
+      (should-not (nsa/research-dashboard--visible-items)))))
+
+(ert-deftest nsa/research-dashboard-major-mode-has-review-navigation-keys ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (should (derived-mode-p 'nsa/research-dashboard-mode))
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "/"))
+                #'nsa/research-dashboard-search))
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "L"))
+                #'nsa/research-dashboard-toggle-legacy))
+    (should (keymapp (lookup-key nsa/research-dashboard-mode-map (kbd "f"))))))
+
+(ert-deftest nsa/research-dashboard-migrates-review-ready-unmigrated-without-changing-lifecycle ()
   (let ((updated (nsa/research-dashboard--decision-content
-                  nsa/research-dashboard-test--legacy "APPROVED"
+                  nsa/research-dashboard-test--legacy-review "APPROVED"
                   "lost-rob0t" "human:test" "aaaa" "bbbb"
                   "2026-08-27T04:00:00-04:00")))
     (should (string-match-p "^#\\+status: REVIEW$" updated))
@@ -63,7 +132,8 @@
 (ert-deftest nsa/research-dashboard-rejects-partial-approval-metadata ()
   (should-error
    (nsa/research-dashboard--decision-content
-    (concat nsa/research-dashboard-test--legacy "#+approval_actor: somebody\n")
+    (concat nsa/research-dashboard-test--legacy-review
+            "#+approval_actor: somebody\n")
     "APPROVED" "lost-rob0t" "human:test" "aaaa" "bbbb"
     "2026-08-27T04:00:00-04:00")
    :type 'user-error))


### PR DESCRIPTION
## Summary

- keep canonical `PENDING` research visible regardless of lifecycle so completed research can still await explicit human approval
- stop treating every Org file under a `research/` directory as a review item
- exclude support artifacts such as `index.org`, `sources.org`, and `search-log.org`
- only retain unmigrated research when lifecycle is actually review-ready (`REVIEW`, `RESEARCHED`, or `VERIFIED`)
- drop unmigrated `DRAFT`, `RESEARCHING`, `APPROVED`, `DONE`, `REJECTED`, `SUPERSEDED`, `implemented-prototype`, `accepted-for-realization`, and missing lifecycle rows
- hide unmigrated research by default; `L` toggles it explicitly and renders the state as `UNMIGRATED` instead of vague `LEGACY`
- add local `/`/`s` search and `f r`, `f p`, `f l` repository/project/lifecycle filters plus `c` clear
- keep all filtering local and instant; GitHub access remains fully async via `gh` + `make-process`
- polish the dedicated `nsa/research-dashboard-mode` with faces, font-lock, hl-line, wider columns, filter state in the header, and `?` help

## Regression coverage

Covers the noisy rows observed in the live dashboard: chatgpt-books support files, missing lifecycle, StarIntel approved/draft/researching/superseded/implemented states, default legacy hiding, search/filter behavior, major-mode keys, canonical DONE+PENDING behavior, and the existing no-blocking-process guard.