### PR TITLE
zara: bump to wake-words release, pin autostart STT to amd/base.en

### DIFF
--- a/.config/qtile/scripts/autostart.sh
+++ b/.config/qtile/scripts/autostart.sh
@@ -129,4 +129,4 @@ run brave
 run python3 /home/unseen/.dotfiles/.config/qtile/scripts/pinger.py -c "$HOME/.config/hosts.toml"
 run kdeconnect-indicator
 run aw-qt
-run zara-wake
+run zara-wake --stt-provider faster-whisper --device amd --model base.en

--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788000335,
-        "narHash": "sha256-8r9mjVgvDPCdg/PcfvKGaFv8C1Ln5jBqKHx87w2VNtY=",
+        "lastModified": 1788056875,
+        "narHash": "sha256-AhATJYLFh6dzaNyszKOZ+sj4wVj7KbLY3aDH0U/O+hk=",
         "owner": "lost-rob0t",
         "repo": "zara",
-        "rev": "cea85d3c523e5690170f7a40bce0da5303bce9f0",
+        "rev": "ad2f43d2cfe914f1ac1c2b06f9048d477a2d4c9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bump the `zara` flake input `cea85d3c` -> `ad2f43d` (adds "Zarathushtra" wake word with edit-distance matching, configurable wake words via `[wake].words` / `kb_config:wake_word/1`)
- Auto-launched `zara-wake` now pins the voice pipeline explicitly: `--stt-provider faster-whisper --device amd --model base.en`, so the AMD GPU + base.en model are guaranteed at startup regardless of user config drift

## Validation
- `bash -n` on autostart.sh
- `nix flake update zara` re-lock verified (diff touches only the `zara` input)
- `zara-wake` builds at `ad2f43d` and the built package contains the new wake-word sources
- Home Manager `unseen@flake` activation build is currently red repo-wide from the pre-existing `llm-log` pinned-rev test failure (root cause in lost-rob0t/llm-log#21, tracked in #146; the updater hit the identical failure on master 2026-08-29). Unrelated to this PR.

## Notes
- `~/.config/zarathushtra/config.toml` is hand-managed (not HM-owned); `[stt] model` and `[dictate] model/device` are updated out-of-band to `base.en`/`amd` so runtime defaults match the autostart pin
- TTS in zara is cloud/HTTP (11labs/edge/qwen3-server) and has no local GPU path; the AMD device applies to the whisper transcription paths (wake STT + dictation)