### PR TITLE
codex: own codex skills in a local HM module

### DIFF
--- a/nix/home-manager/mods/codex.nix
+++ b/nix/home-manager/mods/codex.nix
@@ -1,0 +1,36 @@
+{ config, lib, inputs, ... }:
+
+let
+  cfg = config.codex;
+
+  skillsSource = inputs.skills;
+  availableSkills = builtins.attrNames (
+    lib.filterAttrs (_: entryType: entryType == "directory") (
+      builtins.readDir "${skillsSource}/skills"
+    )
+  );
+in
+{
+  options.codex = {
+    enable = lib.mkEnableOption "codex CLI integration with declaratively managed skills";
+
+    skills = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = availableSkills;
+      description = ''
+        Skills from the skills flake input to link into ~/.codex/skills.
+        Defaults to every skill directory in the pinned input; local-only
+        skills that are not part of the input are left untouched.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.file = lib.listToAttrs (
+      map (name: {
+        name = ".codex/skills/${name}";
+        value = { source = "${skillsSource}/skills/${name}"; };
+      }) cfg.skills
+    );
+  };
+}

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -4,7 +4,7 @@
     inputs.skills.homeManagerModules.opencode
     inputs.skills.homeManagerModules.claude
     inputs.skills.homeManagerModules.agents
-    inputs.skills.homeManagerModules.codex
+    ./codex.nix
     ./base.nix
     ./desktop.nix
     ./gnome.nix


### PR DESCRIPTION
## Summary
- Add `nix/home-manager/mods/codex.nix`: declaratively links every skill from the pinned `skills` flake input into `~/.codex/skills` (option `codex.enable` / `codex.skills`, local-only skills untouched)
- Drop the upstream `inputs.skills.homeManagerModules.codex` import that collided with hand-managed skill links and blocked `home-manager switch`

## Validation
- `nix build .#checks.x86_64-linux.unseen-flake-home` green; built generation contains `.codex/skills/*` store links
- Pre-existing hand-managed state backed up to `~/.local/share/codex-skills-pre-hm-20260830.tar.gz` before takeover