### PR TITLE
feat: autosync GPT TODO agenda from Emacs and systemd

### DIFF
--- a/.doom.d/autoload/gpt-todos.el
+++ b/.doom.d/autoload/gpt-todos.el
@@ -6,13 +6,37 @@
   "Path to the dotfiles-owned gpt-todos sync script."
   :type 'file)
 
+(defcustom gpt-todos-agenda-directory
+  (file-name-as-directory
+   (or (getenv "GPT_TODOS_ORG_DIR")
+       (expand-file-name "~/Documents/Notes/org/agenda")))
+  "Live Org agenda directory mirrored by gpt-todos-sync."
+  :type 'directory)
+
+(defun gpt-todos--agenda-org-file-p (file)
+  "Return non-nil when FILE is logically below the synced agenda directory."
+  (when file
+    (let ((agenda (file-name-as-directory
+                   (expand-file-name gpt-todos-agenda-directory)))
+          (candidate (expand-file-name file)))
+      (and (string-equal (file-name-extension candidate) "org")
+           (string-prefix-p agenda candidate)))))
+
 ;;;###autoload
-(defun gpt-todos-sync ()
-  "Run gpt-todos sync asynchronously in a hidden buffer."
+(defun gpt-todos-sync (&optional file)
+  "Run gpt-todos sync asynchronously.
+When FILE is non-nil, preserve and synchronize that just-saved agenda file."
   (interactive)
   (let* ((buffer (get-buffer-create " *gpt-todos-sync*"))
-         (proc (start-process "gpt-todos-sync" buffer
-                              "/usr/bin/env" "bash" gpt-todos-sync-script)))
+         (command (append (list "/usr/bin/env" "bash" gpt-todos-sync-script)
+                          (when file
+                            (list "--file" (expand-file-name file)))))
+         (proc (make-process
+                :name "gpt-todos-sync"
+                :buffer buffer
+                :command command
+                :connection-type 'pipe
+                :noquery t)))
     (set-process-sentinel
      proc
      (lambda (p _event)
@@ -21,4 +45,14 @@
              (message "gpt-todos sync complete")
            (message "gpt-todos sync failed; see %s"
                     (buffer-name (process-buffer p)))))))
-    (message "gpt-todos sync started")))
+    (message "gpt-todos sync started")
+    proc))
+
+;;;###autoload
+(defun gpt-todos-sync-after-save ()
+  "Synchronize a just-saved Org file when it belongs to the live agenda tree."
+  (when (gpt-todos--agenda-org-file-p buffer-file-name)
+    (gpt-todos-sync buffer-file-name)))
+
+;;;###autoload
+(add-hook 'after-save-hook #'gpt-todos-sync-after-save)

--- a/.doom.d/autoload/gpt-todos.org
+++ b/.doom.d/autoload/gpt-todos.org
@@ -1,6 +1,12 @@
 #+title: GPT TODO sync autoload
 #+property: header-args :emacs-lisp :tangle ./gpt-todos.el :results none
 
+The live Org agenda is synchronized immediately after a saved =.org= file below
+=GPT_TODOS_ORG_DIR= (default =~/Documents/Notes/org/agenda/=).  The work happens
+in an asynchronous process so Git/network work never blocks the Emacs UI.  The
+shell helper owns locking, temporary save snapshots, pull/commit/push, and
+conflict recovery; Emacs only identifies the saved agenda file and delegates it.
+
 #+begin_src emacs-lisp
 ;;; gpt-todos.el -*- lexical-binding: t; -*-
 
@@ -10,13 +16,37 @@
   "Path to the dotfiles-owned gpt-todos sync script."
   :type 'file)
 
