### PR TITLE
nix-gl: provision /run/opengl-driver for nix gui apps on non-nixos hosts

### DIFF
--- a/docs/wiki/nix.org
+++ b/docs/wiki/nix.org
@@ -23,7 +23,7 @@ The flake provides:
 | Output | System source |
 |--------+---------------|
 | =unseen@logos= | [[file:../../nix/home-manager/systems/logos/home.nix][systems/logos/home.nix]] |
-| =unseen@flake= | [[file:../../nix/home-manager/systems/desktop/home.nix][systems/desktop/home.nix]] |
+| =unseen@flake= | [[file:../../nix/home-manager/systems/flake/home.nix][systems/flake/home.nix]] |
 | =unseen@desktop= | [[file:../../nix/home-manager/systems/desktop/home.nix][systems/desktop/home.nix]] |
 | =unseen@hunter02= | [[file:../../nix/home-manager/systems/hunter02/home.nix][systems/hunter02/home.nix]] |
 
@@ -61,6 +61,29 @@ They are configurable through =gptTodos.repoDir=, =gptTodos.orgDir=, and
 The old cron installer remains only as a compatibility path for machines not
 managed by Home Manager.  The canonical synchronization behavior lives in
 [[file:../../scripts/gpt-todos-sync.org][scripts/gpt-todos-sync.org]].
+
+* Nix GUI apps on non-NixOS hosts
+Nixpkgs mesa is patched to look for GL/GBM/Vulkan drivers in =/run/opengl-driver=,
+a path that only NixOS populates.  On the Arch host (=unseen@flake=) Nix GUI
+apps (Firefox, Discord, Electron) therefore fail GPU init and either fall back
+to software rendering without WebGL or crash.
+
+[[file:../../nix/home-manager/mods/nix-gl.nix][nix-gl.nix]] (enable via
+=nixGl.enable = true=) installs the =nix-gl-setup= helper.  Running it once as
+root provisions the driver symlink and a =systemd-tmpfiles= rule so it survives
+reboots:
+
+#+begin_src shell
+  nix profile install nixpkgs#mesa   # once, if not already in the profile
+  pkexec --disable-internal-agent nix-gl-setup
+#+end_src
+
+The rule creates =/run/opengl-driver -> ~/.nix-profile=, a stable path that
+survives mesa upgrades; system applications ignore this path entirely.  Home
+Manager activation warns when the =/etc/tmpfiles.d/nix-opengl-driver.conf= rule
+is missing or stale.  The script lives in
+[[file:../../scripts/nix-gl-setup][scripts/nix-gl-setup]] with a regression test
+in [[file:../../tests/nix-gl-setup][tests/nix-gl-setup]].
 
 * Installer applications
 The flake exposes =install-logos= and =install-logos-gui=.  Their shell implementations live under [[file:../../scripts/][scripts/]].

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -26,5 +26,6 @@
     ./unifi-mcp.nix
     ./home-manager-updater.nix
     ./skill-sync.nix
+    ./nix-gl.nix
   ];
 }

--- a/nix/home-manager/mods/nix-gl.nix
+++ b/nix/home-manager/mods/nix-gl.nix
@@ -1,0 +1,40 @@
+{ lib, pkgs, config, ... }:
+
+let
+  nixGlSetup = pkgs.writeShellApplication {
+    name = "nix-gl-setup";
+    runtimeInputs = with pkgs; [
+      coreutils
+      diffutils
+      glibc
+    ];
+    text = builtins.readFile ../../../scripts/nix-gl-setup;
+  };
+in
+{
+  options.nixGl = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Provision /run/opengl-driver for Nix GUI apps on non-NixOS hosts.
+
+        Installs the nix-gl-setup helper. Run it once with root:
+
+          pkexec --disable-internal-agent nix-gl-setup
+      '';
+    };
+  };
+
+  config = lib.mkIf config.nixGl.enable {
+    home.packages = [ nixGlSetup ];
+
+    # Non-fatal drift check: the tmpfiles rule must keep pointing at this
+    # user's nix profile or Nix GUI apps lose hardware acceleration.
+    home.activation.nixGlDriverCheck = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if ! ${pkgs.gnugrep}/bin/grep -qF "${config.home.homeDirectory}/.nix-profile" /etc/tmpfiles.d/nix-opengl-driver.conf 2>/dev/null; then
+        echo "nix-gl: /etc/tmpfiles.d/nix-opengl-driver.conf is missing or stale; run: pkexec --disable-internal-agent nix-gl-setup" >&2
+      fi
+    '';
+  };
+}

--- a/nix/home-manager/systems/flake/home.nix
+++ b/nix/home-manager/systems/flake/home.nix
@@ -6,4 +6,6 @@
     enable = true;
     hostName = "flake";
   };
+
+  nixGl.enable = true;
 }

