### PR TITLE
codex: manage skills unconditionally when module is imported

### DIFF
--- a/nix/home-manager/mods/codex.nix
+++ b/nix/home-manager/mods/codex.nix
@@ -1,8 +1,6 @@
 { config, lib, inputs, ... }:
 
 let
-  cfg = config.codex;
-
   skillsSource = inputs.skills;
   availableSkills = builtins.attrNames (
     lib.filterAttrs (_: entryType: entryType == "directory") (
@@ -11,26 +9,20 @@ let
   );
 in
 {
-  options.codex = {
-    enable = lib.mkEnableOption "codex CLI integration with declaratively managed skills";
-
-    skills = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = availableSkills;
-      description = ''
-        Skills from the skills flake input to link into ~/.codex/skills.
-        Defaults to every skill directory in the pinned input; local-only
-        skills that are not part of the input are left untouched.
-      '';
-    };
+  options.codex.skills = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = availableSkills;
+    description = ''
+      Skills from the skills flake input to link into ~/.codex/skills.
+      Defaults to every skill directory in the pinned input; local-only
+      skills that are not part of the input are left untouched.
+    '';
   };
 
-  config = lib.mkIf cfg.enable {
-    home.file = lib.listToAttrs (
-      map (name: {
-        name = ".codex/skills/${name}";
-        value = { source = "${skillsSource}/skills/${name}"; };
-      }) cfg.skills
-    );
-  };
+  config.home.file = lib.listToAttrs (
+    map (name: {
+      name = ".codex/skills/${name}";
+      value = { source = "${skillsSource}/skills/${name}"; };
+    }) config.codex.skills
+  );
 }


### PR DESCRIPTION
Follow-up to #169: the `codex.enable` gate had no enabler so the module linked nothing. Import now owns skills unconditionally, matching the upstream module it replaces. Verified the built generation contains all 34 `.codex/skills` store links.