### PR TITLE
fix(emacs): make research dashboard keys work in Evil command states

### DIFF
--- a/.doom.d/autoload/research-dashboard-evil.el
+++ b/.doom.d/autoload/research-dashboard-evil.el
@@ -1,0 +1,39 @@
+;;; research-dashboard-evil.el --- Evil integration for research dashboard -*- lexical-binding: t; -*-
+
+(require 'subr-x)
+
+(defconst nsa/research-dashboard-evil--normal-bindings
+  '(("g" . nsa/research-dashboard-refresh)
+    ("RET" . nsa/research-dashboard-view)
+    ("a" . nsa/research-dashboard-approve)
+    ("r" . nsa/research-dashboard-reject)
+    ("e" . nsa/research-dashboard-errors)
+    ("s" . nsa/research-dashboard-search)
+    ("/" . nsa/research-dashboard-search)
+    ("f" . nsa/research-dashboard-filter)
+    ("c" . nsa/research-dashboard-clear-filters)
+    ("L" . nsa/research-dashboard-toggle-legacy)
+    ("?" . nsa/research-dashboard-help))
+  "Research dashboard commands available from Evil normal state.")
+
+(defun nsa/research-dashboard-evil--apply-normal-bindings ()
+  "Install dashboard-local Evil normal-state bindings in the current buffer."
+  (dolist (binding nsa/research-dashboard-evil--normal-bindings)
+    (evil-local-set-key 'normal (kbd (car binding)) (cdr binding))))
+
+;;;###autoload
+(defun nsa/research-dashboard-evil-setup ()
+  "Make research dashboard controls work directly in Evil normal state."
+  (if (fboundp 'evil-local-set-key)
+      (nsa/research-dashboard-evil--apply-normal-bindings)
+    (let ((dashboard (current-buffer)))
+      (with-eval-after-load 'evil
+        (when (buffer-live-p dashboard)
+          (with-current-buffer dashboard
+            (nsa/research-dashboard-evil--apply-normal-bindings)))))))
+
+;;;###autoload
+(add-hook 'nsa/research-dashboard-mode-hook #'nsa/research-dashboard-evil-setup)
+
+(provide 'research-dashboard-evil)
+;;; research-dashboard-evil.el ends here

--- a/.doom.d/autoload/research-dashboard-evil.el
+++ b/.doom.d/autoload/research-dashboard-evil.el
@@ -2,7 +2,10 @@
 
 (require 'subr-x)
 
-(defconst nsa/research-dashboard-evil--normal-bindings
+(defconst nsa/research-dashboard-evil--command-states '(normal motion)
+  "Evil states where research dashboard commands must remain directly usable.")
+
+(defconst nsa/research-dashboard-evil--bindings
   '(("g" . nsa/research-dashboard-refresh)
     ("RET" . nsa/research-dashboard-view)
     ("a" . nsa/research-dashboard-approve)
@@ -14,23 +17,24 @@
     ("c" . nsa/research-dashboard-clear-filters)
     ("L" . nsa/research-dashboard-toggle-legacy)
     ("?" . nsa/research-dashboard-help))
-  "Research dashboard commands available from Evil normal state.")
+  "Research dashboard commands available from Evil command states.")
 
-(defun nsa/research-dashboard-evil--apply-normal-bindings ()
-  "Install dashboard-local Evil normal-state bindings in the current buffer."
-  (dolist (binding nsa/research-dashboard-evil--normal-bindings)
-    (evil-local-set-key 'normal (kbd (car binding)) (cdr binding))))
+(defun nsa/research-dashboard-evil--apply-bindings ()
+  "Install dashboard-local Evil command-state bindings in the current buffer."
+  (dolist (state nsa/research-dashboard-evil--command-states)
+    (dolist (binding nsa/research-dashboard-evil--bindings)
+      (evil-local-set-key state (kbd (car binding)) (cdr binding)))))
 
 ;;;###autoload
 (defun nsa/research-dashboard-evil-setup ()
-  "Make research dashboard controls work directly in Evil normal state."
+  "Make research dashboard controls work directly in Evil command states."
   (if (fboundp 'evil-local-set-key)
-      (nsa/research-dashboard-evil--apply-normal-bindings)
+      (nsa/research-dashboard-evil--apply-bindings)
     (let ((dashboard (current-buffer)))
       (with-eval-after-load 'evil
         (when (buffer-live-p dashboard)
           (with-current-buffer dashboard
-            (nsa/research-dashboard-evil--apply-normal-bindings)))))))
+            (nsa/research-dashboard-evil--apply-bindings)))))))
 
 ;;;###autoload
 (add-hook 'nsa/research-dashboard-mode-hook #'nsa/research-dashboard-evil-setup)

--- a/.doom.d/autoload/research-dashboard-evil.org
+++ b/.doom.d/autoload/research-dashboard-evil.org
@@ -3,8 +3,12 @@
 
 This file is the literate source for the Evil integration used by the research
 approval dashboard.  Dashboard review commands must remain usable directly from
-Evil normal state; users should never need to enter insert or Emacs state just
+Evil command states; users should never need to enter insert or Emacs state just
 to refresh, inspect, filter, approve, or reject research.
+
+The dashboard derives from =tabulated-list-mode=, so Evil may place it in motion
+state rather than normal state.  The integration therefore installs the same
+local command bindings in both normal and motion states.
 
 The hook is registered through an autoload cookie so Doom can install it without
 eagerly loading the dashboard.  If Evil is not loaded when a dashboard buffer is
@@ -16,7 +20,10 @@ in that original dashboard buffer.
 
 (require 'subr-x)
 
-(defconst nsa/research-dashboard-evil--normal-bindings
+(defconst nsa/research-dashboard-evil--command-states '(normal motion)
+  "Evil states where research dashboard commands must remain directly usable.")
+
+(defconst nsa/research-dashboard-evil--bindings
   '(("g" . nsa/research-dashboard-refresh)
     ("RET" . nsa/research-dashboard-view)
     ("a" . nsa/research-dashboard-approve)
@@ -28,23 +35,24 @@ in that original dashboard buffer.
     ("c" . nsa/research-dashboard-clear-filters)
     ("L" . nsa/research-dashboard-toggle-legacy)
     ("?" . nsa/research-dashboard-help))
-  "Research dashboard commands available from Evil normal state.")
+  "Research dashboard commands available from Evil command states.")
 
-(defun nsa/research-dashboard-evil--apply-normal-bindings ()
-  "Install dashboard-local Evil normal-state bindings in the current buffer."
-  (dolist (binding nsa/research-dashboard-evil--normal-bindings)
-    (evil-local-set-key 'normal (kbd (car binding)) (cdr binding))))
+(defun nsa/research-dashboard-evil--apply-bindings ()
+  "Install dashboard-local Evil command-state bindings in the current buffer."
+  (dolist (state nsa/research-dashboard-evil--command-states)
+    (dolist (binding nsa/research-dashboard-evil--bindings)
+      (evil-local-set-key state (kbd (car binding)) (cdr binding)))))
 
 ;;;###autoload
 (defun nsa/research-dashboard-evil-setup ()
-  "Make research dashboard controls work directly in Evil normal state."
+  "Make research dashboard controls work directly in Evil command states."
   (if (fboundp 'evil-local-set-key)
-      (nsa/research-dashboard-evil--apply-normal-bindings)
+      (nsa/research-dashboard-evil--apply-bindings)
     (let ((dashboard (current-buffer)))
       (with-eval-after-load 'evil
         (when (buffer-live-p dashboard)
           (with-current-buffer dashboard
-            (nsa/research-dashboard-evil--apply-normal-bindings)))))))
+            (nsa/research-dashboard-evil--apply-bindings)))))))
 
 ;;;###autoload
 (add-hook 'nsa/research-dashboard-mode-hook #'nsa/research-dashboard-evil-setup)

--- a/.doom.d/autoload/research-dashboard-evil.org
+++ b/.doom.d/autoload/research-dashboard-evil.org
@@ -1,0 +1,54 @@
+#+title: Research dashboard Evil integration
+#+property: header-args:emacs-lisp :tangle ./research-dashboard-evil.el :results none
+
+This file is the literate source for the Evil integration used by the research
+approval dashboard.  Dashboard review commands must remain usable directly from
+Evil normal state; users should never need to enter insert or Emacs state just
+to refresh, inspect, filter, approve, or reject research.
+
+The hook is registered through an autoload cookie so Doom can install it without
+eagerly loading the dashboard.  If Evil is not loaded when a dashboard buffer is
+created, setup defers until Evil becomes available and then installs the bindings
+in that original dashboard buffer.
+
+#+begin_src emacs-lisp
+;;; research-dashboard-evil.el --- Evil integration for research dashboard -*- lexical-binding: t; -*-
+
+(require 'subr-x)
+
+(defconst nsa/research-dashboard-evil--normal-bindings
+  '(("g" . nsa/research-dashboard-refresh)
+    ("RET" . nsa/research-dashboard-view)
+    ("a" . nsa/research-dashboard-approve)
+    ("r" . nsa/research-dashboard-reject)
+    ("e" . nsa/research-dashboard-errors)
+    ("s" . nsa/research-dashboard-search)
+    ("/" . nsa/research-dashboard-search)
+    ("f" . nsa/research-dashboard-filter)
+    ("c" . nsa/research-dashboard-clear-filters)
+    ("L" . nsa/research-dashboard-toggle-legacy)
+    ("?" . nsa/research-dashboard-help))
+  "Research dashboard commands available from Evil normal state.")
+
+(defun nsa/research-dashboard-evil--apply-normal-bindings ()
+  "Install dashboard-local Evil normal-state bindings in the current buffer."
+  (dolist (binding nsa/research-dashboard-evil--normal-bindings)
+    (evil-local-set-key 'normal (kbd (car binding)) (cdr binding))))
+
+;;;###autoload
+(defun nsa/research-dashboard-evil-setup ()
+  "Make research dashboard controls work directly in Evil normal state."
+  (if (fboundp 'evil-local-set-key)
+      (nsa/research-dashboard-evil--apply-normal-bindings)
+    (let ((dashboard (current-buffer)))
+      (with-eval-after-load 'evil
+        (when (buffer-live-p dashboard)
+          (with-current-buffer dashboard
+            (nsa/research-dashboard-evil--apply-normal-bindings)))))))
+
+;;;###autoload
+(add-hook 'nsa/research-dashboard-mode-hook #'nsa/research-dashboard-evil-setup)
+
+(provide 'research-dashboard-evil)
+;;; research-dashboard-evil.el ends here
+#+end_src

--- a/.doom.d/tests/research-dashboard-evil-test.el
+++ b/.doom.d/tests/research-dashboard-evil-test.el
@@ -19,22 +19,23 @@
     ("c" . nsa/research-dashboard-clear-filters)
     ("L" . nsa/research-dashboard-toggle-legacy)
     ("?" . nsa/research-dashboard-help))
-  "Normal-state dashboard bindings that must work under Evil.")
+  "Dashboard bindings that must work in Evil command states.")
 
 (ert-deftest nsa/research-dashboard-evil-integration-is-installed ()
   (should (fboundp 'nsa/research-dashboard-evil-setup))
   (should (memq #'nsa/research-dashboard-evil-setup
                 nsa/research-dashboard-mode-hook)))
 
-(ert-deftest nsa/research-dashboard-evil-normal-state-gets-dashboard-keys ()
+(ert-deftest nsa/research-dashboard-evil-command-states-get-dashboard-keys ()
   (should (fboundp 'nsa/research-dashboard-evil-setup))
   (let (calls)
     (cl-letf (((symbol-function 'evil-local-set-key)
                (lambda (state key command)
                  (push (list state (key-description key) command) calls))))
       (nsa/research-dashboard-evil-setup))
-    (dolist (binding nsa/research-dashboard-evil-test--expected-bindings)
-      (should (member (list 'normal (car binding) (cdr binding)) calls)))))
+    (dolist (state '(normal motion))
+      (dolist (binding nsa/research-dashboard-evil-test--expected-bindings)
+        (should (member (list state (car binding) (cdr binding)) calls))))))
 
 (provide 'research-dashboard-evil-test)
 ;;; research-dashboard-evil-test.el ends here

--- a/.doom.d/tests/research-dashboard-evil-test.el
+++ b/.doom.d/tests/research-dashboard-evil-test.el
@@ -1,0 +1,40 @@
+;;; research-dashboard-evil-test.el --- Evil bindings for research dashboard -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'research-dashboard)
+
+(when (locate-library "research-dashboard-evil")
+  (require 'research-dashboard-evil))
+
+(defconst nsa/research-dashboard-evil-test--expected-bindings
+  '(("g" . nsa/research-dashboard-refresh)
+    ("RET" . nsa/research-dashboard-view)
+    ("a" . nsa/research-dashboard-approve)
+    ("r" . nsa/research-dashboard-reject)
+    ("e" . nsa/research-dashboard-errors)
+    ("s" . nsa/research-dashboard-search)
+    ("/" . nsa/research-dashboard-search)
+    ("f" . nsa/research-dashboard-filter)
+    ("c" . nsa/research-dashboard-clear-filters)
+    ("L" . nsa/research-dashboard-toggle-legacy)
+    ("?" . nsa/research-dashboard-help))
+  "Normal-state dashboard bindings that must work under Evil.")
+
+(ert-deftest nsa/research-dashboard-evil-integration-is-installed ()
+  (should (fboundp 'nsa/research-dashboard-evil-setup))
+  (should (memq #'nsa/research-dashboard-evil-setup
+                nsa/research-dashboard-mode-hook)))
+
+(ert-deftest nsa/research-dashboard-evil-normal-state-gets-dashboard-keys ()
+  (should (fboundp 'nsa/research-dashboard-evil-setup))
+  (let (calls)
+    (cl-letf (((symbol-function 'evil-local-set-key)
+               (lambda (state key command)
+                 (push (list state (key-description key) command) calls))))
+      (nsa/research-dashboard-evil-setup))
+    (dolist (binding nsa/research-dashboard-evil-test--expected-bindings)
+      (should (member (list 'normal (car binding) (cdr binding)) calls)))))
+
+(provide 'research-dashboard-evil-test)
+;;; research-dashboard-evil-test.el ends here

--- a/.github/workflows/research-dashboard.yml
+++ b/.github/workflows/research-dashboard.yml
@@ -4,13 +4,20 @@ on:
   pull_request:
     paths:
       - '.doom.d/autoload/research-dashboard.el'
+      - '.doom.d/autoload/research-dashboard-evil.org'
+      - '.doom.d/autoload/research-dashboard-evil.el'
       - '.doom.d/tests/research-dashboard-test.el'
+      - '.doom.d/tests/research-dashboard-evil-test.el'
       - '.github/workflows/research-dashboard.yml'
   push:
     branches: [master]
     paths:
       - '.doom.d/autoload/research-dashboard.el'
+      - '.doom.d/autoload/research-dashboard-evil.org'
+      - '.doom.d/autoload/research-dashboard-evil.el'
       - '.doom.d/tests/research-dashboard-test.el'
+      - '.doom.d/tests/research-dashboard-evil-test.el'
+      - '.github/workflows/research-dashboard.yml'
 
 permissions:
   contents: read
@@ -27,4 +34,5 @@ jobs:
           emacs -Q --batch
           -L .doom.d/autoload
           -l .doom.d/tests/research-dashboard-test.el
+          -l .doom.d/tests/research-dashboard-evil-test.el
           -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
## Summary
- make the research dashboard controls work directly from Evil command states
- bind the dashboard-local keys in both `normal` and `motion` state because `nsa/research-dashboard-mode` derives from `tabulated-list-mode`
- preserve load-order safety: if Evil is not loaded when the dashboard buffer is created, install the bindings in that buffer after Evil loads
- keep the integration literate: `.doom.d/autoload/research-dashboard-evil.org` is source, `.doom.d/autoload/research-dashboard-evil.el` is tangled output
- extend the existing Research dashboard CI to test the Evil integration

## Keys
`g`, `RET`, `a`, `r`, `e`, `s`, `/`, `f`, `c`, `L`, `?` now map to the existing dashboard commands in both Evil `normal` and `motion` states.

## TDD evidence
- RED head `4f5fdfd70fb2cf81796f9869948bb76553339340`
- Research dashboard run `33078507323`: 25 tests, 23 passed, 2 failed
- the only failures were the new Evil contracts because `nsa/research-dashboard-evil-setup` did not exist
- final exact head `0368b20a783f8e09a3b80bd7ae80d9f4c13ae6dc`

## Verification
- Research dashboard run `33078884200`: GREEN
- Nix run `33078884151`: GREEN
  - workflow/literate parity checks green
  - image-progress tests green
  - desktop Home Manager evaluation green
  - flake Home Manager evaluation green

No need to enter insert/Emacs state just to operate the dashboard.