--- a/scripts/nix-gl-setup
+++ b/scripts/nix-gl-setup
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provision /run/opengl-driver for Nix GUI apps on non-NixOS hosts.
+#
+# Nixpkgs mesa is patched to search GL/GBM/Vulkan drivers in /run/opengl-driver,
+# a path only NixOS populates. On a foreign distro, Nix GUI apps (Firefox,
+# Discord, Electron) fail their GPU init and fall back to software or crash.
+#
+# Run it once as root (idempotent, safe to re-run):
+#
+#   pkexec --disable-internal-agent nix-gl-setup
+#
+# The /etc/tmpfiles.d rule created here re-creates the symlink on every boot,
+# pointing at the stable nix profile path so mesa upgrades never break it.
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  echo "nix-gl-setup: refused: must run as root:" >&2
+  echo "  pkexec --disable-internal-agent nix-gl-setup" >&2
+  exit 1
+fi
+
+profile_dir="${1:-${NIX_GL_PROFILE_DIR:-}}"
+
+if [[ -z $profile_dir ]]; then
+  # pkexec scrubs the environment but exports PKEXEC_UID; derive the invoking
+  # user's home from it so we target their nix profile, not root's.
+  uid="${PKEXEC_UID:-}"
+  if [[ -n $uid ]]; then
+    user_home="$(getent passwd "$uid" | cut -d: -f6)"
+    profile_dir="$user_home/.nix-profile"
+  else
+    profile_dir="$HOME/.nix-profile"
+  fi
+fi
+
+profile_dir="$(readlink -f "$profile_dir")"
+
+if [[ ! -d $profile_dir/lib/dri ]]; then
+  echo "nix-gl-setup: no GL drivers in $profile_dir/lib/dri" >&2
+  echo "  install them first:  nix profile install nixpkgs#mesa" >&2
+  exit 1
+fi
+
+conf=/etc/tmpfiles.d/nix-opengl-driver.conf
+rule="L+ /run/opengl-driver - - - - ${profile_dir}"
+
+if [[ -f $conf ]] && cmp -s <(printf '%s\n' "$rule") "$conf"; then
+  echo "nix-gl-setup: $conf already up to date"
+else
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
+  printf '%s\n' "$rule" > "$tmp"
+  install -Dm 0644 "$tmp" "$conf"
+  echo "nix-gl-setup: wrote $conf"
+fi
+
+ln -sfn "$profile_dir" /run/opengl-driver
+
+echo "nix-gl-setup: /run/opengl-driver -> $(readlink /run/opengl-driver)"

--- a/tests/nix-gl-setup
+++ b/tests/nix-gl-setup
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SETUP="$ROOT/scripts/nix-gl-setup"
+
+# Syntax must be valid.
+bash -n "$SETUP"
+
+# Refuses to run unprivileged and points at the pkexec invocation instead of
+# embedding sudo credentials.
+out="$(bash "$SETUP" 2>&1)" && status=0 || status=$?
+[[ $status -eq 1 ]]
+grep -q "must run as root" <<<"$out"
+grep -q "pkexec --disable-internal-agent nix-gl-setup" <<<"$out"
+if grep -Eq 'sudo -S|SUDO_ASKPASS|SUDO_ASKPASS_ENV' "$SETUP"; then
+  echo "nix-gl-setup must not collect credentials" >&2
+  exit 1
+fi
+
+# Root-gated behavior cannot be exercised here; the tmpfiles rule, symlink
+# target, and profile validation logic are exercised on the host via
+# pkexec --disable-internal-agent nix-gl-setup.
+
+echo "tests/nix-gl-setup: ok"


### PR DESCRIPTION
## Problem

Nix GUI apps on the Arch host (`unseen@flake`) fail GPU init: nixpkgs mesa is patched to search drivers in `/run/opengl-driver`, a path only NixOS populates. Symptom: nix Firefox reports WebGL disabled while system Firefox works; nix Discord/Electron GPU processes crash (SIGTRAP).

## Change

- new option-gated mod `nix-gl.nix` (`nixGl.enable`, default off) installing the `nix-gl-setup` helper, enabled only for `unseen@flake`
- `scripts/nix-gl-setup`: idempotent, root-via-pkexec provisioner writing `/etc/tmpfiles.d/nix-opengl-driver.conf` (`L+ /run/opengl-driver - - - - ~/.nix-profile`), creating the live symlink, and refusing to collect credentials
- stable symlink target (~/.nix-profile) so mesa upgrades never break it; system apps ignore the path entirely
- activation-time drift check warns when the tmpfiles rule is missing/stale
- regression test `tests/nix-gl-setup` (syntax, non-root fail-closed path, no credential collection)
- docs/wiki/nix.org section + fixed stale `unseen@flake` source mapping in the outputs table

## Validation

- `tests/nix-gl-setup` passes
- `nix build .#checks.x86_64-linux.unseen-flake-home` green (writeShellApplication shellcheck/shfmt gate)
- `unseen@{logos,desktop,hunter02}` activation packages still evaluate (module default-off)

Deployed and verified live: nix Firefox WebGL renders (get.webgl.org cube) on the desktop session.