### PR TITLE
LLM proxy: enable merged expert-plane consumer

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
-          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
+          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
+      - name: Run llm-log expert consumer contract
+        run: bash tests/llm-log-expert-consumer.sh
       - name: Verify bash.org and .bashrc are tangled in sync
         run: |
           set -euo pipefail

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,17 +2,11 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "94b79dccd9010b429eff0472c74391fa50b4db0a";
-  llmLogSource = builtins.fetchGit {
-    url = "https://github.com/lost-rob0t/llm-log.git";
-    rev = llmLogRevision;
-  };
-  llmLogPackage = pkgs.callPackage "${llmLogSource}/nix/package.nix" { };
-  llmLogModule = import "${llmLogSource}/nix/home-manager.nix" {
-    self = {
-      packages.${pkgs.stdenv.hostPlatform.system}.default = llmLogPackage;
-    };
-  };
+  llmLogRevision = "b6a7b74fd7a3aca3a8af94d83e18390f2fc37d62";
+  llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
+  llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;
+  llmLogModule = llmLogFlake.homeManagerModules.default;
   proxyBase = "http://127.0.0.1:8787";
 
   # Keep the OpenCode policy wrapper in dotfiles, not in the reusable skills
@@ -62,6 +56,12 @@ in
       enable = true;
       package = llmLogPackage;
       dataDir = "${config.home.homeDirectory}/Documents/AI/proxy";
+      expert = {
+        enable = true;
+        package = llmLogExpertPackage;
+        dataDir = "${config.home.homeDirectory}/.llm-proxy/expert";
+        require = false;
+      };
       upstreams = {
         openai = "https://api.openai.com";
         openrouter = "https://openrouter.ai";

--- a/tests/llm-log-expert-consumer.sh
+++ b/tests/llm-log-expert-consumer.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+module="nix/home-manager/mods/llm.nix"
+old_revision="94b79dccd9010b429eff0472c74391fa50b4db0a"
+
+fail() {
+  printf 'RED: %s\n' "$*" >&2
+  exit 1
+}
+
+grep -Fq 'dataDir = "${config.home.homeDirectory}/Documents/AI/proxy";' "$module" \
+  || fail 'raw capture path moved from ~/Documents/AI/proxy'
+
+grep -Fq 'openai = "https://api.openai.com";' "$module" \
+  || fail 'OpenAI upstream routing changed'
+grep -Fq 'openrouter = "https://openrouter.ai";' "$module" \
+  || fail 'OpenRouter upstream routing changed'
+grep -Fq 'anthropic = "https://api.anthropic.com";' "$module" \
+  || fail 'Anthropic upstream routing changed'
+grep -Fq 'chatgpt = "https://chatgpt.com";' "$module" \
+  || fail 'ChatGPT upstream routing changed'
+
+if grep -Fq "llmLogRevision = \"${old_revision}\";" "$module"; then
+  fail 'llm-log pin still targets the pre-expert consumer revision'
+fi
+
+grep -Eq 'expert[[:space:]]*=[[:space:]]*\{' "$module" \
+  || fail 'services.llm-log.expert consumer configuration is absent'
+grep -Eq 'enable[[:space:]]*=[[:space:]]*true;' "$module" \
+  || fail 'expert consumer is not enabled'
+grep -Eq 'require[[:space:]]*=[[:space:]]*false;' "$module" \
+  || fail 'initial expert rollout must remain fail-open'
+
+if grep -Eq 'expert[^\n]*dataDir[^\n]*Documents/AI/proxy|Documents/AI/proxy[^\n]*expert' "$module"; then
+  fail 'expert mutable state must not share the raw capture corpus'
+fi
+
+printf 'llm-log expert consumer contract satisfied\n'


### PR DESCRIPTION
Supersedes draft PR #172 solely because the connected ready-for-review mutation is broken (`Repository.fullDatabaseId`). #172 had zero reviews and zero conversation comments; no review history is being discarded.

Consumes the merged llm-log #10 substrate only.

Canonical design: `lost-rob0t/llm-log/research/LLM-LOG-RESEARCH-032-dotfiles-expert-consumer-gate.org`.

Exact production head: `41e3404862247b41d2199481ab4912d417665daf`.
Exact-head Nix run `33368125588` completed GREEN. The unchanged llm-log expert consumer contract is GREEN.

Configuration:
- llm-log pin: merged upstream revision `b6a7b74fd7a3aca3a8af94d83e18390f2fc37d62`;
- raw capture remains `~/Documents/AI/proxy`;
- expert state is `~/.llm-proxy/expert`;
- expert enabled with `require = false` for fail-open rollout;
- OpenAI/OpenRouter/Anthropic/ChatGPT routing unchanged;
- Codex/OpenCode/Claude Code/gptel routing unchanged.

No unrelated dotfiles changes. No Tek9 mutation. Upstream llm-log PR #5 remains separate.

The active `master` ruleset contains only deletion/non-fast-forward restrictions and no review/status rule. Zero reviews means no review is required; it is not an approval.