### PR TITLE
fix(llm-log): pin expert runtime green revision

### DIFF
--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "b6a7b74fd7a3aca3a8af94d83e18390f2fc37d62";
+  llmLogRevision = "176f0f67ad512c9c19fb725b5fccd10f3d308118";
   llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
   llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
   llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;


### PR DESCRIPTION
## Summary

The pinned llm-log revision predates lost-rob0t/llm-log#36, where the expert-service contract tests still hard-asserted RED. That makes the `llm-log` package (and therefore every `home-manager switch`) fail to build — also blocking the daily `home-manager-updater`.

Bumps the pin to `176f0f6` (llm-log main): expert runtime green, tests skip cleanly without the binary, and the flake still exposes `packages.llm-log-expert` + `homeManagerModules.default` as consumed here.

## Validation

- `nix build .#homeConfigurations."unseen@flake".activationPackage` — green locally