### PR TITLE
fix(emacs): make research dashboard discovery current and reliable

### DIFF
--- a/.doom.d/autoload/research-dashboard.el
+++ b/.doom.d/autoload/research-dashboard.el
@@ -16,7 +16,7 @@
   :type '(repeat string))
 
 (defcustom nsa/research-dashboard-max-workers 6
-  "Maximum concurrent research-file fetches."
+  "Maximum concurrent repository-tree and research-file fetches."
   :type 'integer)
 
 (defcustom nsa/research-dashboard-show-legacy-default nil
@@ -366,26 +366,51 @@
                  generation nil (format "%s: %s" id (error-message-string error-data)))))))))
      (list "api" (format "repos/%s/git/blobs/%s" repo blob)))))
 
-(defun nsa/research-dashboard--start-job (generation hit)
-  (pcase-let ((`(,repo ,branch ,path ,blob) hit))
-    (if (not (string-empty-p branch))
-        (nsa/research-dashboard--blob-job generation repo branch path blob)
-      (let ((dashboard (current-buffer)))
-        (nsa/research-dashboard--gh-json
-         dashboard
-         (lambda (ok result)
-           (when (and (buffer-live-p dashboard)
-                      (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
-             (with-current-buffer dashboard
-               (if ok
-                   (let ((resolved (nsa/research-dashboard--get "default_branch" result)))
-                     (if resolved
-                         (nsa/research-dashboard--blob-job generation repo resolved path blob)
-                       (nsa/research-dashboard--job-done
-                        generation nil (format "%s:%s: no default branch" repo path))))
-                 (nsa/research-dashboard--job-done
-                  generation nil (format "%s:%s: %s" repo path result))))))
-         (list "api" (format "repos/%s" repo)))))))
+(defun nsa/research-dashboard--tree-job (generation repo branch)
+  "Enumerate research files from REPO's current default BRANCH tree."
+  (let ((dashboard (current-buffer)))
+    (nsa/research-dashboard--gh-json
+     dashboard
+     (lambda (ok result)
+       (when (and (buffer-live-p dashboard)
+                  (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
+         (with-current-buffer dashboard
+           (cond
+            ((not ok)
+             (nsa/research-dashboard--job-done
+              generation nil (format "%s@%s tree: %s" repo branch result)))
+            ((nsa/research-dashboard--get "truncated" result)
+             (nsa/research-dashboard--job-done
+              generation nil
+              (format "%s@%s: recursive Git tree was truncated; research scan is incomplete"
+                      repo branch)))
+            (t
+             (dolist (entry (nsa/research-dashboard--get "tree" result))
+               (let ((path (nsa/research-dashboard--get "path" entry))
+                     (type (nsa/research-dashboard--get "type" entry))
+                     (blob (nsa/research-dashboard--get "sha" entry)))
+                 (when (and (string= type "blob") blob
+                            (nsa/research-dashboard--candidate-path-p path))
+                   (let ((id (concat repo ":" path)))
+                     (unless (gethash id nsa/research-dashboard--seen)
+                       (puthash id t nsa/research-dashboard--seen)
+                       (setq nsa/research-dashboard--queue
+                             (nconc nsa/research-dashboard--queue
+                                    (list (list 'blob repo branch path blob)))))))))
+             (nsa/research-dashboard--job-done generation))))))
+     (list "api" "--method" "GET"
+           (format "repos/%s/git/trees/%s" repo (url-hexify-string branch))
+           "-f" "recursive=1"))))
+
+(defun nsa/research-dashboard--start-job (generation job)
+  (pcase job
+    (`(tree ,repo ,branch)
+     (nsa/research-dashboard--tree-job generation repo branch))
+    (`(blob ,repo ,branch ,path ,blob)
+     (nsa/research-dashboard--blob-job generation repo branch path blob))
+    (_
+     (nsa/research-dashboard--job-done
+      generation nil (format "Invalid dashboard job: %S" job)))))
 
 (defun nsa/research-dashboard--pump (generation)
   (while (and (= generation nsa/research-dashboard--generation)
@@ -395,10 +420,18 @@
     (nsa/research-dashboard--start-job generation (pop nsa/research-dashboard--queue)))
   (nsa/research-dashboard--schedule-render))
 
-(defun nsa/research-dashboard--search-owner (generation owner login)
-  (let* ((dashboard (current-buffer))
-         (scope (if (string= owner login) (concat "user:" owner) (concat "org:" owner)))
-         (query (format "research in:path extension:org %s" scope)))
+(defun nsa/research-dashboard--owner-repos-args (owner login)
+  (if (string= owner login)
+      (list "api" "--method" "GET" "--paginate" "user/repos"
+            "-f" "affiliation=owner" "-f" "per_page=100"
+            "--jq" ".[] | [.full_name, (.default_branch // \"\")] | @tsv")
+    (list "api" "--method" "GET" "--paginate" (format "orgs/%s/repos" owner)
+          "-f" "type=all" "-f" "per_page=100"
+          "--jq" ".[] | [.full_name, (.default_branch // \"\")] | @tsv")))
+
+(defun nsa/research-dashboard--list-owner-repos (generation owner login)
+  "List OWNER repositories and queue current default-branch tree scans."
+  (let ((dashboard (current-buffer)))
     (nsa/research-dashboard--gh
      dashboard
      (lambda (ok output)
@@ -406,26 +439,25 @@
                   (= generation (buffer-local-value 'nsa/research-dashboard--generation dashboard)))
          (with-current-buffer dashboard
            (if (not ok)
-               (push (format "%s: %s" owner (string-trim output)) nsa/research-dashboard--errors)
+               (push (format "%s repositories: %s" owner (string-trim output))
+                     nsa/research-dashboard--errors)
              (dolist (line (split-string output "\n" t))
-               (pcase-let ((`(,repo ,branch ,path ,blob) (split-string line "\t" nil)))
-                 (let ((id (and repo path (concat repo ":" path))))
-                   (when (and id (nsa/research-dashboard--candidate-path-p path)
-                              (not (gethash id nsa/research-dashboard--seen)))
-                     (puthash id t nsa/research-dashboard--seen)
-                     (setq nsa/research-dashboard--queue
-                           (nconc nsa/research-dashboard--queue
-                                  (list (list repo (or branch "") path blob)))))))))
+               (pcase-let ((`(,repo ,branch) (split-string line "\t" nil)))
+                 (if (or (not repo) (string-empty-p (or branch "")))
+                     (push (format "%s: repository has no default branch" (or repo owner))
+                           nsa/research-dashboard--errors)
+                   (setq nsa/research-dashboard--queue
+                         (nconc nsa/research-dashboard--queue
+                                (list (list 'tree repo branch))))))))
            (cl-decf nsa/research-dashboard--searches-left)
            (nsa/research-dashboard--pump generation)
            (nsa/research-dashboard--finish))))
-     (list "api" "--method" "GET" "--paginate" "search/code"
-           "-f" (concat "q=" query) "-f" "per_page=100"
-           "--jq" ".items[] | [.repository.full_name, (.repository.default_branch // \"\"), .path, .sha] | @tsv"))))
+     (nsa/research-dashboard--owner-repos-args owner login))))
 
 (defun nsa/research-dashboard--start-searches (generation login owners)
   (setq nsa/research-dashboard--searches-left (length owners))
-  (dolist (owner owners) (nsa/research-dashboard--search-owner generation owner login))
+  (dolist (owner owners)
+    (nsa/research-dashboard--list-owner-repos generation owner login))
   (nsa/research-dashboard--finish))
 
 (defun nsa/research-dashboard--discover (generation)
@@ -461,7 +493,7 @@
      (list "api" "user" "--jq" ".login"))))
 
 (defun nsa/research-dashboard-refresh ()
-  "Refresh asynchronously; no GitHub operation waits on the Emacs UI thread."
+  "Refresh asynchronously from current default-branch repository trees."
   (interactive)
   (cl-incf nsa/research-dashboard--generation)
   (nsa/research-dashboard--cancel)
@@ -536,6 +568,7 @@
     (princ "L    show/hide unmigrated review-ready research\n")
     (princ "e    show scan/decision errors\n")
     (princ "?    this help\n\n")
+    (princ "Discovery reads each visible repository's current default-branch tree.\n")
     (princ "By default only canonical PENDING research is visible.\n")
     (princ "UNMIGRATED means REVIEW/RESEARCHED/VERIFIED without the canonical approval block.\n")))
 

--- a/.doom.d/autoload/research-dashboard.el
+++ b/.doom.d/autoload/research-dashboard.el
@@ -27,6 +27,8 @@
   '("index.org" "sources.org" "search-log.org"))
 
 (defconst nsa/research-dashboard--schema "prolog-rlm.research-approval.v1")
+(defconst nsa/research-dashboard--approval-pr-marker
+  "<!-- starintel-research-approval:v1 -->")
 (defconst nsa/research-dashboard--fields
   '("approval_schema" "approval_state" "approval_actor" "approval_evidence"
     "approval_base_commit" "approval_base_blob" "approval_decided_at"))
@@ -728,7 +730,8 @@
              (head . ,(nsa/research-decision-approval-branch decision))
              (base . ,(nsa/research-item-branch item))
              (body . ,(format
-                       "Human research decision recorded by the Emacs research dashboard.\n\nDecision: `%s`\nActor: `%s`\nEvidence: `%s`\n\nApproval-only metadata change. CI intentionally skipped."
+                       "%s\n\nHuman research decision recorded by the Emacs research dashboard.\n\nDecision: `%s`\nActor: `%s`\nEvidence: `%s`\n\nApproval-only metadata change. CI intentionally skipped."
+                       nsa/research-dashboard--approval-pr-marker
                        state
                        (nsa/research-decision-actor decision)
                        (nsa/research-decision-evidence decision)))))))

--- a/.doom.d/tests/research-dashboard-test.el
+++ b/.doom.d/tests/research-dashboard-test.el
@@ -205,6 +205,31 @@
       (should (equal (nsa/research-dashboard--get "sha" payload)
                      "abc123")))))
 
+(ert-deftest nsa/research-dashboard-approval-pr-body-has-machine-marker ()
+  (let* ((item (nsa/research-dashboard-test--item))
+         (decision
+          (nsa/research-decision-create
+           :dashboard (current-buffer)
+           :item item
+           :state "APPROVED"
+           :actor "operator"
+           :evidence "operator decision"
+           :approval-branch "research-approval/example"
+           :approval-commit "abc123"))
+        payload)
+    (cl-letf
+        (((symbol-function 'nsa/research-dashboard--gh-json)
+          (lambda (_dashboard callback args &optional input)
+            (if (seq-some (lambda (arg) (string-suffix-p "/merge" arg)) args)
+                (funcall callback t '((merged . t)))
+              (setq payload (nsa/research-dashboard--json input))
+              (funcall callback t '((number . 42) (html_url . "https://github.com/example/pr/42")))))))
+      (nsa/research-dashboard--create-approval-pr decision))
+    (should
+     (string-match-p
+      (regexp-quote "<!-- starintel-research-approval:v1 -->")
+      (nsa/research-dashboard--get "body" payload)))))
+
 (ert-deftest nsa/research-dashboard-gh-uses-async-processes ()
   (let (spec)
     (cl-letf (((symbol-function 'executable-find)

--- a/.doom.d/tests/research-dashboard-test.el
+++ b/.doom.d/tests/research-dashboard-test.el
@@ -35,6 +35,83 @@
                   "books/prolog/research/search-log.org"))
     (should-not (nsa/research-dashboard--candidate-path-p path))))
 
+(ert-deftest nsa/research-dashboard-tree-job-uses-current-default-branch-tree ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (setq nsa/research-dashboard--generation 1
+          nsa/research-dashboard--active 1
+          nsa/research-dashboard--queue nil
+          nsa/research-dashboard--seen (make-hash-table :test #'equal))
+    (let (captured-args)
+      (cl-letf (((symbol-function 'nsa/research-dashboard--gh-json)
+                 (lambda (_dashboard callback args &optional _input)
+                   (setq captured-args args)
+                   (funcall
+                    callback t
+                    '((truncated . nil)
+                      (tree . (((path . "roam/research/star-server/fresh.org")
+                                (type . "blob") (sha . "fresh-blob"))
+                               ((path . "roam/research/star-server/index.org")
+                                (type . "blob") (sha . "ignored-index"))
+                               ((path . "README.md")
+                                (type . "blob") (sha . "ignored-readme"))))))))
+                ((symbol-function 'nsa/research-dashboard--pump) #'ignore)
+                ((symbol-function 'nsa/research-dashboard--finish) #'ignore)
+                ((symbol-function 'nsa/research-dashboard--schedule-render) #'ignore))
+        (nsa/research-dashboard--tree-job
+         1 "lost-rob0t/starintel-auto-research" "main"))
+      (should
+       (equal captured-args
+              '("api" "--method" "GET"
+                "repos/lost-rob0t/starintel-auto-research/git/trees/main"
+                "-f" "recursive=1")))
+      (should
+       (equal nsa/research-dashboard--queue
+              '((blob "lost-rob0t/starintel-auto-research" "main"
+                      "roam/research/star-server/fresh.org" "fresh-blob")))))))
+
+(ert-deftest nsa/research-dashboard-truncated-tree-fails-closed ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (setq nsa/research-dashboard--generation 1
+          nsa/research-dashboard--active 1
+          nsa/research-dashboard--queue nil
+          nsa/research-dashboard--errors nil
+          nsa/research-dashboard--seen (make-hash-table :test #'equal))
+    (cl-letf (((symbol-function 'nsa/research-dashboard--gh-json)
+               (lambda (_dashboard callback _args &optional _input)
+                 (funcall callback t '((truncated . t) (tree . nil)))))
+              ((symbol-function 'nsa/research-dashboard--pump) #'ignore)
+              ((symbol-function 'nsa/research-dashboard--finish) #'ignore)
+              ((symbol-function 'nsa/research-dashboard--schedule-render) #'ignore))
+      (nsa/research-dashboard--tree-job 1 "lost-rob0t/huge-repo" "main"))
+    (should (null nsa/research-dashboard--queue))
+    (should (= (length nsa/research-dashboard--errors) 1))
+    (should (string-match-p "truncated"
+                            (car nsa/research-dashboard--errors)))))
+
+(ert-deftest nsa/research-dashboard-owner-repo-list-replaces-code-search ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (setq nsa/research-dashboard--generation 1
+          nsa/research-dashboard--searches-left 1
+          nsa/research-dashboard--queue nil)
+    (let (captured-args)
+      (cl-letf (((symbol-function 'nsa/research-dashboard--gh)
+                 (lambda (_dashboard callback args &rest _ignored)
+                   (setq captured-args args)
+                   (funcall callback t
+                            "lost-rob0t/starintel-auto-research\tmain\n")))
+                ((symbol-function 'nsa/research-dashboard--pump) #'ignore)
+                ((symbol-function 'nsa/research-dashboard--finish) #'ignore))
+        (nsa/research-dashboard--list-owner-repos 1 "lost-rob0t" "lost-rob0t"))
+      (should (equal (seq-take captured-args 5)
+                     '("api" "--method" "GET" "--paginate" "user/repos")))
+      (should-not (member "search/code" captured-args))
+      (should
+       (equal nsa/research-dashboard--queue
+              '((tree "lost-rob0t/starintel-auto-research" "main")))))))
+
 (ert-deftest nsa/research-dashboard-canonical-pending-is-open ()
   (let ((item
          (nsa/research-dashboard--item
@@ -306,6 +383,7 @@
                  (regexp-quote "research-approval/") source))
         (should (string-match-p
                  (regexp-quote "pulls/%s/merge") source))
+        (should-not (string-match-p (regexp-quote "search/code") source))
         (should-not
          (string-match-p
           (regexp-quote "(nsa/research-dashboard--write decision)")


### PR DESCRIPTION
## Summary
- stop using GitHub code-search result SHAs as research source-of-truth
- enumerate visible repositories, then read each repository's current default-branch Git tree
- queue only exact current-tree research blob SHAs
- fail closed and surface an error when GitHub reports a truncated recursive tree instead of silently claiming a complete scan
- retain the exact research-approval PR marker for dashboard-generated human decisions

## TDD / regression evidence
- starting head `223cc30c3a88644e4b586ab6ccd1513f4e45439a`
- Research dashboard run `33077120970` failed as intended: 23 tests, 19 passed, 4 failed
- failures proved the missing current-tree contract: undefined `nsa/research-dashboard--tree-job`, undefined `nsa/research-dashboard--list-owner-repos`, and the old `search/code` path still present

## Implementation
- exact candidate head: `77882e879e3bb2a640823332f741ea1899822ac7`
- removes `search/code` from dashboard discovery
- repository listing uses authenticated user/org repository APIs with pagination
- discovery uses each repository's current default branch via `git/trees/<branch>?recursive=1`
- research files are fetched by the blob SHA from that exact current tree
- truncated trees produce an explicit completeness error and no false-complete result

## Verification
- Research dashboard ERT workflow `33077445729`: green; 23 tests passed
- Nix workflow `33077445832`: main `workflows` job green; remaining fan-out jobs still pending at last check

This fixes the observed StarIntel failure where GitHub code search returned pre-migration blobs from `5d01182e...` while `starintel-auto-research/main` was already at the post-migration state. The dashboard no longer trusts GitHub's eventually-consistent code-search index for correctness.