### PR TITLE
llm-log: pin rev with init-file-isolated expert runtime

### DIFF
--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "176f0f67ad512c9c19fb725b5fccd10f3d308118";
+  llmLogRevision = "61eb86f36a4e6500dabdb2d511f2390b18650def";
   llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
   llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
   llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;


### PR DESCRIPTION
The packaged expert binary no longer loads ~/.sbclrc (quicklisp broke
it with 'Can't create directory /build'), so the proxy's expert plane
can actually spawn on this machine.
