### PR TITLE
gpt-todos-sync: smart commit messages and unpushed-commit self-heal

### DIFF
--- a/scripts/gpt-todos-sync
+++ b/scripts/gpt-todos-sync
@@ -269,6 +269,143 @@ list_local_org_paths() {
   done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
 }
 
+publish_local_commits() {
+  local ahead
+  ahead="$(git -C "$REPO_DIR" rev-list --count "$REMOTE_HEAD..HEAD")"
+  (( ahead > 0 )) || return 0
+
+  if (( $(git -C "$REPO_DIR" rev-list --count "HEAD..$REMOTE_HEAD") == 0 )) &&
+     git -C "$REPO_DIR" push; then
+    printf 'gpt-todos-sync: published %d unpushed local commit(s)\n' "$ahead"
+    return 0
+  fi
+
+  # The remote advanced past the last fetch (or the push raced): replay only
+  # this checkout's own unpushed commits on top of upstream.  A replay
+  # conflict aborts and fails closed for manual resolution.
+  if ! git -C "$REPO_DIR" -c commit.gpgsign=false rebase "$REMOTE_HEAD"; then
+    git -C "$REPO_DIR" rebase --abort 2>/dev/null || true
+    printf 'gpt-todos-sync: unpushed local commits conflict with upstream; manual resolution required\n' >&2
+    exit 5
+  fi
+  git -C "$REPO_DIR" push
+  printf 'gpt-todos-sync: published %d unpushed local commit(s)\n' "$ahead"
+}
+
+classify_staged_file() {
+  git -C "$REPO_DIR" diff --cached -U0 -- "$1" | awk '
+    function cb_body(s) {
+      sub(/^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[[Xx ]\][ \t]*/, "", s)
+      return s
+    }
+    function hl_body(s) {
+      sub(/^[ \t]*\*+[ \t]+(TODO|DONE)[ \t:]*/, "", s)
+      return s
+    }
+    /^@@/ { inhunk = 1; next }
+    !inhunk { next }
+    {
+      side = substr($0, 1, 1)
+      line = substr($0, 2)
+      if (line ~ /^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[[Xx]\]/) {
+        if (side == "-") xcount[cb_body(line)]++
+        else xbody[xn++] = cb_body(line)
+      } else if (line ~ /^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[ \]/) {
+        if (side == "-") ocount[cb_body(line)]++
+        else obody[on++] = cb_body(line)
+      } else if (line ~ /^[ \t]*\*+[ \t]+TODO([ \t:]|$)/) {
+        if (side == "-") tcount[hl_body(line)]++
+        else tbody[tn++] = hl_body(line)
+      } else if (line ~ /^[ \t]*\*+[ \t]+DONE([ \t:]|$)/) {
+        if (side == "-") dcount[hl_body(line)]++
+        else dbody[dn++] = hl_body(line)
+      } else if (line ~ /\[[0-9]+%\]|\[[0-9]+\/[0-9]+\][ \t]*$/) {
+        # Org statistics cookies only restate checkbox/headline counts.
+      } else {
+        other++
+      }
+    }
+    END {
+      done = 0
+      for (i = 0; i < xn; i++)
+        if (ocount[xbody[i]] > 0) { ocount[xbody[i]]--; done++ }
+      reopened = 0
+      for (i = 0; i < on; i++)
+        if (xcount[obody[i]] > 0) { xcount[obody[i]]--; reopened++ }
+      for (i = 0; i < dn; i++)
+        if (tcount[dbody[i]] > 0) { tcount[dbody[i]]--; done++ }
+      for (i = 0; i < tn; i++)
+        if (dcount[tbody[i]] > 0) { dcount[tbody[i]]--; reopened++ }
+      printf "%d %d %d\n", done, reopened, other
+    }
+  '
+}
+
+compose_commit_message() {
+  local st rel done_n reopened_n other_n parts_count plural
+  local files=0 added=0 changed=0 total_done=0 total_reopened=0 needs_body=0
+  local -a parts=()
+  local -a bullets=()
+  local only_rel="" subject=""
+
+  while IFS=$'\t' read -r st rel; do
+    [[ -n "$rel" ]] || continue
+    files=$((files + 1))
+    [[ "$files" -eq 1 ]] && only_rel="$rel"
+    parts=()
+    if [[ "$st" == A* ]]; then
+      added=$((added + 1))
+      parts+=("added")
+    else
+      changed=$((changed + 1))
+      read -r done_n reopened_n other_n <<<"$(classify_staged_file "$rel")"
+      : "${done_n:=0}" "${reopened_n:=0}" "${other_n:=0}"
+      total_done=$((total_done + done_n))
+      total_reopened=$((total_reopened + reopened_n))
+      (( done_n > 0 )) && parts+=("${done_n} done")
+      (( reopened_n > 0 )) && parts+=("${reopened_n} reopened")
+      (( ${#parts[@]} == 0 || other_n > 0 )) && parts+=("updated")
+    fi
+    parts_count=${#parts[@]}
+    (( files > 1 || parts_count > 1 )) && needs_body=1
+    bullets+=("- ${rel#agenda/}: $(IFS=' '; echo "${parts[*]}")")
+  done < <(git -C "$REPO_DIR" diff --cached --name-status)
+
+  if (( total_done > 0 && total_reopened > 0 )); then
+    subject="mark ${total_done} done, reopen ${total_reopened}"
+  elif (( total_done > 0 )); then
+    subject="mark ${total_done} done"
+  elif (( total_reopened > 0 )); then
+    subject="reopen ${total_reopened}"
+  fi
+
+  if [[ -n "$subject" ]]; then
+    if (( files == 1 )); then
+      subject="agenda: ${subject} in ${only_rel#agenda/}"
+    else
+      subject="agenda: ${subject} across ${files} files"
+    fi
+  elif (( added > 0 && changed > 0 )); then
+    subject="agenda: add ${added}, update ${changed} agenda files"
+  elif (( added > 0 )); then
+    plural="files"
+    (( added == 1 )) && plural="file"
+    subject="agenda: add ${added} agenda ${plural}"
+  elif (( changed > 0 )); then
+    plural="files"
+    (( changed == 1 )) && plural="file"
+    subject="agenda: update ${changed} agenda ${plural}"
+  else
+    subject="Sync Org task state"
+  fi
+
+  if (( needs_body )); then
+    printf '%s\n\n%s\n' "$subject" "$(printf '%s\n' "${bullets[@]}")"
+  else
+    printf '%s\n' "$subject"
+  fi
+}
+
 prepare_aliased_save
 sync_dotfiles_literate
 repair_legacy_imports
@@ -286,6 +423,11 @@ UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}
 }
 BASE="$(git -C "$REPO_DIR" rev-parse HEAD)"
 REMOTE_HEAD="$(git -C "$REPO_DIR" rev-parse "$UPSTREAM")"
+
+# BASE is the last-synchronized baseline and is captured before healing so
+# remote changes stay attributable to the remote side.  Publishing our own
+# unpushed commits first keeps the later fast-forward pull from wedging.
+publish_local_commits
 
 mapfile -t org_paths < <(
   {
@@ -371,8 +513,9 @@ if ((${#local_changes[@]})); then
 fi
 
 if ! git -C "$REPO_DIR" diff --cached --quiet; then
+  commit_message="$(compose_commit_message)"
   git -C "$REPO_DIR" -c commit.gpgsign=false commit --no-gpg-sign \
-    -m "Sync Org task state"
+    -m "$commit_message"
   git -C "$REPO_DIR" push
 fi
 

--- a/scripts/gpt-todos-sync.org
+++ b/scripts/gpt-todos-sync.org
@@ -20,6 +20,18 @@ path is a symlink or other alias that already resolves to the durable file, that
 path is treated as synchronized instead of invoking =cp= on the same inode.
 The default durable checkout is =~/Documents/gpt-todos=.
 
+Commit messages are composed from the staged agenda diff instead of a fixed
+string.  Checkbox completions (=- [ ]= to =- [X]=), checkbox reopenings, and
+=TODO= to =DONE= headline transitions are paired by item text and counted per
+file; statistics-cookie churn (for example =[0/3]= to =[3/3]=) is treated as
+derived noise.  The subject states the counts (=agenda: mark 10 done in
+starintel.org=, =agenda: mark 3 done, reopen 1 across 2 files=), multi-file
+commits add per-file bullets, and edits without a task-state signal fall back
+to counted =add= / =update= subjects.  Unpushed durable commits no longer wedge
+the fast-forward pull: a strictly ahead checkout is pushed, and a diverged
+checkout replays only its own unpushed commits onto upstream before pushing.
+A replay conflict aborts the rebase and fails closed for manual resolution.
+
 Doom invokes =gpt-todos-sync --file FILE= after saving an Org file below the
 live agenda directory.  File mode first copies the exact saved contents to a
 private temporary file.  If the live file is a symlink into the durable checkout,
@@ -309,6 +321,143 @@ list_local_org_paths() {
   done < <(find "$ORG_DIR" \( -type f -o -type l \) -name '*.org' -print0)
 }
 
+publish_local_commits() {
+  local ahead
+  ahead="$(git -C "$REPO_DIR" rev-list --count "$REMOTE_HEAD..HEAD")"
+  (( ahead > 0 )) || return 0
+
+  if (( $(git -C "$REPO_DIR" rev-list --count "HEAD..$REMOTE_HEAD") == 0 )) &&
+     git -C "$REPO_DIR" push; then
+    printf 'gpt-todos-sync: published %d unpushed local commit(s)\n' "$ahead"
+    return 0
+  fi
+
+  # The remote advanced past the last fetch (or the push raced): replay only
+  # this checkout's own unpushed commits on top of upstream.  A replay
+  # conflict aborts and fails closed for manual resolution.
+  if ! git -C "$REPO_DIR" -c commit.gpgsign=false rebase "$REMOTE_HEAD"; then
+    git -C "$REPO_DIR" rebase --abort 2>/dev/null || true
+    printf 'gpt-todos-sync: unpushed local commits conflict with upstream; manual resolution required\n' >&2
+    exit 5
+  fi
+  git -C "$REPO_DIR" push
+  printf 'gpt-todos-sync: published %d unpushed local commit(s)\n' "$ahead"
+}
+
+classify_staged_file() {
+  git -C "$REPO_DIR" diff --cached -U0 -- "$1" | awk '
+    function cb_body(s) {
+      sub(/^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[[Xx ]\][ \t]*/, "", s)
+      return s
+    }
+    function hl_body(s) {
+      sub(/^[ \t]*\*+[ \t]+(TODO|DONE)[ \t:]*/, "", s)
+      return s
+    }
+    /^@@/ { inhunk = 1; next }
+    !inhunk { next }
+    {
+      side = substr($0, 1, 1)
+      line = substr($0, 2)
+      if (line ~ /^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[[Xx]\]/) {
+        if (side == "-") xcount[cb_body(line)]++
+        else xbody[xn++] = cb_body(line)
+      } else if (line ~ /^[ \t]*([-+*]|[0-9]+[.)])[ \t]+\[ \]/) {
+        if (side == "-") ocount[cb_body(line)]++
+        else obody[on++] = cb_body(line)
+      } else if (line ~ /^[ \t]*\*+[ \t]+TODO([ \t:]|$)/) {
+        if (side == "-") tcount[hl_body(line)]++
+        else tbody[tn++] = hl_body(line)
+      } else if (line ~ /^[ \t]*\*+[ \t]+DONE([ \t:]|$)/) {
+        if (side == "-") dcount[hl_body(line)]++
+        else dbody[dn++] = hl_body(line)
+      } else if (line ~ /\[[0-9]+%\]|\[[0-9]+\/[0-9]+\][ \t]*$/) {
+        # Org statistics cookies only restate checkbox/headline counts.
+      } else {
+        other++
+      }
+    }
+    END {
+      done = 0
+      for (i = 0; i < xn; i++)
+        if (ocount[xbody[i]] > 0) { ocount[xbody[i]]--; done++ }
+      reopened = 0
+      for (i = 0; i < on; i++)
+        if (xcount[obody[i]] > 0) { xcount[obody[i]]--; reopened++ }
+      for (i = 0; i < dn; i++)
+        if (tcount[dbody[i]] > 0) { tcount[dbody[i]]--; done++ }
+      for (i = 0; i < tn; i++)
+        if (dcount[tbody[i]] > 0) { dcount[tbody[i]]--; reopened++ }
+      printf "%d %d %d\n", done, reopened, other
+    }
+  '
+}
+
+compose_commit_message() {
+  local st rel done_n reopened_n other_n parts_count plural
+  local files=0 added=0 changed=0 total_done=0 total_reopened=0 needs_body=0
+  local -a parts=()
+  local -a bullets=()
+  local only_rel="" subject=""
+
+  while IFS=$'\t' read -r st rel; do
+    [[ -n "$rel" ]] || continue
+    files=$((files + 1))
+    [[ "$files" -eq 1 ]] && only_rel="$rel"
+    parts=()
+    if [[ "$st" == A* ]]; then
+      added=$((added + 1))
+      parts+=("added")
+    else
+      changed=$((changed + 1))
+      read -r done_n reopened_n other_n <<<"$(classify_staged_file "$rel")"
+      : "${done_n:=0}" "${reopened_n:=0}" "${other_n:=0}"
+      total_done=$((total_done + done_n))
+      total_reopened=$((total_reopened + reopened_n))
+      (( done_n > 0 )) && parts+=("${done_n} done")
+      (( reopened_n > 0 )) && parts+=("${reopened_n} reopened")
+      (( ${#parts[@]} == 0 || other_n > 0 )) && parts+=("updated")
+    fi
+    parts_count=${#parts[@]}
+    (( files > 1 || parts_count > 1 )) && needs_body=1
+    bullets+=("- ${rel#agenda/}: $(IFS=' '; echo "${parts[*]}")")
+  done < <(git -C "$REPO_DIR" diff --cached --name-status)
+
+  if (( total_done > 0 && total_reopened > 0 )); then
+    subject="mark ${total_done} done, reopen ${total_reopened}"
+  elif (( total_done > 0 )); then
+    subject="mark ${total_done} done"
+  elif (( total_reopened > 0 )); then
+    subject="reopen ${total_reopened}"
+  fi
+
+  if [[ -n "$subject" ]]; then
+    if (( files == 1 )); then
+      subject="agenda: ${subject} in ${only_rel#agenda/}"
+    else
+      subject="agenda: ${subject} across ${files} files"
+    fi
+  elif (( added > 0 && changed > 0 )); then
+    subject="agenda: add ${added}, update ${changed} agenda files"
+  elif (( added > 0 )); then
+    plural="files"
+    (( added == 1 )) && plural="file"
+    subject="agenda: add ${added} agenda ${plural}"
+  elif (( changed > 0 )); then
+    plural="files"
+    (( changed == 1 )) && plural="file"
+    subject="agenda: update ${changed} agenda ${plural}"
+  else
+    subject="Sync Org task state"
+  fi
+
+  if (( needs_body )); then
+    printf '%s\n\n%s\n' "$subject" "$(printf '%s\n' "${bullets[@]}")"
+  else
+    printf '%s\n' "$subject"
+  fi
+}
+
 prepare_aliased_save
 sync_dotfiles_literate
 repair_legacy_imports
@@ -326,6 +475,11 @@ UPSTREAM="$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}
 }
 BASE="$(git -C "$REPO_DIR" rev-parse HEAD)"
 REMOTE_HEAD="$(git -C "$REPO_DIR" rev-parse "$UPSTREAM")"
+
+# BASE is the last-synchronized baseline and is captured before healing so
+# remote changes stay attributable to the remote side.  Publishing our own
+# unpushed commits first keeps the later fast-forward pull from wedging.
+publish_local_commits
 
 mapfile -t org_paths < <(
   {
@@ -411,8 +565,9 @@ if ((${#local_changes[@]})); then
 fi
 
 if ! git -C "$REPO_DIR" diff --cached --quiet; then
+  commit_message="$(compose_commit_message)"
   git -C "$REPO_DIR" -c commit.gpgsign=false commit --no-gpg-sign \
-    -m "Sync Org task state"
+    -m "$commit_message"
   git -C "$REPO_DIR" push
 fi
 

--- a/tests/gpt-todos-sync.sh
+++ b/tests/gpt-todos-sync.sh
@@ -40,6 +40,14 @@ run_sync() {
     bash "$SYNC" "$@"
 }
 
+commit_in_repo() {
+  git -C "$REPO" -c user.name=test -c user.email=test@example.invalid \
+    commit -q --all -m "$1"
+}
+
+subject_of() { git -C "$REPO" log -1 --format=%s; }
+body_of()    { git -C "$REPO" log -1 --format=%b; }
+
 # Initial remote state is restored into the complete local agenda tree.
 run_sync
 cmp "$ORG/shared.org" "$SEED/agenda/shared.org"
@@ -135,5 +143,100 @@ rc=$?
 set -e
 [[ "$rc" -eq 5 ]]
 grep -q 'local-conflict' "$ORG/shared.org"
+
+# Resolve the deliberate conflict above by accepting the remote side, then
+# reset to a synchronized baseline so each smart-message scenario below owns
+# exactly one commit.
+cp "$SEED/agenda/shared.org" "$ORG/shared.org"
+run_sync
+
+printf '* TODO shared-reset\n' > "$ORG/shared.org"
+run_sync
+
+# Checkbox completions produce a counted subject; statistics-cookie churn
+# ([0/3] -> [3/3]) is recognized as derived noise, not a content edit.
+printf '* server research\n*** group [0/3]\n- [ ] alpha\n- [ ] beta\n- [ ] gamma\n' \
+  > "$ORG/smart.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: add 1 agenda file' ]]
+
+sed -i -e 's/\[0\/3\]/[3\/3]/' -e 's/- \[ \]/- [X]/' "$ORG/smart.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: mark 3 done in smart.org' ]]
+[[ -z "$(body_of)" ]]
+
+# Mixed done/reopen work across files counts both and lists per-file bullets.
+printf '* multi\n- [ ] p1\n- [ ] p2\n' > "$ORG/smart-multi.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: add 1 agenda file' ]]
+
+sed -i 's/- \[ \] p1/- [X] p1/' "$ORG/smart-multi.org"
+sed -i 's/- \[X\] alpha/- [ ] alpha/' "$ORG/smart.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: mark 1 done, reopen 1 across 2 files' ]]
+body_of | grep -q -- '- smart-multi.org: 1 done'
+body_of | grep -q -- '- smart.org: 1 reopened'
+
+# TODO -> DONE headline transitions count as done-marking.
+printf '* TODO write report\n' > "$ORG/smart-headline.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: add 1 agenda file' ]]
+
+printf '* DONE write report\n' > "$ORG/smart-headline.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: mark 1 done in smart-headline.org' ]]
+
+# Edits with no task-state signal still sync under a counted update subject.
+printf 'some new context line\n' >> "$ORG/smart-headline.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: update 1 agenda file' ]]
+
+printf 'more context\n' >> "$ORG/smart-headline.org"
+printf '* TODO noise\nplain edit\n' > "$ORG/smart-noise.org"
+run_sync
+[[ "$(subject_of)" == 'agenda: add 1, update 1 agenda files' ]]
+
+# A local commit whose push failed must not wedge the sync: the next run
+# publishes it instead of failing 'Not possible to fast-forward' forever.
+printf '* TODO heal\n' > "$ORG/heal.org"
+run_sync
+
+printf '* TODO heal-stranded\n' > "$REPO/agenda/heal.org"
+commit_in_repo stranded
+run_sync
+git -C "$SEED" pull >/dev/null 2>&1
+git -C "$SEED" log --format=%s -3 | grep -q '^stranded$'
+
+# Divergence with non-overlapping changes is healed by replaying the unpushed
+# commits onto upstream and pushing; remote progress still flows to the agenda.
+printf '* TODO local-diverge\n' > "$REPO/agenda/heal.org"
+commit_in_repo local-diverge
+printf '* TODO remote-diverge\n' > "$SEED/agenda/remote.org"
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -q --all -m remote-diverge
+git -C "$SEED" push >/dev/null 2>&1
+run_sync
+git -C "$SEED" pull >/dev/null 2>&1
+git -C "$SEED" log --format=%s -3 | grep -q '^local-diverge$'
+grep -q 'remote-diverge' "$ORG/remote.org"
+grep -q 'local-diverge' "$ORG/heal.org"
+
+# Divergence that cannot replay cleanly fails closed, keeps the unpushed
+# commits, and leaves no rebase in progress.
+printf '* TODO local-clash\n' > "$REPO/agenda/heal.org"
+commit_in_repo local-clash
+printf '* TODO remote-clash\n' > "$SEED/agenda/heal.org"
+git -C "$SEED" -c user.name=test -c user.email=test@example.invalid \
+  commit -q --all -m remote-clash
+git -C "$SEED" push >/dev/null 2>&1
+
+set +e
+run_sync
+heal_conflict_rc=$?
+set -e
+[[ "$heal_conflict_rc" -ne 0 ]]
+[[ "$(git -C "$REPO" log -1 --format=%s)" == 'local-clash' ]]
+[[ -z "$(git -C "$REPO" status --porcelain -- agenda)" ]]
+grep -q 'local-diverge' "$ORG/heal.org"
 
 printf 'gpt-todos recursive agenda sync tests passed\n'


### PR DESCRIPTION
## Summary
- Compose sync commit messages from the staged agenda diff: checkbox completions (`- [ ]` → `- [X]`), reopenings, and TODO→DONE headline transitions are paired by item text and counted per file; org statistics-cookie churn is ignored. Subjects state the counts (`agenda: mark 10 done in starintel.org`, `agenda: mark 3 done, reopen 1 across 2 files`) with per-file bullets for multi-file commits; unclassifiable edits fall back to counted `add`/`update` subjects.
- Self-heal unpushed durable commits before the fast-forward pull: push when strictly ahead, otherwise replay only the unpushed commits onto upstream (`git rebase`) and push. A replay conflict aborts and fails closed for manual resolution. This un-wedges the 5-minute timer after a failed push (the Aug 27 stranded commit caused a degraded user session for days).

## Test plan
- `tests/gpt-todos-sync.sh` extended with scenarios: single-file done counts (with cookie noise), multi-file done+reopen with body bullets, TODO→DONE headlines, add/update fallbacks, stranded-commit publish, diverged rebase heal, and conflicting-rebase fail-closed. Full suite green.
- Re-tangle idempotent; repo-wide `check-literate-sync` OK (no new drift).
- `nix flake check --no-build` passes.