### PR TITLE
openrouter: minute and year periods with YTD running total

### DIFF
--- a/.config/qtile/qtile-openrouter.org
+++ b/.config/qtile/qtile-openrouter.org
@@ -326,7 +326,7 @@ def _stats_text(payload, label, series, history_info):
             lines.append("balance ${:.2f}".format(float(payload["balance_usd"])))
         tokens = payload.get("tokens_hour")
         if tokens is not None:
-            lines.append("tokens hour/day/week {}".format(_compact_count(tokens)))
+            lines.append("tokens hour {}".format(_compact_count(tokens)))
         spend = payload.get("spend_day")
         if spend is not None:
             lines.append("spend day ${:.2f}".format(float(spend)))
@@ -436,9 +436,21 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         self.index = 0
         self.last_rotate = time.monotonic()
         self.specs = (
-            (("M", "tokens_month"), ("W", "tokens_week"), ("D", "tokens_day"), ("H", "tokens_hour"))
+            (
+                ("m", "tokens_minute"),
+                ("H", "tokens_hour"),
+                ("D", "tokens_day"),
+                ("W", "tokens_week"),
+                ("M", "tokens_month"),
+                ("Y", "tokens_year"),
+            )
             if metric == "tokens"
-            else (("D", "spend_day"), ("W", "spend_week"), ("M", "spend_month"))
+            else (
+                ("D", "spend_day"),
+                ("W", "spend_week"),
+                ("M", "spend_month"),
+                ("Y", "spend_year"),
+            )
         )
         self.icon = "" if metric == "tokens" else ""
         super().__init__(text=f"{self.icon} …", **config)

--- a/.config/qtile/qtile_openrouter.py
+++ b/.config/qtile/qtile_openrouter.py
@@ -300,7 +300,7 @@ def _stats_text(payload, label, series, history_info):
             lines.append("balance ${:.2f}".format(float(payload["balance_usd"])))
         tokens = payload.get("tokens_hour")
         if tokens is not None:
-            lines.append("tokens hour/day/week {}".format(_compact_count(tokens)))
+            lines.append("tokens hour {}".format(_compact_count(tokens)))
         spend = payload.get("spend_day")
         if spend is not None:
             lines.append("spend day ${:.2f}".format(float(spend)))
@@ -410,9 +410,21 @@ class OpenRouterRotatingMetric(base.BackgroundPoll):
         self.index = 0
         self.last_rotate = time.monotonic()
         self.specs = (
-            (("M", "tokens_month"), ("W", "tokens_week"), ("D", "tokens_day"), ("H", "tokens_hour"))
+            (
+                ("m", "tokens_minute"),
+                ("H", "tokens_hour"),
+                ("D", "tokens_day"),
+                ("W", "tokens_week"),
+                ("M", "tokens_month"),
+                ("Y", "tokens_year"),
+            )
             if metric == "tokens"
-            else (("D", "spend_day"), ("W", "spend_week"), ("M", "spend_month"))
+            else (
+                ("D", "spend_day"),
+                ("W", "spend_week"),
+                ("M", "spend_month"),
+                ("Y", "spend_year"),
+            )
         )
         self.icon = "" if metric == "tokens" else ""
         super().__init__(text=f"{self.icon} …", **config)

--- a/.config/qtile/scripts/openrouter_status.py
+++ b/.config/qtile/scripts/openrouter_status.py
@@ -58,9 +58,12 @@ class Status:
     tokens_week: int | None = None
     tokens_day: int | None = None
     tokens_hour: int | None = None
+    tokens_minute: int | None = None
+    tokens_year: int | None = None
     spend_month: float | None = None
     spend_week: float | None = None
     spend_day: float | None = None
+    spend_year: float | None = None
     usage_fetched_at: str | None = None
     balance_fetched_at: str | None = None
     usage_error: str | None = None
@@ -257,10 +260,12 @@ def fetch_tokens(key: str, start: datetime, end: datetime) -> tuple[int, int]:
     return parse_token_totals(_request_json("POST", "/analytics/query", key, payload))
 
 