+(defcustom gpt-todos-agenda-directory
+  (file-name-as-directory
+   (or (getenv "GPT_TODOS_ORG_DIR")
+       (expand-file-name "~/Documents/Notes/org/agenda")))
+  "Live Org agenda directory mirrored by gpt-todos-sync."
+  :type 'directory)
+
+(defun gpt-todos--agenda-org-file-p (file)
+  "Return non-nil when FILE is logically below the synced agenda directory."
+  (when file
+    (let ((agenda (file-name-as-directory
+                   (expand-file-name gpt-todos-agenda-directory)))
+          (candidate (expand-file-name file)))
+      (and (string-equal (file-name-extension candidate) "org")
+           (string-prefix-p agenda candidate)))))
+
 ;;;###autoload
-(defun gpt-todos-sync ()
-  "Run gpt-todos sync asynchronously in a hidden buffer."
+(defun gpt-todos-sync (&optional file)
+  "Run gpt-todos sync asynchronously.
+When FILE is non-nil, preserve and synchronize that just-saved agenda file."
   (interactive)
   (let* ((buffer (get-buffer-create " *gpt-todos-sync*"))
-         (proc (start-process "gpt-todos-sync" buffer
-                              "/usr/bin/env" "bash" gpt-todos-sync-script)))
+         (command (append (list "/usr/bin/env" "bash" gpt-todos-sync-script)
+                          (when file
+                            (list "--file" (expand-file-name file)))))
+         (proc (make-process
+                :name "gpt-todos-sync"
+                :buffer buffer
+                :command command
+                :connection-type 'pipe
+                :noquery t)))
     (set-process-sentinel
      proc
      (lambda (p _event)
@@ -25,5 +55,15 @@
              (message "gpt-todos sync complete")
            (message "gpt-todos sync failed; see %s"
                     (buffer-name (process-buffer p)))))))
-    (message "gpt-todos sync started")))
+    (message "gpt-todos sync started")
+    proc))
+
+;;;###autoload
+(defun gpt-todos-sync-after-save ()
+  "Synchronize a just-saved Org file when it belongs to the live agenda tree."
+  (when (gpt-todos--agenda-org-file-p buffer-file-name)
+    (gpt-todos-sync buffer-file-name)))
+
+;;;###autoload
+(add-hook 'after-save-hook #'gpt-todos-sync-after-save)
 #+end_src

--- a/docs/wiki/emacs.org
+++ b/docs/wiki/emacs.org
@@ -11,6 +11,7 @@ The Doom configuration is literate.
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][init.el]] | Doom module selection from an explicitly tangled block. |
 | [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][packages.el]] | Doom package declarations. |
 | [[file:../../.doom.d/autoload/research-approval.org][.doom.d/autoload/research-approval.org]] | [[file:../../.doom.d/autoload/research-approval.el][research-approval.el]] | Fail-safe research/RAGE approval, commit, and push workflow. |
+| [[file:../../.doom.d/autoload/gpt-todos.org][.doom.d/autoload/gpt-todos.org]] | [[file:../../.doom.d/autoload/gpt-todos.el][gpt-todos.el]] | Durable agenda synchronization and save hook. |
 | [[file:../../.doom.d/snippets/][.doom.d/snippets/]] | n/a | Yasnippet and Org helper snippets. |
 
 The top of =config.org= declares =config.el= as its default tangle target, while individual blocks may override the target.  Read block-level =:tangle= arguments before assuming one Org file produces only one output.
@@ -55,6 +56,23 @@ For package/module changes:
 #+begin_src shell
   doom sync
 #+end_src
