### PR TITLE
feat: add skill-sync for on-demand skills input updates

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
-          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
+          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/opencode-yolo.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh nix/home-manager/files/opencode-yolo.sh
       - name: Run llm-log expert consumer contract
         run: bash tests/llm-log-expert-consumer.sh
       - name: Verify bash.org and .bashrc are tangled in sync
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/screen-capture.sh
       - name: Run Home Manager updater recovery tests
         run: bash tests/home-manager-updater.sh
+      - name: Run skill sync tests
+        run: bash tests/skill-sync.sh
       - name: Run GPT TODO bidirectional sync tests
         run: bash tests/gpt-todos-sync.sh
       - name: Run research approval ERT tests

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -25,5 +25,6 @@
     ./discord-mcp.nix
     ./unifi-mcp.nix
     ./home-manager-updater.nix
+    ./skill-sync.nix
   ];
 }

--- a/nix/home-manager/mods/skill-sync.nix
+++ b/nix/home-manager/mods/skill-sync.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  skill-sync = pkgs.writeShellApplication {
+    name = "skill-sync";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.git
+      pkgs.jq
+      pkgs.nix
+      config.programs.home-manager.package
+    ];
+    text = ''
+      exec ${pkgs.bash}/bin/bash ${../../../scripts/skill-sync.sh} "$@"
+    '';
+  };
+in
+{
+  home.packages = [ skill-sync ];
+}

