### PR TITLE
llm-log: bump pinned rev to websocket-test fix

### DIFF
--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "3e957799d842f058a8ce53b8f675773fc2cde5ef";
+  llmLogRevision = "94b79dccd9010b429eff0472c74391fa50b4db0a";
   llmLogSource = builtins.fetchGit {
     url = "https://github.com/lost-rob0t/llm-log.git";
     rev = llmLogRevision;


### PR DESCRIPTION
## Summary
- Bump `llmLogRevision` `3e95779` -> `94b79dc` (llm-log PR #22 repairs the stale WebSocket envelope assertions from llm-log#21)

## Validation
- `nix build .#checks.x86_64-linux.unseen-flake-home` green for the first time since 2026-08-29 (unblocks #146)
- Verified the built generation contains: `llm-log.service` (default.target.wants), opencode.json provider baseURLs through 127.0.0.1:8787 (openai/openrouter/anthropic), and zara-wake at ad2f43d