+
+* Durable agenda save synchronization
+The canonical integration is [[file:../../.doom.d/autoload/gpt-todos.org][gpt-todos.org]].
+After Emacs saves an =.org= file logically below =~/Documents/Notes/org/agenda/=,
+it starts =gpt-todos-sync --file FILE= asynchronously.  Git/network work therefore
+does not block the editor.
+
+The shell helper snapshots the exact saved contents before it acquires the shared
+sync lock.  This is important when an agenda file is a symlink into the durable
+=~/Documents/gpt-todos/agenda/= checkout: the helper can temporarily rewind only
+that just-written path, fast-forward from GitHub, restore the saved snapshot,
+commit, and push.  Concurrent local/remote edits still fail closed rather than
+silently choosing a winner, and failures retain a recovery copy under the user's
+state directory.
+
+Home Manager also runs the same helper every five minutes.  Both paths share the
+same lock, so the periodic timer and Emacs save hook cannot race each other.
 
 * Deciding a project research record
 From a tracked =research/*.org= buffer, invoke

--- a/docs/wiki/nix.org
+++ b/docs/wiki/nix.org
@@ -38,6 +38,30 @@ OpenCode, Claude, and generic Agent Skills user paths (including the
 changes in the skills repository; this dotfiles repository only selects the input
 revision and enables the client adapters.
 
+* GPT TODO synchronization
+[[file:../../nix/home-manager/mods/gpt-todos.nix][gpt-todos.nix]] installs the
+shared =gpt-todos-sync= command and enables a systemd user timer by default when
+Emacs is enabled.  The timer runs the same locked synchronization path used by
+the Doom after-save hook, so periodic and interactive synchronization serialize
+rather than racing.
+
+The defaults are:
+- durable checkout: =~/Documents/gpt-todos=;
+- live agenda tree: =~/Documents/Notes/org/agenda=;
+- background interval: =5m=.
+
+They are configurable through =gptTodos.repoDir=, =gptTodos.orgDir=, and
+=gptTodos.syncInterval=.  Check the timer with:
+
+#+begin_src shell
+  systemctl --user status gpt-todos-sync.timer
+  systemctl --user list-timers gpt-todos-sync.timer
+#+end_src
+
+The old cron installer remains only as a compatibility path for machines not
+managed by Home Manager.  The canonical synchronization behavior lives in
+[[file:../../scripts/gpt-todos-sync.org][scripts/gpt-todos-sync.org]].
+
 * Installer applications
 The flake exposes =install-logos= and =install-logos-gui=.  Their shell implementations live under [[file:../../scripts/][scripts/]].
 

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -9,6 +9,7 @@
     ./gnome.nix
     ./fonts.nix
     ./emacs.nix
+    ./gpt-todos.nix
     ./security.nix
     ./nim.nix
     ./lisp.nix

--- a/nix/home-manager/mods/gpt-todos.nix
+++ b/nix/home-manager/mods/gpt-todos.nix
@@ -1,12 +1,15 @@
 { lib, pkgs, config, ... }:
 
 let
+  cfg = config.gptTodos;
+
   gptTodosSync = pkgs.writeShellApplication {
     name = "gpt-todos-sync";
     runtimeInputs = [
       pkgs.coreutils
       pkgs.findutils
       pkgs.git
+      pkgs.openssh
       pkgs.rsync
       pkgs.util-linux
       pkgs.cronie
@@ -22,16 +25,69 @@ let
   };
 in
 {
-  options.gptTodos.enable = lib.mkOption {
-    type = lib.types.bool;
-    default = true;
-    description = "Install GPT TODO Org synchronization commands.";
+  options.gptTodos = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Install and run GPT TODO Org synchronization.";
+    };
+
+    repoDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/Documents/gpt-todos";
+      description = "Durable lost-rob0t/gpt-todos checkout.";
+    };
+
+    orgDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/Documents/Notes/org/agenda";
+      description = "Live recursive Org agenda tree synchronized with gpt-todos.";
+    };
+
+    syncInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "5m";
+      description = "Interval between background GPT TODO synchronization runs.";
+    };
   };
 
-  config = lib.mkIf (config.emacs.enable && config.gptTodos.enable) {
+  config = lib.mkIf (config.emacs.enable && cfg.enable) {
     home.packages = [
       gptTodosSync
       installGptTodosCron
     ];
+
+    home.sessionVariables = {
+      GPT_TODOS_SYNC = "${gptTodosSync}/bin/gpt-todos-sync";
+      GPT_TODOS_REPO_DIR = cfg.repoDir;
+      GPT_TODOS_ORG_DIR = cfg.orgDir;
+    };
+
+    systemd.user.services.gpt-todos-sync = {
+      Unit = {
+        Description = "Synchronize durable GPT TODO Org agenda";
+        Wants = [ "network-online.target" ];
+        After = [ "network-online.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${gptTodosSync}/bin/gpt-todos-sync";
+        Environment = [
+          "GPT_TODOS_REPO_DIR=${cfg.repoDir}"
+          "GPT_TODOS_ORG_DIR=${cfg.orgDir}"
+        ];
+      };
+    };
+
+    systemd.user.timers.gpt-todos-sync = {
+      Unit.Description = "Synchronize GPT TODO agenda every ${cfg.syncInterval}";
+      Timer = {
+        OnBootSec = "2m";
+        OnUnitActiveSec = cfg.syncInterval;
+        AccuracySec = "15s";
+        Unit = "gpt-todos-sync.service";
+      };
+      Install.WantedBy = [ "timers.target" ];
+    };
   };
 }

--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -9,6 +9,13 @@ DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
 LOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}"
 [[ -d "$LOCK_DIR" ]] || LOCK_DIR=/tmp
 LOCK="$LOCK_DIR/gpt-todos-sync-${UID}.lock"
+RECOVERY_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gpt-todos-sync/recovery"
+
+SAVE_FILE=""
+SAVE_REL=""
+SAVE_BACKUP=""
+SAVE_ALIASED=0
+SAVE_REWOUND=0
 
 export GIT_TERMINAL_PROMPT=0
 if [[ -z "${GIT_SSH_COMMAND:-}" ]]; then
@@ -45,16 +52,97 @@ if [[ "${1:-}" == "--deploy" ]]; then
   printf 'gpt-todos sync deployed: %s -> %s every %s minutes\n' \
     "$TASK_DIR" "$ORG_DIR" "$minutes"
   exit 0
+elif [[ "${1:-}" == "--file" ]]; then
+  [[ $# -eq 2 ]] || { echo "usage: $0 --file AGENDA_FILE" >&2; exit 2; }
+  SAVE_FILE="$2"
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--file AGENDA_FILE | --deploy [minutes>=5]]" >&2
+  exit 2
 fi
 
+on_exit() {
+  local rc=$?
+  trap - EXIT
+  set +e
+
+  if [[ -n "$SAVE_BACKUP" && -f "$SAVE_BACKUP" ]]; then
+    if (( rc == 0 )); then
+      rm -f -- "$SAVE_BACKUP"
+    else
+      if (( SAVE_ALIASED && SAVE_REWOUND )); then
+        mkdir -p -- "$(dirname "$REPO_DIR/$SAVE_REL")"
+        cp -p -- "$SAVE_BACKUP" "$REPO_DIR/$SAVE_REL"
+      fi
+
+      mkdir -p -- "$RECOVERY_DIR"
+      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      safe_rel="${SAVE_REL//\//__}"
+      recovery="$RECOVERY_DIR/${stamp}-${safe_rel:-agenda-save.org}"
+      mv -- "$SAVE_BACKUP" "$recovery"
+      printf 'gpt-todos-sync: save preserved at %s\n' "$recovery" >&2
+    fi
+  fi
+
+  exit "$rc"
+}
+trap on_exit EXIT
+
 mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
+
+if [[ -n "$SAVE_FILE" ]]; then
+  org_root="$(realpath -m -s -- "$ORG_DIR")"
+  save_logical="$(realpath -m -s -- "$SAVE_FILE")"
+  case "$save_logical" in
+    "$org_root"/*.org) ;;
+    *)
+      printf 'gpt-todos-sync: --file must be an .org file below %s: %s\n' \
+        "$ORG_DIR" "$SAVE_FILE" >&2
+      exit 2
+      ;;
+  esac
+  [[ -f "$save_logical" ]] || {
+    printf 'gpt-todos-sync: saved agenda file does not exist: %s\n' "$save_logical" >&2
+    exit 2
+  }
+
+  SAVE_FILE="$save_logical"
+  SAVE_REL="agenda/${SAVE_FILE#"$org_root/"}"
+  tmp_root="${TMPDIR:-/tmp}"
+  [[ -d "$tmp_root" ]] || tmp_root=/tmp
+  SAVE_BACKUP="$(mktemp "$tmp_root/gpt-todos-sync-${UID}-XXXXXX.org")"
+  cp -p -- "$SAVE_FILE" "$SAVE_BACKUP"
+fi
+
 exec 9>"$LOCK"
-flock -n 9 || exit 0
+flock 9
 
 if [[ ! -d "$REPO_DIR/.git" ]]; then
   git clone "$REMOTE" "$REPO_DIR"
 fi
 mkdir -p "$TASK_DIR"
+
+prepare_aliased_save() {
+  [[ -n "$SAVE_REL" ]] || return 0
+
+  local target="$REPO_DIR/$SAVE_REL"
+  [[ -e "$target" ]] || return 0
+  [[ "$SAVE_FILE" -ef "$target" ]] || return 0
+
+  SAVE_ALIASED=1
+
+  if ! git -C "$REPO_DIR" diff --cached --quiet -- "$SAVE_REL"; then
+    printf 'gpt-todos-sync: saved alias is already staged; refusing to discard index state: %s\n' \
+      "$SAVE_REL" >&2
+    return 6
+  fi
+
+  if git -C "$REPO_DIR" ls-files --error-unmatch -- "$SAVE_REL" >/dev/null 2>&1; then
+    git -C "$REPO_DIR" restore --worktree --source=HEAD -- "$SAVE_REL"
+  else
+    rm -f -- "$target"
+  fi
+  SAVE_REWOUND=1
+}
 
 sync_literate_pair() {
   local src="$1"; shift
@@ -181,6 +269,7 @@ list_local_org_paths() {
   done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
 }
 
+prepare_aliased_save
 sync_dotfiles_literate
 repair_legacy_imports
 
@@ -203,6 +292,7 @@ mapfile -t org_paths < <(
     list_org_paths "$BASE"
     list_org_paths "$REMOTE_HEAD"
     list_local_org_paths
+    [[ -z "$SAVE_REL" ]] || printf '%s\n' "$SAVE_REL"
   } | sort -u
 )
 
@@ -217,9 +307,14 @@ conflicts=0
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
   org_file="$ORG_DIR/$local_rel"
+  local_source="$org_file"
+  if [[ -n "$SAVE_REL" && "$rel" == "$SAVE_REL" ]]; then
+    local_source="$SAVE_BACKUP"
+  fi
+
   base_hash="$(blob_at "$BASE" "$rel")"
   remote_hash="$(blob_at "$REMOTE_HEAD" "$rel")"
-  local_hash="$(file_blob "$org_file")"
+  local_hash="$(file_blob "$local_source")"
 
   if [[ "$base_hash" != "-" && "$remote_hash" == "-" ]]; then
     printf 'gpt-todos-sync: remote deletion requires manual resolution: %s\n' "$rel" >&2
@@ -263,8 +358,12 @@ git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
 
 for rel in "${local_changes[@]}"; do
   local_rel="${rel#agenda/}"
+  local_source="$ORG_DIR/$local_rel"
+  if [[ -n "$SAVE_REL" && "$rel" == "$SAVE_REL" ]]; then
+    local_source="$SAVE_BACKUP"
+  fi
   mkdir -p "$(dirname "$REPO_DIR/$rel")"
-  copy_if_distinct "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
+  copy_if_distinct "$local_source" "$REPO_DIR/$rel"
 done
 
 if ((${#local_changes[@]})); then
@@ -286,3 +385,5 @@ for rel in "${org_paths[@]}"; do
   mkdir -p "$(dirname "$ORG_DIR/$local_rel")"
   copy_if_distinct "$REPO_DIR/$rel" "$ORG_DIR/$local_rel"
 done
+
+SAVE_REWOUND=0

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -20,10 +20,22 @@ path is a symlink or other alias that already resolves to the durable file, that
 path is treated as synchronized instead of invoking =cp= on the same inode.
 The default durable checkout is =~/Documents/gpt-todos=.
 
-The same command also owns deployment.  Run =gpt-todos-sync --deploy 5= to
-perform the initial sync and install the five-minute cron entry.  Git operations
-are deliberately non-interactive for cron use; automated commits disable GPG
-signing so a pinentry prompt cannot wedge synchronization.
+Doom invokes =gpt-todos-sync --file FILE= after saving an Org file below the
+live agenda directory.  File mode first copies the exact saved contents to a
+private temporary file.  If the live file is a symlink into the durable checkout,
+the helper temporarily restores only that owned durable path to =HEAD= so the
+upstream fast-forward can happen on a clean worktree.  It then uses the temporary
+snapshot as the local side, restores it after the pull, commits, and pushes.  A
+failure restores an aliased save to disk and retains a recovery copy under
+=$XDG_STATE_HOME/gpt-todos-sync/recovery= (or =~/.local/state=).  The shared
+=flock= is blocking, so Emacs saves and the Home Manager timer serialize instead
+of racing or silently skipping one another.
+
+Home Manager installs =gpt-todos-sync= and runs the same command from a systemd
+user timer every five minutes.  The older =--deploy= / cron installer remains as
+a compatibility path for non-Home-Manager machines.  Git operations are
+non-interactive; automated commits disable GPG signing so a pinentry prompt
+cannot wedge synchronization.
 
 #+begin_src sh :tangle ./gpt-todos-sync :results none
 #!/usr/bin/env bash
@@ -37,6 +49,13 @@ DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
 LOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}"
 [[ -d "$LOCK_DIR" ]] || LOCK_DIR=/tmp
 LOCK="$LOCK_DIR/gpt-todos-sync-${UID}.lock"
+RECOVERY_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gpt-todos-sync/recovery"
+
+SAVE_FILE=""
+SAVE_REL=""
+SAVE_BACKUP=""
+SAVE_ALIASED=0
+SAVE_REWOUND=0
 
 export GIT_TERMINAL_PROMPT=0
 if [[ -z "${GIT_SSH_COMMAND:-}" ]]; then
@@ -73,16 +92,97 @@ if [[ "${1:-}" == "--deploy" ]]; then
   printf 'gpt-todos sync deployed: %s -> %s every %s minutes\n' \
     "$TASK_DIR" "$ORG_DIR" "$minutes"
   exit 0
+elif [[ "${1:-}" == "--file" ]]; then
+  [[ $# -eq 2 ]] || { echo "usage: $0 --file AGENDA_FILE" >&2; exit 2; }
+  SAVE_FILE="$2"
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--file AGENDA_FILE | --deploy [minutes>=5]]" >&2
+  exit 2
 fi
 
+on_exit() {
+  local rc=$?
+  trap - EXIT
+  set +e
+
+  if [[ -n "$SAVE_BACKUP" && -f "$SAVE_BACKUP" ]]; then
+    if (( rc == 0 )); then
+      rm -f -- "$SAVE_BACKUP"
+    else
+      if (( SAVE_ALIASED && SAVE_REWOUND )); then
+        mkdir -p -- "$(dirname "$REPO_DIR/$SAVE_REL")"
+        cp -p -- "$SAVE_BACKUP" "$REPO_DIR/$SAVE_REL"
+      fi
+
+      mkdir -p -- "$RECOVERY_DIR"
+      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      safe_rel="${SAVE_REL//\//__}"
+      recovery="$RECOVERY_DIR/${stamp}-${safe_rel:-agenda-save.org}"
+      mv -- "$SAVE_BACKUP" "$recovery"
+      printf 'gpt-todos-sync: save preserved at %s\n' "$recovery" >&2
+    fi
+  fi
+
+  exit "$rc"
+}
+trap on_exit EXIT
+
 mkdir -p "$(dirname "$REPO_DIR")" "$ORG_DIR"
+
+if [[ -n "$SAVE_FILE" ]]; then
+  org_root="$(realpath -m -s -- "$ORG_DIR")"
+  save_logical="$(realpath -m -s -- "$SAVE_FILE")"
+  case "$save_logical" in
+    "$org_root"/*.org) ;;
+    *)
+      printf 'gpt-todos-sync: --file must be an .org file below %s: %s\n' \
+        "$ORG_DIR" "$SAVE_FILE" >&2
+      exit 2
+      ;;
+  esac
+  [[ -f "$save_logical" ]] || {
+    printf 'gpt-todos-sync: saved agenda file does not exist: %s\n' "$save_logical" >&2
+    exit 2
+  }
+
+  SAVE_FILE="$save_logical"
+  SAVE_REL="agenda/${SAVE_FILE#"$org_root/"}"
+  tmp_root="${TMPDIR:-/tmp}"
+  [[ -d "$tmp_root" ]] || tmp_root=/tmp
+  SAVE_BACKUP="$(mktemp "$tmp_root/gpt-todos-sync-${UID}-XXXXXX.org")"
+  cp -p -- "$SAVE_FILE" "$SAVE_BACKUP"
+fi
+
 exec 9>"$LOCK"
-flock -n 9 || exit 0
+flock 9
 
 if [[ ! -d "$REPO_DIR/.git" ]]; then
   git clone "$REMOTE" "$REPO_DIR"
 fi
 mkdir -p "$TASK_DIR"
+
+prepare_aliased_save() {
+  [[ -n "$SAVE_REL" ]] || return 0
+
+  local target="$REPO_DIR/$SAVE_REL"
+  [[ -e "$target" ]] || return 0
+  [[ "$SAVE_FILE" -ef "$target" ]] || return 0
+
+  SAVE_ALIASED=1
+
+  if ! git -C "$REPO_DIR" diff --cached --quiet -- "$SAVE_REL"; then
+    printf 'gpt-todos-sync: saved alias is already staged; refusing to discard index state: %s\n' \
+      "$SAVE_REL" >&2
+    return 6
+  fi
+
+  if git -C "$REPO_DIR" ls-files --error-unmatch -- "$SAVE_REL" >/dev/null 2>&1; then
+    git -C "$REPO_DIR" restore --worktree --source=HEAD -- "$SAVE_REL"
+  else
+    rm -f -- "$target"
+  fi
+  SAVE_REWOUND=1
+}
 
 sync_literate_pair() {
   local src="$1"; shift
@@ -209,6 +309,7 @@ list_local_org_paths() {
   done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
 }
 
+prepare_aliased_save
 sync_dotfiles_literate
 repair_legacy_imports
 
@@ -231,6 +332,7 @@ mapfile -t org_paths < <(
     list_org_paths "$BASE"
     list_org_paths "$REMOTE_HEAD"
     list_local_org_paths
+    [[ -z "$SAVE_REL" ]] || printf '%s\n' "$SAVE_REL"
   } | sort -u
 )
 
@@ -245,9 +347,14 @@ conflicts=0
 for rel in "${org_paths[@]}"; do
   local_rel="${rel#agenda/}"
   org_file="$ORG_DIR/$local_rel"
+  local_source="$org_file"
+  if [[ -n "$SAVE_REL" && "$rel" == "$SAVE_REL" ]]; then
+    local_source="$SAVE_BACKUP"
+  fi
+
   base_hash="$(blob_at "$BASE" "$rel")"
   remote_hash="$(blob_at "$REMOTE_HEAD" "$rel")"
-  local_hash="$(file_blob "$org_file")"
+  local_hash="$(file_blob "$local_source")"
 
   if [[ "$base_hash" != "-" && "$remote_hash" == "-" ]]; then
     printf 'gpt-todos-sync: remote deletion requires manual resolution: %s\n' "$rel" >&2
@@ -291,8 +398,12 @@ git -C "$REPO_DIR" merge --ff-only "$REMOTE_HEAD"
 
 for rel in "${local_changes[@]}"; do
   local_rel="${rel#agenda/}"
+  local_source="$ORG_DIR/$local_rel"
+  if [[ -n "$SAVE_REL" && "$rel" == "$SAVE_REL" ]]; then
+    local_source="$SAVE_BACKUP"
+  fi
   mkdir -p "$(dirname "$REPO_DIR/$rel")"
-  copy_if_distinct "$ORG_DIR/$local_rel" "$REPO_DIR/$rel"
+  copy_if_distinct "$local_source" "$REPO_DIR/$rel"
 done
 
 if ((${#local_changes[@]})); then
@@ -314,12 +425,15 @@ for rel in "${org_paths[@]}"; do
   mkdir -p "$(dirname "$ORG_DIR/$local_rel")"
   copy_if_distinct "$REPO_DIR/$rel" "$ORG_DIR/$local_rel"
 done
+
+SAVE_REWOUND=0
 #+end_src
 
 * Cron installer
 
-GitHub-backed task synchronization should not hammer the service.  The helper
-therefore enforces a minimum interval of five minutes.
+The Home Manager module uses a systemd user timer.  This cron installer is kept
+for non-Home-Manager systems and still enforces a minimum interval of five
+minutes.
 
 #+begin_src sh :tangle ./install-gpt-todos-cron :results none
 #!/usr/bin/env bash

--- a/tests/gpt-todos-sync.sh
+++ b/tests/gpt-todos-sync.sh
@@ -11,8 +11,9 @@ SEED="$TMP/seed"
 REPO="$TMP/durable"
 ORG="$TMP/org"
 RUN="$TMP/run"
+STATE="$TMP/state"
 
-mkdir -p "$ORG" "$RUN"
+mkdir -p "$ORG" "$RUN" "$STATE"
 git init --bare "$REMOTE" >/dev/null
 git clone "$REMOTE" "$SEED" >/dev/null 2>&1
 mkdir -p "$SEED/agenda"
@@ -27,6 +28,7 @@ git -C "$SEED" push -u origin HEAD >/dev/null 2>&1
 run_sync() {
   HOME="$TMP/home" \
   XDG_RUNTIME_DIR="$RUN" \
+  XDG_STATE_HOME="$STATE" \
   DOTFILES_DIR="$TMP/no-dotfiles" \
   GPT_TODOS_REPO_DIR="$REPO" \
   GPT_TODOS_ORG_DIR="$ORG" \
@@ -35,7 +37,7 @@ run_sync() {
   GIT_AUTHOR_EMAIL=test@example.invalid \
   GIT_COMMITTER_NAME=test \
   GIT_COMMITTER_EMAIL=test@example.invalid \
-    bash "$SYNC"
+    bash "$SYNC" "$@"
 }
 
 # Initial remote state is restored into the complete local agenda tree.
@@ -75,14 +77,20 @@ git -C "$SEED" push >/dev/null 2>&1
 run_sync
 grep -q 'remote-change' "$ORG/remote.org"
 
-# Agenda files may be symlinked into the live tree. If a live path resolves to
-# the durable file itself, deployment must treat it as already synchronized
-# instead of asking cp to copy a file onto the same inode.
+# Agenda files may be symlinked into the live tree. Saving through that symlink
+# dirties the durable checkout itself. --file must snapshot the just-written
+# contents, temporarily clear only that owned path, pull, restore the snapshot,
+# commit, and push without losing the symlink or touching unrelated paths.
 rm -- "$ORG/remote.org"
 ln -s "$REPO/agenda/remote.org" "$ORG/remote.org"
-run_sync
+printf '* DONE emacs-save\n' > "$ORG/remote.org"
+[[ -n "$(git -C "$REPO" status --porcelain -- agenda/remote.org)" ]]
+run_sync --file "$ORG/remote.org"
 [[ -L "$ORG/remote.org" ]]
-grep -q 'remote-change' "$ORG/remote.org"
+git -C "$SEED" pull >/dev/null 2>&1
+grep -q 'emacs-save' "$SEED/agenda/remote.org"
+grep -q 'emacs-save' "$ORG/remote.org"
+[[ -z "$(git -C "$REPO" status --porcelain -- agenda)" ]]
 
 # Concurrent edits remain fail-closed.
 printf '* TODO local-conflict\n' > "$ORG/shared.org"

--- a/tests/gpt-todos-sync.sh
+++ b/tests/gpt-todos-sync.sh
@@ -92,6 +92,34 @@ grep -q 'emacs-save' "$SEED/agenda/remote.org"
 grep -q 'emacs-save' "$ORG/remote.org"
 [[ -z "$(git -C "$REPO" status --porcelain -- agenda)" ]]
 
+# A true same-file remote conflict must never eat the Emacs save. Save mode
+# rewinds the aliased durable path only long enough to inspect/pull. When both
+# sides changed from the same baseline, it fails closed, restores the exact
+# local save to the symlink target, and leaves a recovery copy in user state.
+printf '* DONE remote-conflict-save\n' > "$SEED/agenda/remote.org"
+git -C "$SEED" add agenda/remote.org
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -m remote-conflict-save >/dev/null
+git -C "$SEED" push >/dev/null 2>&1
+printf '* TODO local-conflict-save\n' > "$ORG/remote.org"
+
+set +e
+run_sync --file "$ORG/remote.org"
+save_conflict_rc=$?
+set -e
+[[ "$save_conflict_rc" -eq 5 ]]
+[[ -L "$ORG/remote.org" ]]
+grep -q 'local-conflict-save' "$ORG/remote.org"
+grep -q 'local-conflict-save' "$REPO/agenda/remote.org"
+find "$STATE/gpt-todos-sync/recovery" -type f -name '*agenda__remote.org' \
+  -exec grep -q 'local-conflict-save' {} \; -print | grep -q .
+
+# Put the fixture back on the last committed baseline, then prove a normal run
+# can consume the pending remote side after the user resolves/discards local.
+git -C "$REPO" restore --worktree --source=HEAD -- agenda/remote.org
+run_sync
+grep -q 'remote-conflict-save' "$ORG/remote.org"
+
 # Concurrent edits remain fail-closed.
 printf '* TODO local-conflict\n' > "$ORG/shared.org"
 git -C "$SEED" pull >/dev/null 2>&1


### PR DESCRIPTION
## What

- add `gpt-todos-sync --file FILE` for save-safe agenda synchronization
- snapshot the just-written Org file before touching Git state
- handle live agenda symlinks into the durable checkout by rewinding only the saved path, pulling, restoring the snapshot, committing, and pushing
- keep concurrent local/remote edits fail-closed with recovery copies
- serialize Emacs saves and periodic runs through the existing shared lock
- add a Doom after-save hook for `.org` files under the live agenda tree
- enable the existing Home Manager GPT TODO module and add a systemd user timer every 5 minutes
- add regression coverage for save-through-symlink behavior
- document the Emacs + Home Manager workflow

## Safety

Unrelated dirty agenda state is never reset or committed. A failed save-mode sync restores the aliased save and retains a recovery copy under the user state directory.
