### PR TITLE
feat(emacs): clean research queue and merge approvals via PR

### DIFF
--- a/.doom.d/autoload/research-dashboard.el
+++ b/.doom.d/autoload/research-dashboard.el
@@ -7,10 +7,12 @@
 (require 'tabulated-list)
 (require 'url-util)
 
-(defgroup nsa/research-dashboard nil "Research review UI." :group 'tools)
+(defgroup nsa/research-dashboard nil
+  "Review research across GitHub repositories."
+  :group 'tools)
 
 (defcustom nsa/research-dashboard-owners nil
-  "Owners to scan. Nil means the authenticated `gh' user plus visible orgs."
+  "Owners to scan.  Nil means the authenticated `gh' user plus visible orgs."
   :type '(repeat string))
 
 (defcustom nsa/research-dashboard-max-workers 6
@@ -18,42 +20,46 @@
   :type 'integer)
 
 (defcustom nsa/research-dashboard-show-legacy-default nil
-  "Whether unmigrated research is visible when the dashboard opens."
+  "Whether unmigrated review-ready research is visible when the dashboard opens."
   :type 'boolean)
+
+(defconst nsa/research-dashboard--auxiliary-files
+  '("index.org" "sources.org" "search-log.org"))
 
 (defconst nsa/research-dashboard--schema "prolog-rlm.research-approval.v1")
 (defconst nsa/research-dashboard--fields
   '("approval_schema" "approval_state" "approval_actor" "approval_evidence"
     "approval_base_commit" "approval_base_blob" "approval_decided_at"))
-(defconst nsa/research-dashboard--auxiliary-files
-  '("index.org" "sources.org" "search-log.org"))
 (defconst nsa/research-dashboard--legacy-reviewable-lifecycles
   '("REVIEW" "RESEARCHED" "VERIFIED"))
 
 (defface nsa/research-dashboard-pending-face
-  '((t :inherit font-lock-warning-face :weight bold))
-  "Face for pending approval state."
-  :group 'nsa/research-dashboard)
-(defface nsa/research-dashboard-unmigrated-face
-  '((t :inherit shadow :slant italic))
-  "Face for old-format reviewable research."
-  :group 'nsa/research-dashboard)
+  '((t :inherit warning :weight bold))
+  "Face for pending approval.")
+(defface nsa/research-dashboard-review-face
+  '((t :inherit font-lock-keyword-face :weight semibold))
+  "Face for active research lifecycle states.")
 (defface nsa/research-dashboard-repo-face
-  '((t :inherit font-lock-constant-face :weight semi-bold))
-  "Face for repository names."
-  :group 'nsa/research-dashboard)
+  '((t :inherit font-lock-constant-face :weight semibold))
+  "Face for repository names.")
 (defface nsa/research-dashboard-project-face
   '((t :inherit font-lock-type-face))
-  "Face for project names."
-  :group 'nsa/research-dashboard)
+  "Face for project names.")
 (defface nsa/research-dashboard-lifecycle-face
   '((t :inherit font-lock-keyword-face))
-  "Face for lifecycle states."
-  :group 'nsa/research-dashboard)
+  "Face for lifecycle states.")
+(defface nsa/research-dashboard-title-face
+  '((t :inherit default :weight semibold))
+  "Face for research titles.")
 (defface nsa/research-dashboard-path-face
   '((t :inherit shadow))
-  "Face for research paths."
-  :group 'nsa/research-dashboard)
+  "Face for repository paths.")
+(defface nsa/research-dashboard-unmigrated-face
+  '((t :inherit shadow :slant italic))
+  "Face for old-format reviewable research.")
+(defface nsa/research-dashboard-busy-face
+  '((t :inherit success :weight bold))
+  "Face for decisions being written.")
 
 (defconst nsa/research-dashboard-font-lock-keywords
   '(("\\_<PENDING\\_>" . 'nsa/research-dashboard-pending-face)
@@ -64,7 +70,8 @@
 (cl-defstruct (nsa/research-item (:constructor nsa/research-item-create))
   repo branch path blob title lifecycle approval content busy)
 (cl-defstruct (nsa/research-decision (:constructor nsa/research-decision-create))
-  dashboard item state actor evidence commit blob content updated)
+  dashboard item state actor evidence commit blob content updated
+  approval-branch approval-commit pr-number pr-url)
 
 (defvar-local nsa/research-dashboard--items nil)
 (defvar-local nsa/research-dashboard--errors nil)
@@ -77,21 +84,11 @@
 (defvar-local nsa/research-dashboard--searches-left 0)
 (defvar-local nsa/research-dashboard--seen nil)
 (defvar-local nsa/research-dashboard--render-timer nil)
-(defvar-local nsa/research-dashboard--query "")
-(defvar-local nsa/research-dashboard--repo-filter nil)
-(defvar-local nsa/research-dashboard--project-filter nil)
-(defvar-local nsa/research-dashboard--lifecycle-filter nil)
+(defvar-local nsa/research-dashboard--search-text "")
+(defvar-local nsa/research-dashboard--field-filters nil)
 (defvar-local nsa/research-dashboard--show-legacy nil)
 
-(defvar nsa/research-dashboard-filter-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "r") #'nsa/research-dashboard-filter-repository)
-    (define-key map (kbd "p") #'nsa/research-dashboard-filter-project)
-    (define-key map (kbd "l") #'nsa/research-dashboard-filter-lifecycle)
-    (define-key map (kbd "c") #'nsa/research-dashboard-clear-filters)
-    map))
-
-(defvar nsa/research-dashboard-mode-map
+(defun nsa/research-dashboard--mode-map ()
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map tabulated-list-mode-map)
     (define-key map (kbd "g") #'nsa/research-dashboard-refresh)
@@ -99,25 +96,21 @@
     (define-key map (kbd "a") #'nsa/research-dashboard-approve)
     (define-key map (kbd "r") #'nsa/research-dashboard-reject)
     (define-key map (kbd "e") #'nsa/research-dashboard-errors)
-    (define-key map (kbd "/") #'nsa/research-dashboard-search)
     (define-key map (kbd "s") #'nsa/research-dashboard-search)
-    (define-key map (kbd "f") nsa/research-dashboard-filter-map)
+    (define-key map (kbd "/") #'nsa/research-dashboard-search)
+    (define-key map (kbd "f") #'nsa/research-dashboard-filter)
     (define-key map (kbd "c") #'nsa/research-dashboard-clear-filters)
     (define-key map (kbd "L") #'nsa/research-dashboard-toggle-legacy)
     (define-key map (kbd "?") #'nsa/research-dashboard-help)
     map))
 
+(defvar nsa/research-dashboard-mode-map (nsa/research-dashboard--mode-map))
+
 (defun nsa/research-dashboard--json (text)
   (json-parse-string text :object-type 'alist :array-type 'list
                      :null-object nil :false-object nil))
-
 (defun nsa/research-dashboard--get (key object)
   (alist-get key object nil nil #'string=))
-
-(defun nsa/research-dashboard--project (item)
-  (let* ((parts (split-string (nsa/research-item-path item) "/" t))
-         (tail (cdr (member "research" parts))))
-    (or (car tail) "(root)")))
 
 (defun nsa/research-dashboard--cancel ()
   (dolist (process nsa/research-dashboard--processes)
@@ -138,19 +131,15 @@
           (setq process
                 (make-process
                  :name (make-temp-name "research-gh-")
-                 :buffer buffer
-                 :command (cons "gh" args)
-                 :connection-type 'pipe
-                 :coding 'utf-8-unix
-                 :noquery t
+                 :buffer buffer :command (cons "gh" args)
+                 :connection-type 'pipe :coding 'utf-8-unix :noquery t
                  :sentinel
                  (lambda (proc _event)
                    (when (memq (process-status proc) '(exit signal))
                      (let ((ok (and (eq (process-status proc) 'exit)
                                     (zerop (process-exit-status proc))))
                            (output (if (buffer-live-p buffer)
-                                       (with-current-buffer buffer (buffer-string))
-                                     "")))
+                                       (with-current-buffer buffer (buffer-string)) "")))
                        (when (buffer-live-p dashboard)
                          (with-current-buffer dashboard
                            (setq nsa/research-dashboard--processes
@@ -167,16 +156,15 @@
           (push process nsa/research-dashboard--processes))
         (when input
           (condition-case error-data
-              (progn
-                (process-send-string process input)
-                (process-send-eof process))
+              (progn (process-send-string process input)
+                     (process-send-eof process))
             (error
              (process-put process 'nsa-cancelled t)
              (when (process-live-p process) (delete-process process))
              (funcall callback nil (error-message-string error-data))))))
       process)))
 
-(defun nsa/research-dashboard--gh-json (dashboard callback args)
+(defun nsa/research-dashboard--gh-json (dashboard callback args &optional input)
   (nsa/research-dashboard--gh
    dashboard
    (lambda (ok output)
@@ -184,164 +172,161 @@
          (funcall callback nil (string-trim output))
        (condition-case error-data
            (funcall callback t (nsa/research-dashboard--json output))
-         (error
-          (funcall callback nil (error-message-string error-data))))))
-   args))
+         (error (funcall callback nil (error-message-string error-data))))))
+   args :input input))
 
 (defun nsa/research-dashboard--keyword (content keyword)
   (with-temp-buffer
-    (insert content)
-    (goto-char (point-min))
+    (insert content) (goto-char (point-min))
     (let ((case-fold-search t)
           (limit (or (and (re-search-forward "^\\*" nil t)
                           (line-beginning-position))
                      (point-max))))
       (goto-char (point-min))
       (when (re-search-forward
-             (format "^#\\+%s:[ \\t]*\\(.*\\)$" (regexp-quote keyword))
-             limit t)
+             (format "^#\\+%s:[ \\t]*\\(.*\\)$" (regexp-quote keyword)) limit t)
         (string-trim (match-string-no-properties 1))))))
-
-(defun nsa/research-dashboard--auxiliary-path-p (path)
-  (member (downcase (file-name-nondirectory path))
-          nsa/research-dashboard--auxiliary-files))
 
 (defun nsa/research-dashboard--candidate-path-p (path)
   (and (stringp path)
        (string-suffix-p ".org" path t)
        (not (string-prefix-p "../" path))
-       (not (nsa/research-dashboard--auxiliary-path-p path))
-       (or (string-prefix-p "research/" path)
-           (string-match-p "/research/" path))))
+       (or (string-prefix-p "research/" path) (string-match-p "/research/" path))
+       (not (member (downcase (file-name-nondirectory path))
+                    nsa/research-dashboard--auxiliary-files))))
 
 (defun nsa/research-dashboard--legacy-reviewable-p (lifecycle)
-  (member (upcase (or lifecycle ""))
+  (member (upcase (string-trim (or lifecycle "")))
           nsa/research-dashboard--legacy-reviewable-lifecycles))
 
 (defun nsa/research-dashboard--item (repo branch path blob content)
   (let* ((title (or (nsa/research-dashboard--keyword content "title")
                     (file-name-base path)))
          (lifecycle (or (nsa/research-dashboard--keyword content "status") "MISSING"))
-         (raw-approval (nsa/research-dashboard--keyword content "approval_state"))
-         (approval (and raw-approval (upcase raw-approval))))
-    (cond
-     ((string= approval "PENDING")
+         (approval (upcase (or (nsa/research-dashboard--keyword content "approval_state")
+                               "LEGACY"))))
+    (when (and (nsa/research-dashboard--candidate-path-p path)
+               (or (string= approval "PENDING")
+                   (and (string= approval "LEGACY")
+                        (nsa/research-dashboard--legacy-reviewable-p lifecycle))))
       (nsa/research-item-create
        :repo repo :branch branch :path path :blob blob :title title
-       :lifecycle lifecycle :approval "PENDING" :content content))
-     ((and (null approval)
-           (nsa/research-dashboard--legacy-reviewable-p lifecycle))
-      (nsa/research-item-create
-       :repo repo :branch branch :path path :blob blob :title title
-       :lifecycle lifecycle :approval "LEGACY" :content content))
-     (t nil))))
+       :lifecycle lifecycle :approval approval :content content))))
 
-(defun nsa/research-dashboard--matches-text-p (item)
-  (let ((query (downcase (string-trim nsa/research-dashboard--query))))
-    (or (string-empty-p query)
-        (seq-some
-         (lambda (value)
-           (and value (string-match-p (regexp-quote query) (downcase value))))
-         (list (nsa/research-item-repo item)
-               (nsa/research-dashboard--project item)
-               (nsa/research-item-lifecycle item)
-               (nsa/research-item-title item)
-               (nsa/research-item-path item))))))
+(defun nsa/research-dashboard--project (item)
+  (let* ((parts (split-string (nsa/research-item-path item) "/" t))
+         (after (cdr (member "research" parts))))
+    (or (car after) "(root)")))
+
+(defun nsa/research-dashboard--search-haystack (item)
+  (mapconcat #'identity
+             (list (nsa/research-item-repo item)
+                   (nsa/research-dashboard--project item)
+                   (nsa/research-item-lifecycle item)
+                   (nsa/research-item-approval item)
+                   (nsa/research-item-title item)
+                   (nsa/research-item-path item))
+             "\n"))
+
+(defun nsa/research-dashboard--filter-value (item field)
+  (pcase field
+    ('repository (nsa/research-item-repo item))
+    ('project (nsa/research-dashboard--project item))
+    ('lifecycle (nsa/research-item-lifecycle item))
+    ('approval (nsa/research-item-approval item))
+    (_ "")))
 
 (defun nsa/research-dashboard--visible-p (item)
   (and (or nsa/research-dashboard--show-legacy
            (not (string= (nsa/research-item-approval item) "LEGACY")))
-       (or (null nsa/research-dashboard--repo-filter)
-           (string= nsa/research-dashboard--repo-filter
-                    (nsa/research-item-repo item)))
-       (or (null nsa/research-dashboard--project-filter)
-           (string= nsa/research-dashboard--project-filter
-                    (nsa/research-dashboard--project item)))
-       (or (null nsa/research-dashboard--lifecycle-filter)
-           (string-equal-ignore-case nsa/research-dashboard--lifecycle-filter
-                                     (nsa/research-item-lifecycle item)))
-       (nsa/research-dashboard--matches-text-p item)))
+       (or (string-empty-p nsa/research-dashboard--search-text)
+           (string-match-p
+            (regexp-quote (downcase nsa/research-dashboard--search-text))
+            (downcase (nsa/research-dashboard--search-haystack item))))
+       (seq-every-p
+        (lambda (filter)
+          (string= (downcase (cdr filter))
+                   (downcase (nsa/research-dashboard--filter-value item (car filter)))))
+        nsa/research-dashboard--field-filters)))
 
 (defun nsa/research-dashboard--visible-items ()
-  (seq-filter #'nsa/research-dashboard--visible-p
-              nsa/research-dashboard--items))
+  (seq-filter #'nsa/research-dashboard--visible-p nsa/research-dashboard--items))
 
-(defun nsa/research-dashboard--approval-cell (item)
-  (let* ((legacy (string= (nsa/research-item-approval item) "LEGACY"))
-         (label (if legacy "UNMIGRATED" "PENDING"))
-         (face (if legacy
-                   'nsa/research-dashboard-unmigrated-face
-                 'nsa/research-dashboard-pending-face)))
-    (when (nsa/research-item-busy item)
-      (setq label (concat label " …")))
-    (propertize label 'face face)))
+(defun nsa/research-dashboard--face-state (value)
+  (let ((state (upcase (or value ""))))
+    (cond
+     ((string= state "PENDING") 'nsa/research-dashboard-pending-face)
+     ((member state '("REVIEW" "RESEARCHED" "RESEARCHING" "VERIFIED"
+                      "DRAFT" "ACCEPTED-FOR-REALIZATION"))
+      'nsa/research-dashboard-review-face)
+     ((string= state "LEGACY") 'nsa/research-dashboard-unmigrated-face)
+     (t 'default))))
 
 (defun nsa/research-dashboard--row (item)
-  (let ((path (nsa/research-item-path item)))
-    (list (concat (nsa/research-item-repo item) ":" path)
-          (vector
-           (nsa/research-dashboard--approval-cell item)
-           (propertize (nsa/research-item-repo item)
-                       'face 'nsa/research-dashboard-repo-face)
-           (propertize (nsa/research-dashboard--project item)
-                       'face 'nsa/research-dashboard-project-face)
-           (propertize (nsa/research-item-lifecycle item)
-                       'face 'nsa/research-dashboard-lifecycle-face)
-           (nsa/research-item-title item)
-           (propertize path 'face 'nsa/research-dashboard-path-face)))))
+  (let ((approval (nsa/research-item-approval item))
+        (lifecycle (nsa/research-item-lifecycle item)))
+    (list
+     (concat (nsa/research-item-repo item) ":" (nsa/research-item-path item))
+     (vector
+      (propertize
+       (if (nsa/research-item-busy item)
+           (concat (if (string= approval "LEGACY") "UNMIGRATED" approval) " …")
+         (if (string= approval "LEGACY") "UNMIGRATED" approval))
+       'face (if (nsa/research-item-busy item)
+                 'nsa/research-dashboard-busy-face
+               (if (string= approval "LEGACY")
+                   'nsa/research-dashboard-unmigrated-face
+                 (nsa/research-dashboard--face-state approval))))
+      (propertize (nsa/research-item-repo item) 'face 'nsa/research-dashboard-repo-face)
+      (propertize (nsa/research-dashboard--project item) 'face 'nsa/research-dashboard-project-face)
+      (propertize lifecycle 'face 'nsa/research-dashboard-lifecycle-face)
+      (propertize (nsa/research-item-title item) 'face 'nsa/research-dashboard-title-face)
+      (propertize (nsa/research-item-path item) 'face 'nsa/research-dashboard-path-face)))))
 
 (defun nsa/research-dashboard--filter-summary ()
   (string-join
    (delq nil
          (list
-          (unless (string-empty-p nsa/research-dashboard--query)
-            (format "search:%S" nsa/research-dashboard--query))
-          (and nsa/research-dashboard--repo-filter
-               (format "repo:%s" nsa/research-dashboard--repo-filter))
-          (and nsa/research-dashboard--project-filter
-               (format "project:%s" nsa/research-dashboard--project-filter))
-          (and nsa/research-dashboard--lifecycle-filter
-               (format "state:%s" nsa/research-dashboard--lifecycle-filter))
-          (if nsa/research-dashboard--show-legacy
-              "unmigrated:shown"
-            "unmigrated:hidden")))
+          (unless (string-empty-p nsa/research-dashboard--search-text)
+            (format "search:%s" nsa/research-dashboard--search-text))
+          (when nsa/research-dashboard--field-filters
+            (mapconcat (lambda (filter) (format "%s:%s" (car filter) (cdr filter)))
+                       (reverse nsa/research-dashboard--field-filters) ","))
+          (when nsa/research-dashboard--show-legacy "unmigrated:on")))
    "  "))
 
 (defun nsa/research-dashboard--render ()
   (let ((visible (nsa/research-dashboard--visible-items)))
-    (setq tabulated-list-entries
-          (mapcar #'nsa/research-dashboard--row visible)
+    (setq tabulated-list-entries (mapcar #'nsa/research-dashboard--row visible)
           header-line-format
-          (format "Research review  %d/%d shown%s  queued:%d active:%d errors:%d  |  %s"
-                  (length visible)
-                  (length nsa/research-dashboard--items)
-                  (if nsa/research-dashboard--scanning " [scanning]" "")
-                  (length nsa/research-dashboard--queue)
-                  nsa/research-dashboard--active
-                  (length nsa/research-dashboard--errors)
-                  (nsa/research-dashboard--filter-summary)))
+          (format
+           "Research  %d/%d shown%s  queued:%d active:%d errors:%d   [/ search] [f filter] [c clear] [L unmigrated] [a approve] [r reject] [g refresh]%s"
+           (length visible) (length nsa/research-dashboard--items)
+           (if nsa/research-dashboard--scanning "  scanning…" "")
+           (length nsa/research-dashboard--queue)
+           nsa/research-dashboard--active
+           (length nsa/research-dashboard--errors)
+           (let ((summary (nsa/research-dashboard--filter-summary)))
+             (if (string-empty-p summary) "" (concat "   " summary)))))
     (tabulated-list-print t)))
 
 (defun nsa/research-dashboard--schedule-render ()
   (unless (timerp nsa/research-dashboard--render-timer)
     (let ((dashboard (current-buffer)))
       (setq nsa/research-dashboard--render-timer
-            (run-at-time
-             0.05 nil
-             (lambda ()
-               (when (buffer-live-p dashboard)
-                 (with-current-buffer dashboard
-                   (setq nsa/research-dashboard--render-timer nil)
-                   (nsa/research-dashboard--render)))))))))
+            (run-at-time 0.05 nil
+                         (lambda ()
+                           (when (buffer-live-p dashboard)
+                             (with-current-buffer dashboard
+                               (setq nsa/research-dashboard--render-timer nil)
+                               (nsa/research-dashboard--render)))))))))
 
 (defun nsa/research-dashboard--done-p ()
   (and (zerop nsa/research-dashboard--searches-left)
        (zerop nsa/research-dashboard--active)
        (null nsa/research-dashboard--queue)))
-
 (defun nsa/research-dashboard--finish ()
-  (when (and nsa/research-dashboard--scanning
-             (nsa/research-dashboard--done-p))
+  (when (and nsa/research-dashboard--scanning (nsa/research-dashboard--done-p))
     (setq nsa/research-dashboard--scanning nil)
     (nsa/research-dashboard--render)))
 
@@ -355,19 +340,15 @@
     (nsa/research-dashboard--finish)))
 
 (defun nsa/research-dashboard--blob-job (generation repo branch path blob)
-  (let ((dashboard (current-buffer))
-        (id (concat repo ":" path)))
+  (let ((dashboard (current-buffer)) (id (concat repo ":" path)))
     (nsa/research-dashboard--gh-json
      dashboard
      (lambda (ok result)
        (when (and (buffer-live-p dashboard)
-                  (= generation
-                     (buffer-local-value
-                      'nsa/research-dashboard--generation dashboard)))
+                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
            (if (not ok)
-               (nsa/research-dashboard--job-done
-                generation nil (format "%s: %s" id result))
+               (nsa/research-dashboard--job-done generation nil (format "%s: %s" id result))
              (condition-case error-data
                  (let ((encoding (nsa/research-dashboard--get "encoding" result))
                        (content (nsa/research-dashboard--get "content" result)))
@@ -377,13 +358,10 @@
                     generation
                     (nsa/research-dashboard--item
                      repo branch path blob
-                     (decode-coding-string
-                      (base64-decode-string content) 'utf-8))))
+                     (decode-coding-string (base64-decode-string content) 'utf-8))))
                (error
                 (nsa/research-dashboard--job-done
-                 generation nil
-                 (format "%s: %s" id
-                         (error-message-string error-data)))))))))
+                 generation nil (format "%s: %s" id (error-message-string error-data)))))))))
      (list "api" (format "repos/%s/git/blobs/%s" repo blob)))))
 
 (defun nsa/research-dashboard--start-job (generation hit)
@@ -395,56 +373,42 @@
          dashboard
          (lambda (ok result)
            (when (and (buffer-live-p dashboard)
-                      (= generation
-                         (buffer-local-value
-                          'nsa/research-dashboard--generation dashboard)))
+                      (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
              (with-current-buffer dashboard
                (if ok
-                   (let ((resolved
-                          (nsa/research-dashboard--get "default_branch" result)))
+                   (let ((resolved (nsa/research-dashboard--get "default_branch" result)))
                      (if resolved
-                         (nsa/research-dashboard--blob-job
-                          generation repo resolved path blob)
+                         (nsa/research-dashboard--blob-job generation repo resolved path blob)
                        (nsa/research-dashboard--job-done
-                        generation nil
-                        (format "%s:%s: no default branch" repo path))))
+                        generation nil (format "%s:%s: no default branch" repo path))))
                  (nsa/research-dashboard--job-done
                   generation nil (format "%s:%s: %s" repo path result))))))
          (list "api" (format "repos/%s" repo)))))))
 
 (defun nsa/research-dashboard--pump (generation)
   (while (and (= generation nsa/research-dashboard--generation)
-              (< nsa/research-dashboard--active
-                 (max 1 nsa/research-dashboard-max-workers))
+              (< nsa/research-dashboard--active (max 1 nsa/research-dashboard-max-workers))
               nsa/research-dashboard--queue)
     (cl-incf nsa/research-dashboard--active)
-    (nsa/research-dashboard--start-job
-     generation (pop nsa/research-dashboard--queue)))
+    (nsa/research-dashboard--start-job generation (pop nsa/research-dashboard--queue)))
   (nsa/research-dashboard--schedule-render))
 
 (defun nsa/research-dashboard--search-owner (generation owner login)
   (let* ((dashboard (current-buffer))
-         (scope (if (string= owner login)
-                    (concat "user:" owner)
-                  (concat "org:" owner)))
+         (scope (if (string= owner login) (concat "user:" owner) (concat "org:" owner)))
          (query (format "research in:path extension:org %s" scope)))
     (nsa/research-dashboard--gh
      dashboard
      (lambda (ok output)
        (when (and (buffer-live-p dashboard)
-                  (= generation
-                     (buffer-local-value
-                      'nsa/research-dashboard--generation dashboard)))
+                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
            (if (not ok)
-               (push (format "%s: %s" owner (string-trim output))
-                     nsa/research-dashboard--errors)
+               (push (format "%s: %s" owner (string-trim output)) nsa/research-dashboard--errors)
              (dolist (line (split-string output "\n" t))
-               (pcase-let ((`(,repo ,branch ,path ,blob)
-                            (split-string line "\t" nil)))
+               (pcase-let ((`(,repo ,branch ,path ,blob) (split-string line "\t" nil)))
                  (let ((id (and repo path (concat repo ":" path))))
-                   (when (and id
-                              (nsa/research-dashboard--candidate-path-p path)
+                   (when (and id (nsa/research-dashboard--candidate-path-p path)
                               (not (gethash id nsa/research-dashboard--seen)))
                      (puthash id t nsa/research-dashboard--seen)
                      (setq nsa/research-dashboard--queue
@@ -454,15 +418,12 @@
            (nsa/research-dashboard--pump generation)
            (nsa/research-dashboard--finish))))
      (list "api" "--method" "GET" "--paginate" "search/code"
-           "-f" (concat "q=" query)
-           "-f" "per_page=100"
-           "--jq"
-           ".items[] | [.repository.full_name, (.repository.default_branch // \"\"), .path, .sha] | @tsv"))))
+           "-f" (concat "q=" query) "-f" "per_page=100"
+           "--jq" ".items[] | [.repository.full_name, (.repository.default_branch // \"\"), .path, .sha] | @tsv"))))
 
 (defun nsa/research-dashboard--start-searches (generation login owners)
   (setq nsa/research-dashboard--searches-left (length owners))
-  (dolist (owner owners)
-    (nsa/research-dashboard--search-owner generation owner login))
+  (dolist (owner owners) (nsa/research-dashboard--search-owner generation owner login))
   (nsa/research-dashboard--finish))
 
 (defun nsa/research-dashboard--discover (generation)
@@ -471,9 +432,7 @@
      dashboard
      (lambda (ok output)
        (when (and (buffer-live-p dashboard)
-                  (= generation
-                     (buffer-local-value
-                      'nsa/research-dashboard--generation dashboard)))
+                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
            (if (not ok)
                (progn
@@ -484,27 +443,20 @@
                (setq nsa/research-dashboard--login login)
                (if nsa/research-dashboard-owners
                    (nsa/research-dashboard--start-searches
-                    generation login
-                    (delete-dups
-                     (copy-sequence nsa/research-dashboard-owners)))
+                    generation login (delete-dups (copy-sequence nsa/research-dashboard-owners)))
                  (nsa/research-dashboard--gh
                   dashboard
                   (lambda (org-ok org-output)
                     (when (buffer-live-p dashboard)
                       (with-current-buffer dashboard
                         (unless org-ok
-                          (push (string-trim org-output)
-                                nsa/research-dashboard--errors))
+                          (push (string-trim org-output) nsa/research-dashboard--errors))
                         (nsa/research-dashboard--start-searches
                          generation login
                          (delete-dups
-                          (cons login
-                                (if org-ok
-                                    (split-string org-output "\n" t)
-                                  nil)))))))
-                  (list "api" "--paginate" "user/orgs"
-                        "--jq" ".[].login"))))))))
-     (list "api" "user" "--jq" ".login"))))
+                          (cons login (if org-ok (split-string org-output "\n" t) nil)))))))
+                  (list "api" "--paginate" "user/orgs" "--jq" ".[].login")))))))
+     (list "api" "user" "--jq" ".login")))))
 
 (defun nsa/research-dashboard-refresh ()
   "Refresh asynchronously; no GitHub operation waits on the Emacs UI thread."
@@ -522,74 +474,53 @@
     (nsa/research-dashboard--render)
     (nsa/research-dashboard--discover generation)))
 
-(defun nsa/research-dashboard-search ()
-  "Set a local text filter without hitting GitHub."
-  (interactive)
-  (setq nsa/research-dashboard--query
-        (string-trim
-         (read-string "Search research: " nsa/research-dashboard--query)))
+(defun nsa/research-dashboard-search (text)
+  "Search all visible research fields for TEXT."
+  (interactive
+   (list (read-string "Research search (empty clears): " nsa/research-dashboard--search-text)))
+  (setq nsa/research-dashboard--search-text (string-trim text))
   (nsa/research-dashboard--render))
 
-(defun nsa/research-dashboard--filter-values (kind)
+(defun nsa/research-dashboard--field-values (field)
   (sort
    (delete-dups
-    (delq nil
-          (mapcar
-           (lambda (item)
-             (pcase kind
-               ('repo (nsa/research-item-repo item))
-               ('project (nsa/research-dashboard--project item))
-               ('lifecycle (nsa/research-item-lifecycle item))))
-           nsa/research-dashboard--items)))
+    (mapcar (lambda (item) (nsa/research-dashboard--filter-value item field))
+            nsa/research-dashboard--items))
    #'string-lessp))
 
-(defun nsa/research-dashboard--read-filter (prompt kind current)
-  (let* ((choices (nsa/research-dashboard--filter-values kind))
-         (value (completing-read prompt (cons "" choices) nil t nil nil current)))
-    (unless (string-empty-p value) value)))
-
-(defun nsa/research-dashboard-filter-repository ()
-  (interactive)
-  (setq nsa/research-dashboard--repo-filter
-        (nsa/research-dashboard--read-filter
-         "Repository (blank clears): " 'repo nsa/research-dashboard--repo-filter))
-  (nsa/research-dashboard--render))
-
-(defun nsa/research-dashboard-filter-project ()
-  (interactive)
-  (setq nsa/research-dashboard--project-filter
-        (nsa/research-dashboard--read-filter
-         "Project (blank clears): " 'project nsa/research-dashboard--project-filter))
-  (nsa/research-dashboard--render))
-
-(defun nsa/research-dashboard-filter-lifecycle ()
-  (interactive)
-  (setq nsa/research-dashboard--lifecycle-filter
-        (nsa/research-dashboard--read-filter
-         "Lifecycle (blank clears): " 'lifecycle
-         nsa/research-dashboard--lifecycle-filter))
+(defun nsa/research-dashboard-filter (field value)
+  "Filter the dashboard by FIELD and exact VALUE."
+  (interactive
+   (let* ((field-name
+           (completing-read "Filter field: "
+                            '("repository" "project" "lifecycle" "approval") nil t))
+          (field (intern field-name))
+          (value
+           (completing-read (format "%s: " field-name)
+                            (nsa/research-dashboard--field-values field) nil t)))
+     (list field value)))
+  (setq nsa/research-dashboard--field-filters
+        (cons (cons field value)
+              (assq-delete-all field nsa/research-dashboard--field-filters)))
   (nsa/research-dashboard--render))
 
 (defun nsa/research-dashboard-clear-filters ()
+  "Clear text search and all field filters."
   (interactive)
-  (setq nsa/research-dashboard--query ""
-        nsa/research-dashboard--repo-filter nil
-        nsa/research-dashboard--project-filter nil
-        nsa/research-dashboard--lifecycle-filter nil
-        nsa/research-dashboard--show-legacy
-        nsa/research-dashboard-show-legacy-default)
+  (setq nsa/research-dashboard--search-text ""
+        nsa/research-dashboard--field-filters nil)
   (nsa/research-dashboard--render))
 
 (defun nsa/research-dashboard-toggle-legacy ()
-  "Toggle review-ready unmigrated research."
+  "Toggle visibility of review-ready unmigrated research."
   (interactive)
-  (setq nsa/research-dashboard--show-legacy
-        (not nsa/research-dashboard--show-legacy))
+  (setq nsa/research-dashboard--show-legacy (not nsa/research-dashboard--show-legacy))
   (nsa/research-dashboard--render)
   (message "Unmigrated research %s"
            (if nsa/research-dashboard--show-legacy "shown" "hidden")))
 
 (defun nsa/research-dashboard-help ()
+  "Show dashboard key bindings and filtering semantics."
   (interactive)
   (with-help-window "*Research Dashboard Help*"
     (princ "Research Dashboard\n\n")
@@ -597,119 +528,92 @@
     (princ "a    approve\n")
     (princ "r    reject\n")
     (princ "g    async refresh\n")
-    (princ "/ s  search locally\n")
-    (princ "f r  filter repository\n")
-    (princ "f p  filter project\n")
-    (princ "f l  filter lifecycle\n")
-    (princ "c    clear filters\n")
-    (princ "L    show/hide unmigrated legacy research\n")
+    (princ "/ s  local search\n")
+    (princ "f    exact field filter\n")
+    (princ "c    clear search/filters\n")
+    (princ "L    show/hide unmigrated review-ready research\n")
     (princ "e    show scan/decision errors\n")
     (princ "?    this help\n\n")
     (princ "By default only canonical PENDING research is visible.\n")
-    (princ "UNMIGRATED means the file is review-ready but lacks the canonical approval block.\n")))
+    (princ "UNMIGRATED means REVIEW/RESEARCHED/VERIFIED without the canonical approval block.\n")))
 
 (defun nsa/research-dashboard--at-point ()
   (let ((id (tabulated-list-get-id)))
     (or (seq-find
          (lambda (item)
-           (string= id
-                    (concat (nsa/research-item-repo item) ":"
-                            (nsa/research-item-path item))))
+           (string= id (concat (nsa/research-item-repo item) ":"
+                               (nsa/research-item-path item))))
          nsa/research-dashboard--items)
         (user-error "No research item on this row"))))
 
 (defun nsa/research-dashboard-view ()
   (interactive)
   (let* ((item (nsa/research-dashboard--at-point))
-         (buffer
-          (get-buffer-create
-           (format "*Research: %s*" (nsa/research-item-title item)))))
+         (buffer (get-buffer-create (format "*Research: %s*" (nsa/research-item-title item)))))
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert (nsa/research-item-content item))
-        (org-mode)
-        (read-only-mode 1)
+        (erase-buffer) (insert (nsa/research-item-content item))
+        (org-mode) (read-only-mode 1)
         (setq-local header-line-format
-                    (format "%s — %s"
-                            (nsa/research-item-repo item)
+                    (format "%s — %s" (nsa/research-item-repo item)
                             (nsa/research-item-path item)))))
     (pop-to-buffer buffer)))
 
 (defun nsa/research-dashboard-errors ()
   (interactive)
   (with-output-to-temp-buffer "*Research Dashboard Errors*"
-    (princ
-     (if nsa/research-dashboard--errors
-         (string-join (reverse nsa/research-dashboard--errors) "\n")
-       "No errors."))))
+    (princ (if nsa/research-dashboard--errors
+               (string-join (reverse nsa/research-dashboard--errors) "\n\n")
+             "No errors."))))
 
 (defun nsa/research-dashboard--encode-path (path)
   (mapconcat #'url-hexify-string (split-string path "/" t) "/"))
-
 (defun nsa/research-dashboard--field-regexp (field)
   (format "^#\\+%s:[ \\t]*.*$" (regexp-quote field)))
-
 (defun nsa/research-dashboard--has-field-p (content)
-  (seq-some
-   (lambda (field)
-     (string-match-p (nsa/research-dashboard--field-regexp field) content))
-   nsa/research-dashboard--fields))
-
+  (seq-some (lambda (field)
+              (string-match-p (nsa/research-dashboard--field-regexp field) content))
+            nsa/research-dashboard--fields))
 (defun nsa/research-dashboard--canonical-p (content)
   (string-match-p
    (concat "^#\\+status:.*\n#\\+approval_schema: "
            (regexp-quote nsa/research-dashboard--schema)
            "\n#\\+approval_state: PENDING\n#\\+approval_actor: .*\n"
            "#\\+approval_evidence: .*\n#\\+approval_base_commit: .*\n"
-           "#\\+approval_base_blob: .*\n#\\+approval_decided_at: .*$")
-   content))
+           "#\\+approval_base_blob: .*\n#\\+approval_decided_at: .*$") content))
 
 (defun nsa/research-dashboard--replace-field (content field value)
   (with-temp-buffer
-    (insert content)
-    (goto-char (point-min))
-    (unless (re-search-forward
-             (nsa/research-dashboard--field-regexp field) nil t)
+    (insert content) (goto-char (point-min))
+    (unless (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
       (user-error "Missing #+%s" field))
     (replace-match (format "#+%s: %s" field value) t t)
-    (when (re-search-forward
-           (nsa/research-dashboard--field-regexp field) nil t)
+    (when (re-search-forward (nsa/research-dashboard--field-regexp field) nil t)
       (user-error "Duplicate #+%s" field))
     (buffer-string)))
 
-(defun nsa/research-dashboard--decision-content
-    (content state actor evidence commit blob timestamp)
-  (let ((values
-         `(("approval_schema" . ,nsa/research-dashboard--schema)
-           ("approval_state" . ,state)
-           ("approval_actor" . ,actor)
-           ("approval_evidence" . ,evidence)
-           ("approval_base_commit" . ,commit)
-           ("approval_base_blob" . ,blob)
-           ("approval_decided_at" . ,timestamp))))
+(defun nsa/research-dashboard--decision-content (content state actor evidence commit blob timestamp)
+  (let ((values `(("approval_schema" . ,nsa/research-dashboard--schema)
+                  ("approval_state" . ,state) ("approval_actor" . ,actor)
+                  ("approval_evidence" . ,evidence) ("approval_base_commit" . ,commit)
+                  ("approval_base_blob" . ,blob) ("approval_decided_at" . ,timestamp))))
     (cond
      ((nsa/research-dashboard--canonical-p content)
       (dolist (pair values content)
-        (setq content
-              (nsa/research-dashboard--replace-field
-               content (car pair) (cdr pair)))))
+        (setq content (nsa/research-dashboard--replace-field content (car pair) (cdr pair)))))
      ((nsa/research-dashboard--has-field-p content)
       (user-error "Partial/noncanonical approval metadata exists"))
      (t
       (with-temp-buffer
-        (insert content)
-        (goto-char (point-min))
+        (insert content) (goto-char (point-min))
         (unless (re-search-forward "^#\\+status:.*$" nil t)
-          (user-error "Missing #+status; lifecycle will not be invented"))
+          (user-error "Legacy research has no #+status; cannot safely record approval"))
         (end-of-line)
-        (insert
-         "\n"
-         (mapconcat
-          (lambda (field)
-            (format "#+%s: %s" field
-                    (alist-get field values nil nil #'string=)))
-          nsa/research-dashboard--fields "\n"))
+        (insert "\n" (mapconcat
+                       (lambda (field)
+                         (format "#+%s: %s" field
+                                 (alist-get field values nil nil #'string=)))
+                       nsa/research-dashboard--fields "\n"))
         (buffer-string))))))
 
 (defun nsa/research-dashboard--branch-head (decision callback)
@@ -720,13 +624,12 @@
      (lambda (ok result)
        (if ok
            (funcall callback t
-                    (nsa/research-dashboard--get
-                     "sha" (nsa/research-dashboard--get "commit" result)))
+                    (nsa/research-dashboard--get "sha"
+                                                 (nsa/research-dashboard--get "commit" result)))
          (funcall callback nil result)))
-     (list "api"
-           (format "repos/%s/branches/%s"
-                   (nsa/research-item-repo item)
-                   (url-hexify-string (nsa/research-item-branch item)))))))
+     (list "api" (format "repos/%s/branches/%s"
+                         (nsa/research-item-repo item)
+                         (url-hexify-string (nsa/research-item-branch item)))))))
 
 (defun nsa/research-dashboard--remote-file (decision commit callback)
   (let* ((item (nsa/research-decision-item decision))
@@ -734,23 +637,17 @@
     (nsa/research-dashboard--gh-json
      dashboard
      (lambda (ok result)
-       (if (not ok)
-           (funcall callback nil result)
+       (if (not ok) (funcall callback nil result)
          (let ((content (nsa/research-dashboard--get "content" result))
                (encoding (nsa/research-dashboard--get "encoding" result)))
            (if (not (and (string= encoding "base64") (stringp content)))
                (funcall callback nil "unsupported contents encoding")
-             (funcall callback
-                      t
-                      (cons
-                       (nsa/research-dashboard--get "sha" result)
-                       (decode-coding-string
-                        (base64-decode-string content) 'utf-8)))))))
+             (funcall callback t
+                      (cons (nsa/research-dashboard--get "sha" result)
+                            (decode-coding-string (base64-decode-string content) 'utf-8)))))))
      (list "api" "--method" "GET"
-           (format "repos/%s/contents/%s"
-                   (nsa/research-item-repo item)
-                   (nsa/research-dashboard--encode-path
-                    (nsa/research-item-path item)))
+           (format "repos/%s/contents/%s" (nsa/research-item-repo item)
+                   (nsa/research-dashboard--encode-path (nsa/research-item-path item)))
            "-f" (concat "ref=" commit)))))
 
 (defun nsa/research-dashboard--fail (decision text)
@@ -763,48 +660,135 @@
         (nsa/research-dashboard--render)
         (message "Research decision failed: %s" text)))))
 
-(defun nsa/research-dashboard--write (decision)
+(defun nsa/research-dashboard--approval-branch-name (decision)
+  (let* ((item (nsa/research-decision-item decision))
+         (stem (replace-regexp-in-string
+                "[^A-Za-z0-9._-]+" "-" (file-name-base (nsa/research-item-path item)))))
+    (format "research-approval/%s-%s"
+            (downcase stem) (format-time-string "%Y%m%d%H%M%S"))))
+
+(defun nsa/research-dashboard--approval-commit-message (decision)
+  (let ((item (nsa/research-decision-item decision)))
+    (format "docs(research): %s %s [skip ci]"
+            (downcase (nsa/research-decision-state decision))
+            (file-name-base (nsa/research-item-path item)))))
+
+(defun nsa/research-dashboard--create-approval-branch (decision)
   (let* ((dashboard (nsa/research-decision-dashboard decision))
          (item (nsa/research-decision-item decision))
+         (branch (nsa/research-dashboard--approval-branch-name decision))
+         (payload (json-encode
+                   `((ref . ,(concat "refs/heads/" branch))
+                     (sha . ,(nsa/research-decision-commit decision))))))
+    (setf (nsa/research-decision-approval-branch decision) branch)
+    (nsa/research-dashboard--gh-json
+     dashboard
+     (lambda (ok result)
+       (if ok
+           (nsa/research-dashboard--write-approval-branch decision)
+         (nsa/research-dashboard--fail
+          decision (format "Could not create approval branch: %s" result))))
+     (list "api" "--method" "POST"
+           (format "repos/%s/git/refs" (nsa/research-item-repo item))
+           "--input" "-") payload)))
+
+(defun nsa/research-dashboard--write-approval-branch (decision)
+  (let* ((dashboard (nsa/research-decision-dashboard decision))
+         (item (nsa/research-decision-item decision))
+         (payload (json-encode
+                   `((message . ,(nsa/research-dashboard--approval-commit-message decision))
+                     (content . ,(base64-encode-string
+                                  (nsa/research-decision-updated decision) t))
+                     (sha . ,(nsa/research-decision-blob decision))
+                     (branch . ,(nsa/research-decision-approval-branch decision))))))
+    (nsa/research-dashboard--gh-json
+     dashboard
+     (lambda (ok result)
+       (if (not ok)
+           (nsa/research-dashboard--fail
+            decision (format "Could not write approval branch: %s" result))
+         (let* ((commit (nsa/research-dashboard--get "commit" result))
+                (sha (nsa/research-dashboard--get "sha" commit)))
+           (setf (nsa/research-decision-approval-commit decision) sha)
+           (nsa/research-dashboard--create-approval-pr decision))))
+     (list "api" "--method" "PUT"
+           (format "repos/%s/contents/%s" (nsa/research-item-repo item)
+                   (nsa/research-dashboard--encode-path (nsa/research-item-path item)))
+           "--input" "-") payload)))
+
+(defun nsa/research-dashboard--create-approval-pr (decision)
+  (let* ((dashboard (nsa/research-decision-dashboard decision))
+         (item (nsa/research-decision-item decision))
+         (state (nsa/research-decision-state decision))
          (payload
           (json-encode
-           `((message
-              . ,(format "docs(research): %s %s"
-                         (downcase (nsa/research-decision-state decision))
-                         (file-name-base (nsa/research-item-path item))))
-             (content
-              . ,(base64-encode-string
-                  (nsa/research-decision-updated decision) t))
-             (sha . ,(nsa/research-decision-blob decision))
-             (branch . ,(nsa/research-item-branch item))))))
-    (nsa/research-dashboard--gh
+           `((title . ,(format "docs(research): %s %s"
+                              (downcase state)
+                              (file-name-base (nsa/research-item-path item))))
+             (head . ,(nsa/research-decision-approval-branch decision))
+             (base . ,(nsa/research-item-branch item))
+             (body . ,(format
+                       "Human research decision recorded by the Emacs research dashboard.\n\nDecision: `%s`\nActor: `%s`\nEvidence: `%s`\n\nApproval-only metadata change. CI intentionally skipped."
+                       state
+                       (nsa/research-decision-actor decision)
+                       (nsa/research-decision-evidence decision)))))))
+    (nsa/research-dashboard--gh-json
      dashboard
-     (lambda (ok output)
-       (if ok
-           (with-current-buffer dashboard
-             (nsa/research-dashboard-refresh))
-         (nsa/research-dashboard--fail decision (string-trim output))))
+     (lambda (ok result)
+       (if (not ok)
+           (nsa/research-dashboard--fail
+            decision (format "Could not open approval PR: %s" result))
+         (setf (nsa/research-decision-pr-number decision)
+               (nsa/research-dashboard--get "number" result)
+               (nsa/research-decision-pr-url decision)
+               (nsa/research-dashboard--get "html_url" result))
+         (nsa/research-dashboard--merge-approval-pr decision)))
+     (list "api" "--method" "POST"
+           (format "repos/%s/pulls" (nsa/research-item-repo item))
+           "--input" "-") payload)))
+
+(defun nsa/research-dashboard--merge-approval-pr (decision)
+  (let* ((dashboard (nsa/research-decision-dashboard decision))
+         (item (nsa/research-decision-item decision))
+         (number (nsa/research-decision-pr-number decision))
+         (payload (json-encode
+                   `((merge_method . "rebase")
+                     (sha . ,(nsa/research-decision-approval-commit decision))))))
+    (nsa/research-dashboard--gh-json
+     dashboard
+     (lambda (ok result)
+       (if (not ok)
+           (nsa/research-dashboard--fail
+            decision
+            (format "Approval PR %s could not merge immediately: %s%s"
+                    number result
+                    (if (nsa/research-decision-pr-url decision)
+                        (format "\n%s" (nsa/research-decision-pr-url decision)) "")))
+         (if (nsa/research-dashboard--get "merged" result)
+             (with-current-buffer dashboard
+               (message "%s %s:%s — approval PR #%s merged"
+                        (nsa/research-decision-state decision)
+                        (nsa/research-item-repo item)
+                        (nsa/research-item-path item) number)
+               (nsa/research-dashboard-refresh))
+           (nsa/research-dashboard--fail
+            decision
+            (format "Approval PR #%s was not merged: %s"
+                    number (or (nsa/research-dashboard--get "message" result) result))))))
      (list "api" "--method" "PUT"
-           (format "repos/%s/contents/%s"
-                   (nsa/research-item-repo item)
-                   (nsa/research-dashboard--encode-path
-                    (nsa/research-item-path item)))
-           "--input" "-")
-     :input payload)))
+           (format "repos/%s/pulls/%s/merge" (nsa/research-item-repo item) number)
+           "--input" "-") payload)))
 
 (defun nsa/research-dashboard--recheck-file (decision ok remote)
-  (if (not ok)
-      (nsa/research-dashboard--fail decision remote)
-    (if (not (and
-              (string= (nsa/research-decision-blob decision) (car remote))
-              (string= (nsa/research-decision-content decision) (cdr remote))))
+  (if (not ok) (nsa/research-dashboard--fail decision remote)
+    (if (not (and (string= (nsa/research-decision-blob decision) (car remote))
+                  (string= (nsa/research-decision-content decision) (cdr remote))))
         (nsa/research-dashboard--fail
          decision "Research changed during review; refresh first")
-      (nsa/research-dashboard--write decision))))
+      (nsa/research-dashboard--create-approval-branch decision))))
 
 (defun nsa/research-dashboard--recheck-head (decision ok head)
-  (if (not ok)
-      (nsa/research-dashboard--fail decision head)
+  (if (not ok) (nsa/research-dashboard--fail decision head)
     (if (not (string= head (nsa/research-decision-commit decision)))
         (nsa/research-dashboard--fail
          decision "Branch changed during review; refresh first")
@@ -819,20 +803,21 @@
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
         (erase-buffer)
+        (insert (format "%s\n%s\n\n"
+                        (nsa/research-item-repo item)
+                        (nsa/research-item-path item)))
         (dolist (field nsa/research-dashboard--fields)
-          (insert
-           (format "#+%s: %s\n"
-                   field
-                   (nsa/research-dashboard--keyword
-                    (nsa/research-decision-updated decision) field))))
+          (insert (format "#+%s: %s\n" field
+                          (nsa/research-dashboard--keyword
+                           (nsa/research-decision-updated decision) field))))
+        (insert "\nDelivery: approval-only PR, [skip ci], immediate rebase merge\n")
         (special-mode)))
     (display-buffer buffer)
-    (if (not
-         (yes-or-no-p
-          (format "%s %s:%s? "
-                  (nsa/research-decision-state decision)
-                  (nsa/research-item-repo item)
-                  (nsa/research-item-path item))))
+    (if (not (yes-or-no-p
+              (format "%s %s/%s? "
+                      (nsa/research-decision-state decision)
+                      (nsa/research-item-repo item)
+                      (file-name-nondirectory (nsa/research-item-path item)))))
         (let ((dashboard (nsa/research-decision-dashboard decision)))
           (with-current-buffer dashboard
             (setf (nsa/research-item-busy item) nil)
@@ -843,14 +828,11 @@
          (nsa/research-dashboard--recheck-head decision ok head))))))
 
 (defun nsa/research-dashboard--got-file (decision ok remote)
-  (if (not ok)
-      (nsa/research-dashboard--fail decision remote)
+  (if (not ok) (nsa/research-dashboard--fail decision remote)
     (let* ((item (nsa/research-decision-item decision))
-           (blob (car remote))
-           (content (cdr remote)))
-      (if (not
-           (and (string= blob (nsa/research-item-blob item))
-                (string= content (nsa/research-item-content item))))
+           (blob (car remote)) (content (cdr remote)))
+      (if (not (and (string= blob (nsa/research-item-blob item))
+                    (string= content (nsa/research-item-content item))))
           (nsa/research-dashboard--fail
            decision "Research changed since refresh; refresh first")
         (condition-case error-data
@@ -859,12 +841,10 @@
                     (nsa/research-decision-content decision) content
                     (nsa/research-decision-updated decision)
                     (nsa/research-dashboard--decision-content
-                     content
-                     (nsa/research-decision-state decision)
+                     content (nsa/research-decision-state decision)
                      (nsa/research-decision-actor decision)
                      (nsa/research-decision-evidence decision)
-                     (nsa/research-decision-commit decision)
-                     blob
+                     (nsa/research-decision-commit decision) blob
                      (format-time-string "%Y-%m-%dT%H:%M:%S%:z")))
               (nsa/research-dashboard--confirm decision))
           (error
@@ -872,8 +852,7 @@
             decision (error-message-string error-data))))))))
 
 (defun nsa/research-dashboard--got-head (decision ok commit)
-  (if (not ok)
-      (nsa/research-dashboard--fail decision commit)
+  (if (not ok) (nsa/research-dashboard--fail decision commit)
     (setf (nsa/research-decision-commit decision) commit)
     (nsa/research-dashboard--remote-file
      decision commit
@@ -881,39 +860,26 @@
        (nsa/research-dashboard--got-file decision file-ok remote)))))
 
 (defun nsa/research-dashboard--decide (state)
-  (let* ((dashboard (current-buffer))
-         (item (nsa/research-dashboard--at-point)))
-    (when (nsa/research-item-busy item)
-      (user-error "Decision already running"))
-    (let ((actor
-           (read-string "Human decision-maker: "
-                        (or nsa/research-dashboard--login "")))
-          (evidence
-           (read-string "Durable approval evidence: "
-                        "human:emacs-research-dashboard")))
+  (let* ((dashboard (current-buffer)) (item (nsa/research-dashboard--at-point)))
+    (when (nsa/research-item-busy item) (user-error "Decision already running"))
+    (let ((actor (read-string "Human decision-maker: " (or nsa/research-dashboard--login "")))
+          (evidence (read-string "Durable approval evidence: "
+                                 "human:emacs-research-dashboard")))
       (when (or (string-empty-p (string-trim actor))
                 (string-empty-p (string-trim evidence)))
         (user-error "Actor and evidence must be nonempty"))
       (setf (nsa/research-item-busy item) t)
       (nsa/research-dashboard--render)
-      (let ((decision
-             (nsa/research-decision-create
-              :dashboard dashboard
-              :item item
-              :state state
-              :actor actor
-              :evidence evidence)))
+      (let ((decision (nsa/research-decision-create
+                       :dashboard dashboard :item item :state state
+                       :actor actor :evidence evidence)))
         (nsa/research-dashboard--branch-head
-         decision
-         (lambda (ok commit)
-           (nsa/research-dashboard--got-head decision ok commit)))))))
+         decision (lambda (ok commit)
+                    (nsa/research-dashboard--got-head decision ok commit)))))))
 
-(defun nsa/research-dashboard-approve ()
-  (interactive)
+(defun nsa/research-dashboard-approve () (interactive)
   (nsa/research-dashboard--decide "APPROVED"))
-
-(defun nsa/research-dashboard-reject ()
-  (interactive)
+(defun nsa/research-dashboard-reject () (interactive)
   (nsa/research-dashboard--decide "REJECTED"))
 
 (define-derived-mode nsa/research-dashboard-mode tabulated-list-mode "Research-Review"
@@ -922,14 +888,10 @@
   (setq-local tabulated-list-padding 2)
   (setq-local font-lock-defaults '(nsa/research-dashboard-font-lock-keywords))
   (setq tabulated-list-format
-        [("Approval" 12 t)
-         ("Repository" 30 t)
-         ("Project" 22 t)
-         ("Lifecycle" 20 t)
-         ("Title" 56 t)
-         ("Path" 72 t)]
-        tabulated-list-sort-key '("Repository" . nil))
-  (setq nsa/research-dashboard--show-legacy
+        [("Approval" 12 t) ("Repository" 30 t) ("Project" 20 t)
+         ("Lifecycle" 22 t) ("Title" 56 t) ("Path" 64 t)]
+        tabulated-list-sort-key '("Repository" . nil)
+        nsa/research-dashboard--show-legacy
         nsa/research-dashboard-show-legacy-default)
   (tabulated-list-init-header)
   (hl-line-mode 1)

--- a/.doom.d/tests/research-dashboard-test.el
+++ b/.doom.d/tests/research-dashboard-test.el
@@ -6,15 +6,22 @@
 (defconst nsa/research-dashboard-test--canonical
   "#+title: Canonical research\n#+status: RESEARCHED\n#+approval_schema: prolog-rlm.research-approval.v1\n#+approval_state: PENDING\n#+approval_actor: NONE\n#+approval_evidence: NONE\n#+approval_base_commit: NONE\n#+approval_base_blob: NONE\n#+approval_decided_at: NONE\n\n* Findings\nBody\n")
 
-(defconst nsa/research-dashboard-test--legacy-review
+(defconst nsa/research-dashboard-test--legacy
   "#+title: Legacy StarIntel research\n#+status: REVIEW\n#+filetags: :research:\n\n* Findings\nBody\n")
 
-(defun nsa/research-dashboard-test--legacy-with-status (status)
-  (string-replace "#+status: REVIEW"
-                  (format "#+status: %s" status)
-                  nsa/research-dashboard-test--legacy-review))
+(defun nsa/research-dashboard-test--item
+    (&optional approval lifecycle title repo path)
+  (nsa/research-item-create
+   :repo (or repo "lost-rob0t/prolog-rlm")
+   :branch "main"
+   :path (or path "research/example.org")
+   :blob "deadbeef"
+   :title (or title "Example research")
+   :lifecycle (or lifecycle "RESEARCHED")
+   :approval (or approval "PENDING")
+   :content nsa/research-dashboard-test--canonical))
 
-(ert-deftest nsa/research-dashboard-recognizes-only-review-artifact-paths ()
+(ert-deftest nsa/research-dashboard-recognizes-research-paths ()
   (dolist (path '("research/example.org"
                   "roam/research/star-server/example.org"
                   "nested/research/topic/example.org"))
@@ -28,102 +35,125 @@
                   "books/prolog/research/search-log.org"))
     (should-not (nsa/research-dashboard--candidate-path-p path))))
 
-(ert-deftest nsa/research-dashboard-canonical-pending-is-open-even-when-lifecycle-done ()
-  (let ((item (nsa/research-dashboard--item
-               "lost-rob0t/prolog-rlm" "main" "research/example.org"
-               "deadbeef"
-               (string-replace "#+status: RESEARCHED" "#+status: DONE"
-                               nsa/research-dashboard-test--canonical))))
+(ert-deftest nsa/research-dashboard-canonical-pending-is-open ()
+  (let ((item
+         (nsa/research-dashboard--item
+          "lost-rob0t/prolog-rlm" "main" "research/example.org"
+          "deadbeef" nsa/research-dashboard-test--canonical)))
     (should item)
     (should (equal (nsa/research-item-approval item) "PENDING"))
-    (should (equal (nsa/research-item-lifecycle item) "DONE"))))
+    (should (equal (nsa/research-item-lifecycle item) "RESEARCHED"))))
 
-(ert-deftest nsa/research-dashboard-unmigrated-review-ready-is-retained ()
-  (let ((item (nsa/research-dashboard--item
-               "lost-rob0t/starintel-auto-research" "main"
-               "roam/research/star-server/example.org" "deadbeef"
-               nsa/research-dashboard-test--legacy-review)))
+(ert-deftest nsa/research-dashboard-legacy-active-record-can-be-loaded ()
+  (let ((item
+         (nsa/research-dashboard--item
+          "lost-rob0t/starintel-auto-research" "main"
+          "roam/research/star-server/example.org" "deadbeef"
+          nsa/research-dashboard-test--legacy)))
     (should item)
     (should (equal (nsa/research-item-approval item) "LEGACY"))))
 
+(ert-deftest nsa/research-dashboard-unmigrated-review-ready-is-retained ()
+  (dolist (state '("REVIEW" "RESEARCHED" "VERIFIED"))
+    (should
+     (nsa/research-dashboard--item
+      "lost-rob0t/starintel-auto-research" "main"
+      "roam/research/star-server/example.org" "deadbeef"
+      (string-replace "#+status: REVIEW"
+                      (format "#+status: %s" state)
+                      nsa/research-dashboard-test--legacy)))))
+
 (ert-deftest nsa/research-dashboard-unmigrated-nonreview-states-are-not-queued ()
-  (dolist (status '("DRAFT" "RESEARCHING" "APPROVED" "DONE" "REJECTED"
-                    "SUPERSEDED" "implemented-prototype" "accepted-for-realization"))
+  (dolist (state '("DRAFT" "RESEARCHING" "APPROVED" "DONE" "REJECTED"
+                   "SUPERSEDED" "implemented-prototype"
+                   "accepted-for-realization" "MISSING"))
     (should-not
      (nsa/research-dashboard--item
       "lost-rob0t/starintel-auto-research" "main"
       "roam/research/star-server/example.org" "deadbeef"
-      (nsa/research-dashboard-test--legacy-with-status status))))
-  (should-not
-   (nsa/research-dashboard--item
-    "lost-rob0t/chatgpt-books" "main"
-    "research/publishing-pipeline.org" "deadbeef"
-    "#+title: Publishing Pipeline Decision\n* Findings\nBody\n")))
+      (if (string= state "MISSING")
+          "#+title: Missing lifecycle\n* Findings\nBody\n"
+        (string-replace "#+status: REVIEW"
+                        (format "#+status: %s" state)
+                        nsa/research-dashboard-test--legacy))))))
 
-(ert-deftest nsa/research-dashboard-default-view-hides-unmigrated ()
+(ert-deftest nsa/research-dashboard-hides-legacy-by-default ()
   (with-temp-buffer
     (nsa/research-dashboard-mode)
-    (let ((canonical (nsa/research-dashboard--item
-                      "lost-rob0t/prolog-rlm" "main" "research/a.org"
-                      "a" nsa/research-dashboard-test--canonical))
-          (legacy (nsa/research-dashboard--item
-                   "lost-rob0t/starintel-auto-research" "main"
-                   "roam/research/star-server/b.org" "b"
-                   nsa/research-dashboard-test--legacy-review)))
-      (setq nsa/research-dashboard--items (list canonical legacy))
-      (should-not nsa/research-dashboard--show-legacy)
+    (let ((canonical (nsa/research-dashboard-test--item))
+          (legacy (nsa/research-dashboard-test--item "LEGACY" "REVIEW")))
+      (setq nsa/research-dashboard--items (list canonical legacy)
+            nsa/research-dashboard--show-legacy nil
+            nsa/research-dashboard--search-text ""
+            nsa/research-dashboard--field-filters nil)
       (should (equal (nsa/research-dashboard--visible-items)
                      (list canonical)))
       (setq nsa/research-dashboard--show-legacy t)
       (should (= (length (nsa/research-dashboard--visible-items)) 2)))))
 
-(ert-deftest nsa/research-dashboard-search-and-filters-are-local ()
+(ert-deftest nsa/research-dashboard-searches-all-important-fields ()
   (with-temp-buffer
     (nsa/research-dashboard-mode)
-    (let ((a (nsa/research-dashboard--item
-              "lost-rob0t/prolog-rlm" "main"
-              "research/RLM-RESEARCH-020-ui.org" "a"
-              (string-replace "Canonical research" "Emacs UI contract"
-                              nsa/research-dashboard-test--canonical)))
-          (b (nsa/research-dashboard--item
-              "lost-rob0t/prolog-rlm" "main"
-              "research/RLM-RESEARCH-010-prompt.org" "b"
-              (string-replace "Canonical research" "Prompt compiler"
-                              nsa/research-dashboard-test--canonical))))
-      (setq nsa/research-dashboard--items (list a b)
-            nsa/research-dashboard--query "emacs")
-      (should (equal (nsa/research-dashboard--visible-items) (list a)))
-      (setq nsa/research-dashboard--query ""
-            nsa/research-dashboard--lifecycle-filter "RESEARCHED")
-      (should (= (length (nsa/research-dashboard--visible-items)) 2))
-      (setq nsa/research-dashboard--repo-filter "lost-rob0t/other")
+    (let ((item
+           (nsa/research-dashboard-test--item
+            "PENDING" "RESEARCHED"
+            "Managed Context Tool Discovery"
+            "lost-rob0t/prolog-rlm"
+            "research/RLM-RESEARCH-011-managed-context-tool-discovery.org")))
+      (setq nsa/research-dashboard--items (list item)
+            nsa/research-dashboard--show-legacy nil
+            nsa/research-dashboard--field-filters nil
+            nsa/research-dashboard--search-text "managed context")
+      (should (equal (nsa/research-dashboard--visible-items) (list item)))
+      (setq nsa/research-dashboard--search-text "starintel")
       (should-not (nsa/research-dashboard--visible-items)))))
 
-(ert-deftest nsa/research-dashboard-major-mode-has-review-navigation-keys ()
+(ert-deftest nsa/research-dashboard-field-filter-is-exact ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (let ((rlm (nsa/research-dashboard-test--item
+                "PENDING" "RESEARCHED" "RLM"
+                "lost-rob0t/prolog-rlm"))
+          (other (nsa/research-dashboard-test--item
+                  "PENDING" "REVIEW" "Other"
+                  "lost-rob0t/other-repo")))
+      (setq nsa/research-dashboard--items (list rlm other)
+            nsa/research-dashboard--show-legacy nil
+            nsa/research-dashboard--search-text ""
+            nsa/research-dashboard--field-filters
+            '((repository . "lost-rob0t/prolog-rlm")))
+      (should (equal (nsa/research-dashboard--visible-items) (list rlm))))))
+
+(ert-deftest nsa/research-dashboard-major-mode-has-review-controls ()
   (with-temp-buffer
     (nsa/research-dashboard-mode)
     (should (derived-mode-p 'nsa/research-dashboard-mode))
     (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "/"))
                 #'nsa/research-dashboard-search))
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "f"))
+                #'nsa/research-dashboard-filter))
     (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "L"))
                 #'nsa/research-dashboard-toggle-legacy))
-    (should (keymapp (lookup-key nsa/research-dashboard-mode-map (kbd "f"))))))
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "a"))
+                #'nsa/research-dashboard-approve))))
 
-(ert-deftest nsa/research-dashboard-migrates-review-ready-unmigrated-without-changing-lifecycle ()
-  (let ((updated (nsa/research-dashboard--decision-content
-                  nsa/research-dashboard-test--legacy-review "APPROVED"
-                  "lost-rob0t" "human:test" "aaaa" "bbbb"
-                  "2026-08-27T04:00:00-04:00")))
+(ert-deftest nsa/research-dashboard-migrates-legacy-without-changing-lifecycle ()
+  (let ((updated
+         (nsa/research-dashboard--decision-content
+          nsa/research-dashboard-test--legacy "APPROVED"
+          "lost-rob0t" "human:test" "aaaa" "bbbb"
+          "2026-08-27T04:00:00-04:00")))
     (should (string-match-p "^#\\+status: REVIEW$" updated))
     (should (string-match-p "^#\\+approval_state: APPROVED$" updated))
     (should (string-match-p "^#\\+approval_base_commit: aaaa$" updated))
     (should (string-match-p "^#\\+approval_base_blob: bbbb$" updated))))
 
 (ert-deftest nsa/research-dashboard-updates-canonical-fields-only ()
-  (let ((updated (nsa/research-dashboard--decision-content
-                  nsa/research-dashboard-test--canonical "APPROVED"
-                  "lost-rob0t" "human:test" "aaaa" "bbbb"
-                  "2026-08-27T04:00:00-04:00")))
+  (let ((updated
+         (nsa/research-dashboard--decision-content
+          nsa/research-dashboard-test--canonical "APPROVED"
+          "lost-rob0t" "human:test" "aaaa" "bbbb"
+          "2026-08-27T04:00:00-04:00")))
     (should (string-match-p "^#\\+status: RESEARCHED$" updated))
     (should (string-match-p "^#\\+approval_state: APPROVED$" updated))
     (should (string-match-p "^\\* Findings$" updated))
@@ -132,11 +162,48 @@
 (ert-deftest nsa/research-dashboard-rejects-partial-approval-metadata ()
   (should-error
    (nsa/research-dashboard--decision-content
-    (concat nsa/research-dashboard-test--legacy-review
+    (concat nsa/research-dashboard-test--legacy
             "#+approval_actor: somebody\n")
     "APPROVED" "lost-rob0t" "human:test" "aaaa" "bbbb"
     "2026-08-27T04:00:00-04:00")
    :type 'user-error))
+
+(ert-deftest nsa/research-dashboard-approval-commit-skips-ci ()
+  (let* ((item (nsa/research-dashboard-test--item))
+         (decision
+          (nsa/research-decision-create
+           :item item :state "APPROVED")))
+    (should
+     (string-match-p
+      (regexp-quote "[skip ci]")
+      (nsa/research-dashboard--approval-commit-message decision)))))
+
+(ert-deftest nsa/research-dashboard-approval-merge-is-immediate-rebase ()
+  (let* ((item (nsa/research-dashboard-test--item))
+         (decision
+          (nsa/research-decision-create
+           :dashboard (current-buffer)
+           :item item
+           :state "APPROVED"
+           :approval-commit "abc123"
+           :pr-number 42))
+         captured-args captured-input)
+    (cl-letf
+        (((symbol-function 'nsa/research-dashboard--gh-json)
+          (lambda (_dashboard _callback args &optional input)
+            (setq captured-args args
+                  captured-input input))))
+      (nsa/research-dashboard--merge-approval-pr decision))
+    (should
+     (equal captured-args
+            '("api" "--method" "PUT"
+              "repos/lost-rob0t/prolog-rlm/pulls/42/merge"
+              "--input" "-")))
+    (let ((payload (nsa/research-dashboard--json captured-input)))
+      (should (equal (nsa/research-dashboard--get "merge_method" payload)
+                     "rebase"))
+      (should (equal (nsa/research-dashboard--get "sha" payload)
+                     "abc123")))))
 
 (ert-deftest nsa/research-dashboard-gh-uses-async-processes ()
   (let (spec)
@@ -148,31 +215,48 @@
                  'fake-process)))
       (with-temp-buffer
         (nsa/research-dashboard--gh
-         (current-buffer) (lambda (&rest _ignored)) '("api" "user"))
-        (should (equal (plist-get spec :command) '("gh" "api" "user")))
+         (current-buffer)
+         (lambda (&rest _ignored))
+         '("api" "user"))
+        (should (equal (plist-get spec :command)
+                       '("gh" "api" "user")))
         (should (eq (plist-get spec :connection-type) 'pipe))
         (should (functionp (plist-get spec :sentinel)))))))
 
 (ert-deftest nsa/research-dashboard-source-forbids-blocking-process-apis ()
-  (let ((source-file (symbol-file 'nsa/research-dashboard-refresh 'defun)))
+  (let ((source-file
+         (symbol-file 'nsa/research-dashboard-refresh 'defun)))
     (should source-file)
     (with-temp-buffer
       (insert-file-contents source-file)
       (let ((source (buffer-string)))
-        (dolist (forbidden '("(process-file" "(process-lines" "(call-process"
-                             "(call-process-region" "(shell-command"
-                             "(shell-command-to-string" "(start-process-shell-command"
-                             "(make-thread" "(accept-process-output" "(sleep-for"))
-          (should-not (string-match-p (regexp-quote forbidden) source)))
-        (should (string-match-p (regexp-quote "(make-process") source))))))
+        (dolist
+            (forbidden
+             '("(process-file" "(process-lines" "(call-process"
+               "(call-process-region" "(shell-command"
+               "(shell-command-to-string" "(start-process-shell-command"
+               "(make-thread" "(accept-process-output" "(sleep-for"))
+          (should-not
+           (string-match-p (regexp-quote forbidden) source)))
+        (should (string-match-p (regexp-quote "(make-process") source))
+        (should (string-match-p (regexp-quote "[skip ci]") source))
+        (should (string-match-p
+                 (regexp-quote "research-approval/") source))
+        (should (string-match-p
+                 (regexp-quote "pulls/%s/merge") source))
+        (should-not
+         (string-match-p
+          (regexp-quote "(nsa/research-dashboard--write decision)")
+          source))))))
 
 (ert-deftest nsa/research-dashboard-refresh-schedules-and-returns ()
   (let (called)
     (with-temp-buffer
       (nsa/research-dashboard-mode)
-      (cl-letf (((symbol-function 'nsa/research-dashboard--discover)
-                 (lambda (generation)
-                   (setq called generation))))
+      (cl-letf
+          (((symbol-function 'nsa/research-dashboard--discover)
+            (lambda (generation)
+              (setq called generation))))
         (nsa/research-dashboard-refresh)
         (should called)
         (should nsa/research-dashboard--scanning)


### PR DESCRIPTION
## Summary

- make `nsa/research-dashboard-mode` a polished dedicated review mode with faces/font-lock, hl-line, local search, exact field filters, help, and clear filter state
- hide unmigrated/legacy research by default; `L` toggles review-ready unmigrated records
- exclude research helper files such as `index.org`, `sources.org`, and `search-log.org`
- only retain unmigrated records in review-ready lifecycle states (`REVIEW`, `RESEARCHED`, `VERIFIED`); drop DRAFT/RESEARCHING/already-resolved legacy noise
- preserve canonical `PENDING` records even when their lifecycle is already `DONE`
- replace direct default-branch approval writes with approval-only branches and PRs
- mark approval commits `[skip ci]`
- immediately rebase-merge the approval PR after the human dashboard confirmation
- keep exact branch-head/blob/content stale-write checks before creating the approval branch
- keep all `gh` operations asynchronous through `make-process`

## Controls

- `RET` view
- `a` approve
- `r` reject
- `/` or `s` search
- `f` exact field filter
- `c` clear filters
- `L` show/hide unmigrated review-ready research
- `g` async refresh
- `e` errors
- `?` help

## Regression coverage

Covers noisy helper paths from the observed dashboard output, legacy lifecycle filtering, default legacy hiding, search/field filtering, major-mode keys, canonical metadata mutation, `[skip ci]`, immediate rebase merge payload, and the existing no-blocking-process guard.

Follow-up to #155/#157.