### PR TITLE
fix(qtile): restore group highlight glyph alignment

### DIFF
--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -490,7 +490,7 @@ def _owned_group_box(config_globals: dict[str, Any]):
         margin_y=2,
         margin_x=2,
         padding_y=-4,
-        padding_x=2,
+        padding_x=6,
         borderwidth=2,
         active=palette["white"],
         inactive=palette["muted"],

--- a/.config/qtile/tests/test_groupbox_navigation.py
+++ b/.config/qtile/tests/test_groupbox_navigation.py
@@ -162,6 +162,11 @@ class OwnedGroupBoxNavigationTests(unittest.TestCase):
         box, _ = self._build_box()
         self.assertEqual(box.font, "Symbols Nerd Font")
 
+    def test_group_highlight_uses_glyph_width_padding(self):
+        box, _ = self._build_box()
+        self.assertEqual(box.padding_x, 6)
+        self.assertEqual(box.borderwidth, 2)
+
     def test_next_group_skips_windowless_groups(self):
         box, navigated = self._build_box()
         groups = [


### PR DESCRIPTION
Restores the live topology GroupBox horizontal padding expected by the existing glyph-width alignment math.

- `OwnedGroupBox.padding_x`: 2 -> 6
- keeps `Symbols Nerd Font` so icon metrics remain truthful
- adds a regression assertion for `padding_x=6` + `borderwidth=2`
- leaves restored disk/network/system telemetry untouched

Branch diff is intentionally tiny: 1 line changed in runtime code, 5 test lines added.