### PR TITLE
llm-log: keep the tek9 expert db inside the proxy corpus dir

### DIFF
--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -59,7 +59,8 @@ in
       expert = {
         enable = true;
         package = llmLogExpertPackage;
-        dataDir = "${config.home.homeDirectory}/.llm-proxy/expert";
+        # Tek9 state lives with the proxy corpus on this machine.
+        dataDir = "${config.home.homeDirectory}/Documents/AI/proxy/expert";
         require = false;
       };
       upstreams = {


### PR DESCRIPTION
Point services.llm-log.expert.dataDir at ~/Documents/AI/proxy/expert so
the mutable tek9 symbolic state sits alongside the append-only capture
corpus instead of ~/.llm-proxy/expert.