-def fetch_usage_range(key: str, start: datetime, end: datetime) -> tuple[int, float]:
+def fetch_usage_range(
+    key: str, start: datetime, end: datetime, granularity: str = "hour"
+) -> tuple[int, float]:
     payload = {
         "metrics": ["tokens_total", "total_usage"],
-        "granularity": "hour",
+        "granularity": granularity,
         "time_range": {
             "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
             "end": end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -322,7 +327,8 @@ def period_starts(now: datetime | None = None) -> dict[str, datetime]:
     hour = now.replace(minute=0, second=0, microsecond=0)
     week = day - timedelta(days=day.weekday())
     month = day.replace(day=1)
-    return {"month": month, "week": week, "day": day, "hour": hour}
+    year = day.replace(month=1, day=1)
+    return {"month": month, "week": week, "day": day, "hour": hour, "year": year}
 
 
 def fetch_period_totals(key: str, now: datetime | None = None) -> dict[str, float | int]:
@@ -331,17 +337,25 @@ def fetch_period_totals(key: str, now: datetime | None = None) -> dict[str, floa
     elif now.tzinfo is None:
         now = now.astimezone()
     starts = period_starts(now)
-    periods = ("month", "week", "day", "hour")
+    minute_start, minute_end = _closed_minute_window(now)
+    windows: dict[str, tuple[datetime, datetime, str]] = {
+        "minute": (minute_start, minute_end, "minute"),
+        "hour": (starts["hour"], now, "hour"),
+        "day": (starts["day"], now, "hour"),
+        "week": (starts["week"], now, "hour"),
+        "month": (starts["month"], now, "hour"),
+        "year": (starts["year"], now, "hour"),
+    }
     result: dict[str, float | int] = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(periods)) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(windows)) as executor:
         futures = {
-            period: executor.submit(fetch_usage_range, key, starts[period], now)
-            for period in periods
+            period: executor.submit(fetch_usage_range, key, start, end, granularity)
+            for period, (start, end, granularity) in windows.items()
         }
-        for period in periods:
-            tokens, spend = futures[period].result()
+        for period, future in futures.items():
+            tokens, spend = future.result()
             result[f"tokens_{period}"] = tokens
-            if period != "hour":
+            if period not in ("hour", "minute"):
                 result[f"spend_{period}"] = spend
     return result
 

--- a/.config/qtile/tests/test_openrouter_status.py
+++ b/.config/qtile/tests/test_openrouter_status.py
@@ -60,6 +60,7 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(starts["week"], MODULE.datetime(2026, 8, 17, tzinfo=tz))
         self.assertEqual(starts["day"], MODULE.datetime(2026, 8, 22, tzinfo=tz))
         self.assertEqual(starts["hour"], MODULE.datetime(2026, 8, 22, 18, tzinfo=tz))
+        self.assertEqual(starts["year"], MODULE.datetime(2026, 1, 1, tzinfo=tz))
 
     def test_fetch_usage_range_uses_supported_metrics(self):
         start = MODULE.datetime(2026, 8, 22, tzinfo=MODULE.timezone.utc)
@@ -71,16 +72,32 @@ class OpenRouterStatusTests(unittest.TestCase):
         self.assertEqual(query["metrics"], ["tokens_total", "total_usage"])
         self.assertEqual(query["granularity"], "hour")
 
-    def test_fetch_period_totals_queries_month_week_day_hour(self):
+    def test_fetch_period_totals_queries_minute_through_year(self):
         tz = MODULE.timezone(MODULE.timedelta(hours=-4))
-        now = MODULE.datetime(2026, 8, 22, 18, 57, tzinfo=tz)
+        now = MODULE.datetime(2026, 8, 22, 18, 57, 31, tzinfo=tz)
         with mock.patch.object(MODULE, "fetch_usage_range", return_value=(100, 0.25)) as fetch:
             result = MODULE.fetch_period_totals("key", now)
-        self.assertEqual(fetch.call_count, 4)
-        self.assertEqual(result["tokens_month"], 100)
-        self.assertEqual(result["tokens_hour"], 100)
+        self.assertEqual(fetch.call_count, 6)
+        for period in ("minute", "hour", "day", "week", "month", "year"):
+            self.assertEqual(result[f"tokens_{period}"], 100)
         self.assertEqual(result["spend_day"], 0.25)
+        self.assertEqual(result["spend_year"], 0.25)
         self.assertNotIn("spend_hour", result)
+        self.assertNotIn("spend_minute", result)
+
+    def test_minute_period_uses_closed_minute_window_and_minute_granularity(self):
+        tz = MODULE.timezone(MODULE.timedelta(hours=-4))
+        now = MODULE.datetime(2026, 8, 22, 18, 57, 31, tzinfo=tz)
+        with mock.patch.object(MODULE, "fetch_usage_range", return_value=(0, 0.0)) as fetch:
+            MODULE.fetch_period_totals("key", now)
+        calls = {(call.args[3], call.args[1], call.args[2]) for call in fetch.call_args_list}
+        minute_calls = [entry for entry in calls if entry[0] == "minute"]
+        self.assertEqual(len(minute_calls), 1)
+        _, start, end = minute_calls[0]
+        self.assertEqual(end, MODULE.datetime(2026, 8, 22, 22, 57, tzinfo=MODULE.timezone.utc))
+        self.assertEqual((end - start).total_seconds(), 60)
+        for granularity, _, _ in calls:
+            self.assertIn(granularity, ("minute", "hour"))
 
     def test_closed_window_is_previous_full_minute(self):
         now = MODULE.datetime(2026, 8, 22, 21, 10, 47, 900, tzinfo=MODULE.timezone.utc)

--- a/.config/qtile/tests/test_openrouter_widget_structure.py
+++ b/.config/qtile/tests/test_openrouter_widget_structure.py
@@ -57,10 +57,17 @@ class OpenRouterWidgetStructureTests(unittest.TestCase):
         self.assertIn("balance < 10", SOURCE_TEXT)
         self.assertIn('name="openrouter_credit"', SOURCE_TEXT)
 
-    def test_tokens_rotate_month_week_day_hour_and_spend_day_week_month(self):
-        for value in ("tokens_month", "tokens_week", "tokens_day", "tokens_hour"):
+    def test_tokens_rotate_minute_through_year_and_spend_includes_year(self):
+        for value in (
+            "tokens_minute",
+            "tokens_hour",
+            "tokens_day",
+            "tokens_week",
+            "tokens_month",
+            "tokens_year",
+        ):
             self.assertIn(value, SOURCE_TEXT)
-        for value in ("spend_day", "spend_week", "spend_month"):
+        for value in ("spend_day", "spend_week", "spend_month", "spend_year"):
             self.assertIn(value, SOURCE_TEXT)
 
     def test_graph_uses_all_requested_persistent_ranges(self):


### PR DESCRIPTION
## Summary
- Add "tokens last minute" (closed previous minute, minute-granularity analytics query) and a calendar-year running total (Jan 1 → now) to the rotating OpenRouter metrics
- Tokens rotation: m → H → D → W → M → Y; spend rotation gains Y
- `tokens_minute`/`tokens_year`/`spend_year` flow through the collector status cache; spend stays omitted for sub-hour windows (existing hour precedent)

## Test plan
- Red/green: updated `test_openrouter_status.py` (6 period queries, closed-minute window + granularity, year start) and widget structure test
- Literate parity org ↔ py verified; full qtile suite: 220 passed