--- a/scripts/skill-sync.sh
+++ b/scripts/skill-sync.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Sync a flake input (default: skills) in the dotfiles checkout, publish the
+# checked lockfile, and activate the local Home Manager configuration.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: skill-sync [OPTIONS]
+
+Update the skills flake input, validate the flake, publish the lockfile, and
+activate the local Home Manager configuration.
+
+Environment:
+  SKILL_SYNC_REPO    Dotfiles checkout (default: ~/.dotfiles)
+
+Options:
+  --repo DIR            Dotfiles git checkout
+  --input NAME          Flake input to update (default: skills)
+  --branch NAME         Default branch to sync and push (default: origin/HEAD, else master)
+  --configuration NAME  Home Manager target (default: auto-discovered USER@HOST,
+                        otherwise the sole exported configuration)
+  --dry-run             Print the plan without changing anything
+  --no-push             Commit the lockfile locally but skip pushing
+  --no-activate         Skip the Home Manager build and switch
+  -h, --help            Show this help
+
+The lockfile is only published after `nix flake check -L` succeeds, mirroring
+the repository's daily flake-update workflow.
+EOF
+}
+
+log() {
+  printf '[skill-sync] %s\n' "$*"
+}
+
+die() {
+  printf '[skill-sync] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repo="${SKILL_SYNC_REPO:-$HOME/.dotfiles}"
+input="skills"
+branch=""
+configuration=""
+dry_run=0
+no_push=0
+no_activate=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="${2:?--repo needs a value}"; shift 2 ;;
+    --input) input="${2:?--input needs a value}"; shift 2 ;;
+    --branch) branch="${2:?--branch needs a value}"; shift 2 ;;
+    --configuration) configuration="${2:?--configuration needs a value}"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    --no-push) no_push=1; shift ;;
+    --no-activate) no_activate=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) printf '[skill-sync] unknown option: %s\n\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -d "$repo" ]] || die "repository not found: $repo"
+repo="$(cd "$repo" && pwd)"
+[[ -f "$repo/flake.nix" ]] || die "no flake.nix in $repo"
+[[ -f "$repo/flake.lock" ]] || die "no flake.lock in $repo"
+for tool in git jq nix; do
+  command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+done
+if (( ! no_activate )); then
+  command -v home-manager >/dev/null 2>&1 || die "home-manager not found; pass --no-activate to skip activation"
+fi
+
+git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not a git checkout: $repo"
+
+locked_rev() {
+  jq -r --arg input "$input" '.nodes[$input].locked.rev // empty' "$repo/flake.lock"
+}
+
+git -C "$repo" fetch --prune origin
+if [[ -z "$branch" ]]; then
+  branch="$(git -C "$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+  branch="${branch:-master}"
+fi
+current_branch="$(git -C "$repo" branch --show-current)"
+if [[ "$current_branch" != "$branch" ]]; then
+  die "current branch is '$current_branch', expected '$branch'; refusing to sync"
+fi
+if [[ -n "$(git -C "$repo" status --porcelain -- flake.lock)" ]]; then
+  die "flake.lock has uncommitted changes; refusing to sync"
+fi
+jq -e --arg input "$input" '.nodes | has($input)' "$repo/flake.lock" >/dev/null \
+  || die "flake input '$input' is not locked in flake.lock"
+old_rev="$(locked_rev)"
+[[ -n "$old_rev" ]] || die "flake input '$input' has no locked revision"
+
+if (( dry_run )); then
+  log "dry-run: would fast-forward $branch to origin/$branch"
+  log "dry-run: would update input '$input' (locked at ${old_rev:0:12})"
+  log "dry-run: would gate on: nix flake check -L --show-trace"
+  if (( no_push )); then
+    log "dry-run: would commit flake.lock locally (push disabled)"
+  else
+    log "dry-run: would commit flake.lock and push to origin/$branch"
+  fi
+  if (( no_activate )); then
+    log "dry-run: activation skipped (--no-activate)"
+  else
+    log "dry-run: would build and switch the discovered Home Manager configuration"
+  fi
+  exit 0
+fi
+
+git -C "$repo" merge --ff-only "origin/$branch"
+(cd "$repo" && nix flake update "$input")
+new_rev="$(locked_rev)"
+[[ -n "$new_rev" ]] || die "flake input '$input' has no locked revision after update"
+
+if [[ "$new_rev" == "$old_rev" ]]; then
+  log "Input '$input' is already current at ${old_rev:0:12}; nothing to do"
+  exit 0
+fi
+log "Input '$input': ${old_rev:0:12} -> ${new_rev:0:12}"
+
+log "Validating flake: nix flake check -L"
+(cd "$repo" && nix flake check -L --show-trace)
+
+git -C "$repo" add -- flake.lock
+git -C "$repo" commit -m "chore(nix): sync $input input to ${new_rev:0:12}"
+if (( no_push )); then
+  log "Committed flake.lock locally; push skipped (--no-push)"
+else
+  git -C "$repo" push origin "HEAD:$branch"
+  log "Pushed flake.lock to origin/$branch"
+fi
+
+if (( no_activate )); then
+  log "Activation skipped (--no-activate)"
+  exit 0
+fi
+
+if [[ -z "$configuration" ]]; then
+  configs_json="$(nix eval --json "$repo#homeConfigurations" --apply 'builtins.attrNames')"
+  mapfile -t configs < <(jq -r '.[]' <<<"$configs_json")
+  want="$(id -un)@$(hostname -s)"
+  for candidate in "${configs[@]}"; do
+    if [[ "$candidate" == "$want" ]]; then
+      configuration="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$configuration" ]]; then
+    if (( ${#configs[@]} == 1 )); then
+      configuration="${configs[0]}"
+    else
+      die "could not discover a Home Manager configuration for '$want'; exported: ${configs[*]}. Pass --configuration."
+    fi
+  fi
+fi
+
+log "Building activation package for $configuration"
+nix build --no-link "$repo#homeConfigurations.\"$configuration\".activationPackage"
+log "Activating $configuration"
+home-manager switch --flake "$repo#$configuration" --show-trace
+log "Done: $input ${old_rev:0:12} -> ${new_rev:0:12}; configuration $configuration activated"

--- a/tests/skill-sync.sh
+++ b/tests/skill-sync.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$repo_root/scripts/skill-sync.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+old_rev="0000000000000000000000000000000000000000"
+new_rev="1111111111111111111111111111111111111111"
+mockbin="$tmp/bin"
+mkdir -p "$mockbin"
+
+cat >"$mockbin/nix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  flake)
+    case "${2:-}" in
+      update)
+        jq --arg new "${MOCK_NEW_REV:?}" '.nodes.skills.locked.rev = $new' flake.lock >flake.lock.tmp
+        mv flake.lock.tmp flake.lock
+        ;;
+      check) exit "${MOCK_CHECK_RC:-0}" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  eval) printf '["unseen@flake"]\n' ;;
+  build) exit "${MOCK_BUILD_RC:-0}" ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"$mockbin/home-manager" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "switch" ]]; then
+  printf '%s\n' "$*" >>"${MOCK_HM_LOG:?}"
+  exit "${MOCK_SWITCH_RC:-0}"
+fi
+exit 2
+EOF
+
+chmod +x "$mockbin/nix" "$mockbin/home-manager"
+
+hm_log="$tmp/hm.log"
+: >"$hm_log"
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "$got" != "$want" ]]; then
+    printf 'FAIL: %s\n  got:  %s\n  want: %s\n' "$msg" "$got" "$want" >&2
+    exit 1
+  fi
+  printf 'ok: %s\n' "$msg"
+}
+
+make_fixture() {
+  local name="$1"
+  local fixture="$tmp/$name"
+  : >"$hm_log"
+  git init -q -b master "$fixture"
+  printf '{"description":"fixture","inputs":{"skills":{"url":"github:example/skills"}},"outputs":{}}\n' >"$fixture/flake.nix"
+  printf '{"nodes":{"skills":{"locked":{"rev":"%s"}}},"root":"","version":7}\n' "$old_rev" >"$fixture/flake.lock"
+  git -C "$fixture" add -A
+  git -C "$fixture" -c user.name=test -c user.email=test@example.test commit -qm init
+  git init -q --bare "$tmp/$name-origin.git"
+  git -C "$fixture" remote add origin "$tmp/$name-origin.git"
+  git -C "$fixture" push -q origin master
+  git -C "$fixture" config user.name test
+  git -C "$fixture" config user.email test@example.test
+  printf '%s\n' "$fixture"
+}
+
+run_sync() {
+  local fixture="$1"
+  shift
+  (
+    export PATH="$mockbin:$PATH"
+    export MOCK_NEW_REV="$new_rev"
+    export MOCK_HM_LOG="$hm_log"
+    export SKILL_SYNC_REPO="$fixture"
+    "$script" --repo "$fixture" "$@"
+  )
+}
+
+# --help exits 0 and prints usage.
+"$script" --help >"$tmp/help.txt"
+grep -q '^Usage:' "$tmp/help.txt"
+printf 'ok: --help prints usage\n'
+
+# Happy path: update input, validate, commit, push, activate.
+fixture="$(make_fixture happy)"
+run_sync "$fixture" >/dev/null
+assert_eq "$(jq -r '.nodes.skills.locked.rev' "$fixture/flake.lock")" "$new_rev" "happy: lock updated"
+assert_eq "$(git -C "$fixture" rev-parse HEAD)" "$(git -C "$fixture" rev-parse origin/master)" "happy: pushed"
+git -C "$fixture" log -1 --format=%s | grep -q 'sync skills input'
+grep -q 'switch' "$hm_log"
+printf 'ok: happy path commits, pushes, and activates\n'
+
+# Second run is a no-op.
+before="$(git -C "$fixture" rev-parse HEAD)"
+out="$(run_sync "$fixture")"
+grep -q 'already current' <<<"$out"
+assert_eq "$(git -C "$fixture" rev-parse HEAD)" "$before" "idempotent: no extra commit"
+
+# Dry run changes nothing.
+fixture="$(make_fixture dryrun)"
+run_sync "$fixture" --dry-run >/dev/null
+assert_eq "$(jq -r '.nodes.skills.locked.rev' "$fixture/flake.lock")" "$old_rev" "dry-run: lock untouched"
+assert_eq "$(git -C "$fixture" rev-parse HEAD)" "$(git -C "$fixture" rev-parse origin/master)" "dry-run: nothing committed"
+assert_eq "$(wc -l <"$hm_log")" "0" "dry-run: no activation"
+
+# Refuses to run off the default branch.
+fixture="$(make_fixture offbranch)"
+git -C "$fixture" checkout -q -b feature/x
+out="$(run_sync "$fixture" 2>&1 >/dev/null || true)"
+grep -q "expected 'master'" <<<"$out"
+printf 'ok: refuses off the default branch\n'
+
+# Refuses a dirty lockfile.
+fixture="$(make_fixture dirtylock)"
+printf 'junk\n' >>"$fixture/flake.lock"
+out="$(run_sync "$fixture" 2>&1 >/dev/null || true)"
+grep -q 'uncommitted changes' <<<"$out"
+printf 'ok: refuses a dirty lockfile\n'
+
+# --no-activate skips the switch but still publishes.
+fixture="$(make_fixture noactivate)"
+run_sync "$fixture" --no-activate >/dev/null
+assert_eq "$(jq -r '.nodes.skills.locked.rev' "$fixture/flake.lock")" "$new_rev" "no-activate: lock updated"
+assert_eq "$(wc -l <"$hm_log")" "0" "no-activate: no switch"
+
+# --no-push commits locally without pushing.
+fixture="$(make_fixture nopush)"
+run_sync "$fixture" --no-push >/dev/null
+assert_eq "$(git -C "$fixture" rev-parse origin/master)" "$(git -C "$fixture" rev-parse master^)" "no-push: origin untouched"
+assert_eq "$(jq -r '.nodes.skills.locked.rev' "$fixture/flake.lock")" "$new_rev" "no-push: lock updated"
+
+printf 'all skill-sync tests passed\n'


### PR DESCRIPTION
## Summary

- `scripts/skill-sync.sh`: updates the `skills` flake input, gates on `nix flake check -L` (mirroring the daily update workflow), commits/pushes only `flake.lock`, then builds and switches the auto-discovered Home Manager configuration.
- Fail-closed guards: non-default branch, dirty `flake.lock`, missing tools, ambiguous configuration discovery, unchanged input short-circuit.
- Deployed via new HM mod `mods/skill-sync.nix` (`writeShellApplication`, no options).
- `tests/skill-sync.sh`: 8 scenarios (happy path, idempotence, dry-run, off-branch, dirty lock, --no-activate, --no-push, --help) with stubbed nix/home-manager and real git fixtures.
- Registered in CI `bash -n`/`shellcheck`/`tests`.

## Validation

- `bash -n` + `shellcheck --severity=warning` clean
- `bash tests/skill-sync.sh` — all passed
- `nix eval .#homeConfigurations."unseen@flake".activationPackage.drvPath` — ok