### PR TITLE
Nyxt: StarIntel workspace, Quasar launcher, and Vim/theme integration

### DIFF
--- a/.config/nyxt/config.lisp
+++ b/.config/nyxt/config.lisp
@@ -71,5 +71,7 @@ Only run it on a trusted machine/session."
 (nyxt::load-lisp "~/.config/nyxt/theme.lisp")
 (nyxt::load-lisp "~/.config/nyxt/status.lisp")
 (nyxt::load-lisp "~/.config/nyxt/reporting.lisp")
+(nyxt::load-lisp "~/.config/nyxt/starintel.lisp")
+(nyxt::load-lisp "~/.config/nyxt/quasar.lisp")
 (nyxt::load-lisp "~/.config/nyxt/proxy.lisp")
 (nyxt::load-lisp "~/.config/nyxt/crunchbase.lisp")

--- a/.config/nyxt/quasar.lisp
+++ b/.config/nyxt/quasar.lisp
@@ -1,0 +1,50 @@
+(in-package #:nyxt-user)
+
+(defparameter *quasar-url* "http://127.0.0.1:5173"
+  "Quasar development UI opened by the Nyxt plugin.")
+
+(defun quasar-launch-background ()
+  (uiop:launch-program
+   '("systemd-run"
+     "--user"
+     "--collect"
+     "--unit=quasar-nyxt"
+     "--property=Restart=on-failure"
+     "quasar-start")
+   :output nil
+   :error-output nil))
+
+(define-command-global quasar-open ()
+  "Open the Quasar UI without changing its process state."
+  (ffi-buffer-load (make-buffer-focus) *quasar-url*))
+
+(define-command-global quasar-start ()
+  "Start the pinned Quasar runtime as a user unit and open its UI."
+  (quasar-launch-background)
+  (quasar-open)
+  (echo "Quasar start requested via quasar-nyxt.service."))
+
+(define-command-global quasar-stop ()
+  "Stop the Nyxt-managed Quasar user unit."
+  (uiop:launch-program '("systemctl" "--user" "stop" "quasar-nyxt.service")
+                       :output nil
+                       :error-output nil)
+  (echo "Quasar stop requested."))
+
+(define-command-global quasar-restart ()
+  "Restart the pinned Quasar runtime and open its UI."
+  (uiop:launch-program '("systemctl" "--user" "stop" "quasar-nyxt.service")
+                       :output nil
+                       :error-output nil)
+  (quasar-launch-background)
+  (quasar-open)
+  (echo "Quasar restart requested."))
+
+(define-configuration nyxt/mode/vi:vi-normal-mode
+  ((keyscheme-map
+    (define-keyscheme-map
+     "vi-quasar" (list :import %slot-value%)
+     nyxt/keyscheme:vi-normal
+     (list
+      "g q" 'quasar-start
+      "g Q" 'quasar-open)))))

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -1,12 +1,89 @@
 (in-package #:nyxt-user)
 
-(defparameter *starintel-base-url*
-  (string-right-trim "/" (or (uiop:getenv "STARINTEL_URL")
-                              "http://127.0.0.1:5000"))
-  "StarIntel HTTP API base URL.")
+(defparameter *starintel-default-base-url* "http://127.0.0.1:5000"
+  "Default StarIntel HTTP API base URL when no persistent config or override exists.")
+
+(defun starintel-config-root ()
+  (merge-pathnames
+   "starintel/"
+   (uiop:ensure-directory-pathname
+    (or (uiop:getenv "XDG_CONFIG_HOME")
+        (merge-pathnames ".config/" (user-homedir-pathname))))))
+
+(defun starintel-config-file (name)
+  (merge-pathnames name (starintel-config-root)))
+
+(defun starintel-trim (value)
+  (and value
+       (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+
+(defun starintel-read-config-file (name)
+  (let ((path (starintel-config-file name)))
+    (when (probe-file path)
+      (starintel-trim (uiop:read-file-string path)))))
+
+(defun starintel-base-url ()
+  (string-right-trim
+   "/"
+   (or (starintel-trim (uiop:getenv "STARINTEL_URL"))
+       (starintel-read-config-file "url")
+       *starintel-default-base-url*)))
+
+(defun starintel-file-mode (path)
+  (starintel-trim
+   (ignore-errors
+     (uiop:run-program
+      (list "stat" "-L" "-c" "%a" (namestring path))
+      :output :string
+      :error-output nil
+      :ignore-error-status t))))
+
+(defun starintel-api-key-file ()
+  (let ((path (starintel-config-file "api-key")))
+    (when (probe-file path)
+      (unless (string= (or (starintel-file-mode path) "") "600")
+        (error "Refusing StarIntel API key file unless its mode is 0600: ~a"
+               (namestring path)))
+      (starintel-trim (uiop:read-file-string path)))))
 
 (defun starintel-api-key ()
-  (uiop:getenv "STARINTEL_API_KEY"))
+  (or (starintel-trim (uiop:getenv "STARINTEL_API_KEY"))
+      (starintel-api-key-file)))
+
+(defun starintel-write-config-file (name value &key secret)
+  (let* ((root (starintel-config-root))
+         (path (starintel-config-file name)))
+    (ensure-directories-exist path)
+    (uiop:run-program (list "chmod" "700" (namestring root))
+                      :output nil
+                      :error-output nil)
+    (with-open-file (stream path
+                            :direction :output
+                            :if-does-not-exist :create
+                            :if-exists :supersede)
+      (write-line value stream))
+    (uiop:run-program (list "chmod" (if secret "600" "600") (namestring path))
+                      :output nil
+                      :error-output nil)
+    path))
+
+(define-command-global starintel-set-api-key ()
+  "Persist the StarIntel API key in ~/.config/starintel/api-key with mode 0600."
+  (let ((key (prompt1 :prompt "StarIntel API key" :sources 'prompter:raw-source)))
+    (when (str:blankp key)
+      (error "StarIntel API key cannot be blank."))
+    (starintel-write-config-file "api-key" key :secret t)
+    (echo "Saved StarIntel API key to ~/.config/starintel/api-key (0600).")))
+
+(define-command-global starintel-set-url ()
+  "Persist the StarIntel API URL in ~/.config/starintel/url."
+  (let ((url (prompt1 :prompt "StarIntel API URL"
+                      :input (starintel-base-url)
+                      :sources 'prompter:raw-source)))
+    (when (str:blankp url)
+      (error "StarIntel API URL cannot be blank."))
+    (starintel-write-config-file "url" (string-right-trim "/" url))
+    (echo "Saved StarIntel API URL to ~/.config/starintel/url.")))
 
 (defun starintel-headers (&key json)
   (let ((headers (when json
@@ -16,11 +93,11 @@
     headers))
 
 (defun starintel-get (path)
-  (dex:get (format nil "~a~a" *starintel-base-url* path)
+  (dex:get (format nil "~a~a" (starintel-base-url) path)
            :headers (starintel-headers)))
 
 (defun starintel-post (path object)
-  (dex:post (format nil "~a~a" *starintel-base-url* path)
+  (dex:post (format nil "~a~a" (starintel-base-url) path)
             :headers (starintel-headers :json t)
             :content (njson:encode object)))
 
@@ -105,7 +182,7 @@
        " · "
        (:a :href "starintel:search" "search")
        " · API "
-       (:span.muted *starintel-base-url*))
+       (:span.muted (starintel-base-url)))
       (funcall body-writer)))))
 
 (defun starintel-search-page (url)
@@ -187,13 +264,13 @@
         (:SEARCH (starintel-search-page url))
         (:DOCUMENT (starintel-document-page url))
         (otherwise (starintel-search-page "starintel:search")))
-    (error (condition)
+    (error ()
       (starintel-page
        "StarIntel Error"
        (lambda ()
          (spinneret:with-html
            (:h1 "StarIntel request failed")
-           (:pre (princ-to-string condition))))))))
+           (:p "The request failed. Check the API URL, API key, and Nyxt logs.")))))))
 
 (define-internal-scheme "starintel" #'starintel-scheme-handler)
 

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -13,24 +13,26 @@
 (defun starintel-config-file (name)
   (merge-pathnames name (starintel-config-root)))
 
-(defun starintel-trim (value)
-  (and value
-       (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+(defun starintel-nonblank (value)
+  (when value
+    (let ((trimmed (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+      (unless (zerop (length trimmed))
+        trimmed))))
 
 (defun starintel-read-config-file (name)
   (let ((path (starintel-config-file name)))
     (when (probe-file path)
-      (starintel-trim (uiop:read-file-string path)))))
+      (starintel-nonblank (uiop:read-file-string path)))))
 
 (defun starintel-base-url ()
   (string-right-trim
    "/"
-   (or (starintel-trim (uiop:getenv "STARINTEL_URL"))
+   (or (starintel-nonblank (uiop:getenv "STARINTEL_URL"))
        (starintel-read-config-file "url")
        *starintel-default-base-url*)))
 
 (defun starintel-file-mode (path)
-  (starintel-trim
+  (starintel-nonblank
    (ignore-errors
      (uiop:run-program
       (list "stat" "-L" "-c" "%a" (namestring path))
@@ -44,46 +46,11 @@
       (unless (string= (or (starintel-file-mode path) "") "600")
         (error "Refusing StarIntel API key file unless its mode is 0600: ~a"
                (namestring path)))
-      (starintel-trim (uiop:read-file-string path)))))
+      (starintel-read-config-file "api-key"))))
 
 (defun starintel-api-key ()
-  (or (starintel-trim (uiop:getenv "STARINTEL_API_KEY"))
+  (or (starintel-nonblank (uiop:getenv "STARINTEL_API_KEY"))
       (starintel-api-key-file)))
-
-(defun starintel-write-config-file (name value &key secret)
-  (let* ((root (starintel-config-root))
-         (path (starintel-config-file name)))
-    (ensure-directories-exist path)
-    (uiop:run-program (list "chmod" "700" (namestring root))
-                      :output nil
-                      :error-output nil)
-    (with-open-file (stream path
-                            :direction :output
-                            :if-does-not-exist :create
-                            :if-exists :supersede)
-      (write-line value stream))
-    (uiop:run-program (list "chmod" (if secret "600" "600") (namestring path))
-                      :output nil
-                      :error-output nil)
-    path))
-
-(define-command-global starintel-set-api-key ()
-  "Persist the StarIntel API key in ~/.config/starintel/api-key with mode 0600."
-  (let ((key (prompt1 :prompt "StarIntel API key" :sources 'prompter:raw-source)))
-    (when (str:blankp key)
-      (error "StarIntel API key cannot be blank."))
-    (starintel-write-config-file "api-key" key :secret t)
-    (echo "Saved StarIntel API key to ~/.config/starintel/api-key (0600).")))
-
-(define-command-global starintel-set-url ()
-  "Persist the StarIntel API URL in ~/.config/starintel/url."
-  (let ((url (prompt1 :prompt "StarIntel API URL"
-                      :input (starintel-base-url)
-                      :sources 'prompter:raw-source)))
-    (when (str:blankp url)
-      (error "StarIntel API URL cannot be blank."))
-    (starintel-write-config-file "url" (string-right-trim "/" url))
-    (echo "Saved StarIntel API URL to ~/.config/starintel/url.")))
 
 (defun starintel-headers (&key json)
   (let ((headers (when json
@@ -93,13 +60,19 @@
     headers))
 
 (defun starintel-get (path)
-  (dex:get (format nil "~a~a" (starintel-base-url) path)
-           :headers (starintel-headers)))
+  (handler-case
+      (dex:get (format nil "~a~a" (starintel-base-url) path)
+               :headers (starintel-headers))
+    (error ()
+      (error "StarIntel GET request failed."))))
 
 (defun starintel-post (path object)
-  (dex:post (format nil "~a~a" (starintel-base-url) path)
-            :headers (starintel-headers :json t)
-            :content (njson:encode object)))
+  (handler-case
+      (dex:post (format nil "~a~a" (starintel-base-url) path)
+                :headers (starintel-headers :json t)
+                :content (njson:encode object))
+    (error ()
+      (error "StarIntel POST request failed."))))
 
 (defun starintel-param (url key &optional default)
   (or (assoc-value (quri:uri-query-params (quri:uri url)) key :test #'string=)

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -116,13 +116,20 @@
   (or (starintel-json-get (starintel-result-doc row) "dataset") ""))
 
 (defun starintel-result-summary (row)
-  (let ((doc (starintel-result-doc row)))
-    (or (starintel-json-get doc "text")
-        (starintel-json-get doc "name")
-        (starintel-json-get doc "domain")
-        (starintel-json-get doc "url")
-        (starintel-json-get doc "handle")
-        (starintel-json-get doc "email")
+  (let* ((doc (starintel-result-doc row))
+         (data (or (starintel-json-get doc "data") doc)))
+    (or (starintel-nonblank (starintel-json-get doc "title"))
+        (starintel-nonblank (starintel-json-get doc "summary"))
+        (starintel-nonblank (starintel-json-get doc "description"))
+        (starintel-json-get data "name")
+        (starintel-json-get data "display_name")
+        (starintel-json-get data "legal_name")
+        (starintel-json-get data "text")
+        (starintel-json-get data "content")
+        (starintel-json-get data "domain")
+        (starintel-json-get data "url")
+        (starintel-json-get data "handle")
+        (starintel-json-get data "email")
         "")))
 
 (defparameter *starintel-page-css*
@@ -303,14 +310,6 @@
           (gethash "data" document) data)
     document))
 
-(defun starintel-merge-json-object (target source)
-  (unless (hash-table-p source)
-    (error "Extra JSON must be an object."))
-  (maphash (lambda (key value)
-             (setf (gethash key target) value))
-           source)
-  target)
-
 (define-command-global starintel-create-document-from-selection ()
   "Create a canonical StarIntel v0.9 document using selected text as a data field."
   (let ((selection (ffi-buffer-copy (current-buffer))))
@@ -338,11 +337,16 @@
             (echo "Created StarIntel ~a document from selected data field ~a." dtype field))))))
 
 (define-command-global starintel-create-document ()
-  "Create a StarIntel document from a complete canonical JSON object."
+  "Create a StarIntel document by editing a complete canonical JSON object."
   (let* ((dtype (starintel-canonical-dtype
                  (prompt1 :prompt "Document type" :sources 'prompter:raw-source)))
+         (dataset (prompt1 :prompt "Dataset"
+                           :input "manual"
+                           :sources 'prompter:raw-source))
+         (template (starintel-new-document dtype dataset
+                                           (make-hash-table :test #'equal)))
          (raw (prompt1 :prompt "Canonical document JSON"
-                       :input (format nil "{\"dtype\":\"~a\"}" dtype)
+                       :input (njson:encode template)
                        :sources 'prompter:raw-source))
          (document (njson:decode raw)))
     (unless (hash-table-p document)

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -3,6 +3,10 @@
 (defparameter *starintel-default-base-url* "http://127.0.0.1:5000"
   "Default StarIntel HTTP API base URL when no persistent config or override exists.")
 
+(defparameter *starintel-empty-document-json*
+  "{\"_id\":\"\",\"dataset\":\"\",\"dtype\":\"\",\"schema_version\":\"0.9.0\",\"version\":1,\"date_added\":\"\",\"date_updated\":\"\",\"title\":\"\",\"summary\":\"\",\"description\":\"\",\"status\":\"recorded\",\"language\":\"en\",\"tags\":[],\"labels\":[],\"aliases\":[],\"keywords\":[],\"identifiers\":[],\"sources\":[],\"evidence\":[],\"temporal\":{},\"provenance\":{},\"assessment\":{},\"verification\":{\"status\":\"unverified\",\"verified\":false},\"handling\":{\"visibility\":\"public\",\"sensitive\":false,\"pii\":false},\"lineage\":{},\"quality\":{},\"workflow\":{},\"geospatial\":{},\"attachments\":[],\"related_ids\":[],\"notes\":[],\"data\":{},\"extensions\":{}}"
+  "Canonical empty StarIntel v0.9 document envelope.")
+
 (defun starintel-config-root ()
   (merge-pathnames
    "starintel/"
@@ -265,6 +269,40 @@
          (format nil "starintel:search?q=~a" (quri:url-encode selection))
          :new-buffer t))))
 
+(defun starintel-canonical-dtype (dtype)
+  (let ((token (substitute #\- #\_ (string-downcase dtype))))
+    (cond
+      ((member token '("organization" "organisation") :test #'string=) "org")
+      ((string= token "investigation-target") "target")
+      ((string= token "social-media-posts") "social-media-post")
+      (t token))))
+
+(defun starintel-now ()
+  (multiple-value-bind (second minute hour day month year)
+      (decode-universal-time (get-universal-time) 0)
+    (format nil "~4,'0d-~2,'0d-~2,'0dT~2,'0d:~2,'0d:~2,'0dZ"
+            year month day hour minute second)))
+
+(defun starintel-new-id (dtype)
+  (format nil "starintel:~a:nyxt-~d-~8,'0x"
+          dtype
+          (get-universal-time)
+          (random #x100000000)))
+
+(defun starintel-new-document (dtype dataset data)
+  (unless (hash-table-p data)
+    (error "StarIntel data JSON must be an object."))
+  (let* ((dtype (starintel-canonical-dtype dtype))
+         (now (starintel-now))
+         (document (njson:decode *starintel-empty-document-json*)))
+    (setf (gethash "_id" document) (starintel-new-id dtype)
+          (gethash "dataset" document) dataset
+          (gethash "dtype" document) dtype
+          (gethash "date_added" document) now
+          (gethash "date_updated" document) now
+          (gethash "data" document) data)
+    document))
+
 (defun starintel-merge-json-object (target source)
   (unless (hash-table-p source)
     (error "Extra JSON must be an object."))
@@ -274,29 +312,36 @@
   target)
 
 (define-command-global starintel-create-document-from-selection ()
-  "Create a StarIntel document using selected text as an arbitrary field."
+  "Create a canonical StarIntel v0.9 document using selected text as a data field."
   (let ((selection (ffi-buffer-copy (current-buffer))))
     (if (str:blankp selection)
         (echo "Select the field value first.")
-        (let* ((dtype (prompt1 :prompt "Document type" :sources 'prompter:raw-source))
-               (field (prompt1 :prompt "Field name" :sources 'prompter:raw-source))
-               (extra-raw (prompt1 :prompt "Extra JSON object"
+        (let* ((dtype (starintel-canonical-dtype
+                       (prompt1 :prompt "Document type" :sources 'prompter:raw-source)))
+               (dataset (prompt1 :prompt "Dataset"
+                                 :input "manual"
+                                 :sources 'prompter:raw-source))
+               (field (prompt1 :prompt "Data field name" :sources 'prompter:raw-source))
+               (extra-raw (prompt1 :prompt "Extra data JSON object"
                                    :input "{}"
                                    :sources 'prompter:raw-source))
-               (extra (njson:decode extra-raw))
-               (document (make-hash-table :test #'equal)))
-          (when (or (str:blankp dtype) (str:blankp field))
-            (error "Document type and field name are required."))
-          (starintel-merge-json-object document extra)
-          (setf (gethash "dtype" document) dtype
-                (gethash field document) selection)
-          (starintel-post (format nil "/new/document/~a" (quri:url-encode dtype)) document)
-          (echo "Created StarIntel ~a document from selected ~a." dtype field)))))
+               (data (njson:decode extra-raw)))
+          (when (or (str:blankp dtype)
+                    (str:blankp dataset)
+                    (str:blankp field))
+            (error "Document type, dataset, and data field name are required."))
+          (unless (hash-table-p data)
+            (error "Extra data JSON must be an object."))
+          (setf (gethash field data) selection)
+          (let ((document (starintel-new-document dtype dataset data)))
+            (starintel-post (format nil "/new/document/~a" (quri:url-encode dtype)) document)
+            (echo "Created StarIntel ~a document from selected data field ~a." dtype field))))))
 
 (define-command-global starintel-create-document ()
-  "Create a StarIntel document from a complete JSON object."
-  (let* ((dtype (prompt1 :prompt "Document type" :sources 'prompter:raw-source))
-         (raw (prompt1 :prompt "Document JSON"
+  "Create a StarIntel document from a complete canonical JSON object."
+  (let* ((dtype (starintel-canonical-dtype
+                 (prompt1 :prompt "Document type" :sources 'prompter:raw-source)))
+         (raw (prompt1 :prompt "Canonical document JSON"
                        :input (format nil "{\"dtype\":\"~a\"}" dtype)
                        :sources 'prompter:raw-source))
          (document (njson:decode raw)))

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -74,12 +74,14 @@
     (error ()
       (error "StarIntel POST request failed."))))
 
-(defun starintel-param (url key &optional default)
-  (or (assoc-value (quri:uri-query-params (quri:uri url)) key :test #'string=)
+(defun starintel-param (url-designator key &optional default)
+  (or (assoc-value (quri:uri-query-params (url url-designator))
+                   key
+                   :test #'string=)
       default))
 
-(defun starintel-route-name (url)
-  (let* ((uri (quri:uri url))
+(defun starintel-route-name (url-designator)
+  (let* ((uri (url url-designator))
          (host (quri:uri-host uri))
          (path (string-trim "/" (or (quri:uri-path uri) ""))))
     (string-downcase (if (and host (plusp (length host))) host path))))

--- a/.config/nyxt/starintel.lisp
+++ b/.config/nyxt/starintel.lisp
@@ -1,0 +1,268 @@
+(in-package #:nyxt-user)
+
+(defparameter *starintel-base-url*
+  (string-right-trim "/" (or (uiop:getenv "STARINTEL_URL")
+                              "http://127.0.0.1:5000"))
+  "StarIntel HTTP API base URL.")
+
+(defun starintel-api-key ()
+  (uiop:getenv "STARINTEL_API_KEY"))
+
+(defun starintel-headers (&key json)
+  (let ((headers (when json
+                   (list (cons "Content-Type" "application/json")))))
+    (when-let ((key (starintel-api-key)))
+      (push (cons "Authorization" (format nil "Bearer ~a" key)) headers))
+    headers))
+
+(defun starintel-get (path)
+  (dex:get (format nil "~a~a" *starintel-base-url* path)
+           :headers (starintel-headers)))
+
+(defun starintel-post (path object)
+  (dex:post (format nil "~a~a" *starintel-base-url* path)
+            :headers (starintel-headers :json t)
+            :content (njson:encode object)))
+
+(defun starintel-param (url key &optional default)
+  (or (assoc-value (quri:uri-query-params (quri:uri url)) key :test #'string=)
+      default))
+
+(defun starintel-route-name (url)
+  (let* ((uri (quri:uri url))
+         (host (quri:uri-host uri))
+         (path (string-trim "/" (or (quri:uri-path uri) ""))))
+    (string-downcase (if (and host (plusp (length host))) host path))))
+
+(defun starintel-json-get (object key &optional default)
+  (handler-case
+      (let ((value (njson:jget key object)))
+        (if (eq value :null) default value))
+    (error () default)))
+
+(defun starintel-result-doc (row)
+  (or (starintel-json-get row "doc") row))
+
+(defun starintel-result-id (row)
+  (let ((doc (starintel-result-doc row)))
+    (or (starintel-json-get doc "_id")
+        (starintel-json-get doc "id")
+        (starintel-json-get row "id")
+        "")))
+
+(defun starintel-result-type (row)
+  (let ((doc (starintel-result-doc row)))
+    (or (starintel-json-get doc "dtype")
+        (starintel-json-get doc "type")
+        "")))
+
+(defun starintel-result-dataset (row)
+  (or (starintel-json-get (starintel-result-doc row) "dataset") ""))
+
+(defun starintel-result-summary (row)
+  (let ((doc (starintel-result-doc row)))
+    (or (starintel-json-get doc "text")
+        (starintel-json-get doc "name")
+        (starintel-json-get doc "domain")
+        (starintel-json-get doc "url")
+        (starintel-json-get doc "handle")
+        (starintel-json-get doc "email")
+        "")))
+
+(defparameter *starintel-page-css*
+  "body { background:#170c32; color:#f3f4f5; font-family:system-ui,sans-serif; margin:0; padding:24px; }
+   a { color:#2de2e6; text-decoration:none; }
+   a:visited { color:#92406e; }
+   a:hover, a:active { color:#f6019d; }
+   h1,h2 { color:#f6019d; }
+   .bar, .card { background:#202146; border:1px solid #92406e; border-radius:8px; padding:14px; margin-bottom:16px; }
+   form { display:flex; gap:8px; flex-wrap:wrap; align-items:end; }
+   label { color:#2de2e6; font-size:.85rem; display:flex; flex-direction:column; gap:4px; }
+   input { background:#170c32; color:#f3f4f5; border:1px solid #92406e; border-radius:6px; padding:8px; }
+   input:focus { outline:1px solid #2de2e6; border-color:#2de2e6; }
+   button { background:#f6019d; color:#170c32; border:1px solid #2de2e6; border-radius:6px; padding:8px 14px; font-weight:700; }
+   table { width:100%; border-collapse:collapse; background:#202146; }
+   th { color:#2de2e6; text-align:left; border-bottom:1px solid #92406e; padding:8px; }
+   td { border-bottom:1px solid #3a285d; padding:8px; vertical-align:top; }
+   tr:hover { background:#2a285b; }
+   code, pre { font-family:ui-monospace,monospace; }
+   pre { white-space:pre-wrap; overflow-wrap:anywhere; background:#0f0822; border:1px solid #92406e; padding:14px; border-radius:8px; }
+   .muted { color:#bca8cf; }
+   .pager { display:flex; gap:14px; margin-top:16px; }"
+  "CSS for native StarIntel Nyxt pages.")
+
+(defun starintel-page (title body-writer)
+  (spinneret:with-html-string
+    (:doctype)
+    (:html
+     (:head
+      (:meta :charset "utf-8")
+      (:title title)
+      (:style (:raw *starintel-page-css*)))
+     (:body
+      (:div.bar
+       (:strong "STARINTEL")
+       " · "
+       (:a :href "starintel:search" "search")
+       " · API "
+       (:span.muted *starintel-base-url*))
+      (funcall body-writer)))))
+
+(defun starintel-search-page (url)
+  (let* ((query (starintel-param url "q" ""))
+         (limit-raw (starintel-param url "limit" "50"))
+         (sort (starintel-param url "sort" ""))
+         (bookmark (starintel-param url "bookmark" ""))
+         (limit (or (parse-integer limit-raw :junk-allowed t) 50))
+         (limit (max 1 (min limit 200)))
+         (body (unless (str:blankp query)
+                 (starintel-get
+                  (format nil "/search?q=~a&limit=~d~@[&sort=~a~]~@[&bookmark=~a~]"
+                          (quri:url-encode query)
+                          limit
+                          (unless (str:blankp sort) (quri:url-encode sort))
+                          (unless (str:blankp bookmark) (quri:url-encode bookmark))))))
+         (json (when body (njson:decode body)))
+         (rows (or (and json (starintel-json-get json "rows")) #()))
+         (next-bookmark (and json (starintel-json-get json "bookmark")))
+         (total (and json (or (starintel-json-get json "total_rows")
+                              (starintel-json-get json "total")))))
+    (starintel-page
+     "StarIntel Search"
+     (lambda ()
+       (spinneret:with-html
+         (:h1 "Search")
+         (:div.card
+          (:form :method "get" :action "starintel:search"
+           (:label "Query" (:input :name "q" :value query :size "60" :autofocus t))
+           (:label "Limit" (:input :name "limit" :type "number" :min "1" :max "200" :value (princ-to-string limit)))
+           (:label "Sort" (:input :name "sort" :value sort :placeholder "optional CouchDB sort"))
+           (:button :type "submit" "Search")))
+         (when body
+           (:p.muted
+            (format nil "~d result~:p~@[ · ~a total~]" (length rows) total))
+           (:table
+            (:thead (:tr (:th "Type") (:th "ID") (:th "Dataset") (:th "Summary")))
+            (:tbody
+             (loop for row across (coerce rows 'vector)
+                   for id = (starintel-result-id row)
+                   do (:tr
+                       (:td (starintel-result-type row))
+                       (:td
+                        (if (str:blankp id)
+                            "—"
+                            (:a :href (format nil "starintel:document?id=~a" (quri:url-encode id)) id)))
+                       (:td (starintel-result-dataset row))
+                       (:td (starintel-result-summary row))))))
+           (when next-bookmark
+             (:div.pager
+              (:a :href (format nil "starintel:search?q=~a&limit=~d~@[&sort=~a~]&bookmark=~a"
+                                (quri:url-encode query)
+                                limit
+                                (unless (str:blankp sort) (quri:url-encode sort))
+                                (quri:url-encode next-bookmark))
+                  "Next page →")))
+           (:details
+            (:summary "Raw response")
+            (:pre body))))))))
+
+(defun starintel-document-page (url)
+  (let* ((id (starintel-param url "id" ""))
+         (body (unless (str:blankp id)
+                 (starintel-get (format nil "/document/~a" (quri:url-encode id))))))
+    (starintel-page
+     (if (str:blankp id) "StarIntel Document" (format nil "StarIntel · ~a" id))
+     (lambda ()
+       (spinneret:with-html
+         (:h1 "Document")
+         (if (str:blankp id)
+             (:p "Missing document id.")
+             (progn
+               (:p (:strong id))
+               (:pre body))))))))
+
+(defun starintel-scheme-handler (url)
+  (handler-case
+      (case (intern (string-upcase (starintel-route-name url)) :keyword)
+        (:SEARCH (starintel-search-page url))
+        (:DOCUMENT (starintel-document-page url))
+        (otherwise (starintel-search-page "starintel:search")))
+    (error (condition)
+      (starintel-page
+       "StarIntel Error"
+       (lambda ()
+         (spinneret:with-html
+           (:h1 "StarIntel request failed")
+           (:pre (princ-to-string condition))))))))
+
+(define-internal-scheme "starintel" #'starintel-scheme-handler)
+
+(defun starintel-open-url (url &key new-buffer)
+  (ffi-buffer-load (if new-buffer (make-buffer-focus) (current-buffer)) url))
+
+(define-command-global starintel-search ()
+  "Open the full StarIntel search interface in Nyxt."
+  (starintel-open-url "starintel:search" :new-buffer t))
+
+(define-command-global starintel-search-selection ()
+  "Search StarIntel for the current page selection."
+  (let ((selection (ffi-buffer-copy (current-buffer))))
+    (if (str:blankp selection)
+        (echo "Select text first.")
+        (starintel-open-url
+         (format nil "starintel:search?q=~a" (quri:url-encode selection))
+         :new-buffer t))))
+
+(defun starintel-merge-json-object (target source)
+  (unless (hash-table-p source)
+    (error "Extra JSON must be an object."))
+  (maphash (lambda (key value)
+             (setf (gethash key target) value))
+           source)
+  target)
+
+(define-command-global starintel-create-document-from-selection ()
+  "Create a StarIntel document using selected text as an arbitrary field."
+  (let ((selection (ffi-buffer-copy (current-buffer))))
+    (if (str:blankp selection)
+        (echo "Select the field value first.")
+        (let* ((dtype (prompt1 :prompt "Document type" :sources 'prompter:raw-source))
+               (field (prompt1 :prompt "Field name" :sources 'prompter:raw-source))
+               (extra-raw (prompt1 :prompt "Extra JSON object"
+                                   :input "{}"
+                                   :sources 'prompter:raw-source))
+               (extra (njson:decode extra-raw))
+               (document (make-hash-table :test #'equal)))
+          (when (or (str:blankp dtype) (str:blankp field))
+            (error "Document type and field name are required."))
+          (starintel-merge-json-object document extra)
+          (setf (gethash "dtype" document) dtype
+                (gethash field document) selection)
+          (starintel-post (format nil "/new/document/~a" (quri:url-encode dtype)) document)
+          (echo "Created StarIntel ~a document from selected ~a." dtype field)))))
+
+(define-command-global starintel-create-document ()
+  "Create a StarIntel document from a complete JSON object."
+  (let* ((dtype (prompt1 :prompt "Document type" :sources 'prompter:raw-source))
+         (raw (prompt1 :prompt "Document JSON"
+                       :input (format nil "{\"dtype\":\"~a\"}" dtype)
+                       :sources 'prompter:raw-source))
+         (document (njson:decode raw)))
+    (unless (hash-table-p document)
+      (error "Document JSON must be an object."))
+    (setf (gethash "dtype" document) dtype)
+    (starintel-post (format nil "/new/document/~a" (quri:url-encode dtype)) document)
+    (echo "Created StarIntel ~a document." dtype)))
+
+;; Extend only VI normal mode: these bindings never steal printable keys while
+;; Nyxt is in VI insert mode or a prompt buffer is accepting text.
+(define-configuration nyxt/mode/vi:vi-normal-mode
+  ((keyscheme-map
+    (define-keyscheme-map
+     "vi-starintel" (list :import %slot-value%)
+     nyxt/keyscheme:vi-normal
+     (list
+      "g s" 'starintel-search
+      "g S" 'starintel-search-selection
+      "g d" 'starintel-create-document-from-selection
+      "g D" 'starintel-create-document)))))

--- a/.config/nyxt/theme.lisp
+++ b/.config/nyxt/theme.lisp
@@ -29,6 +29,14 @@
       '("#input:focus"
         :border-color "#2de2e6"
         :box-shadow "inset 0 0 10px rgba(45, 226, 230, 0.16), 0 0 8px rgba(45, 226, 230, 0.20)")
+      '(a
+        :color "#2de2e6")
+      '("a:visited"
+        :color "#92406e")
+      '("a:hover"
+        :color "#f6019d")
+      '("a:active"
+        :color "#f6019d")
       '(".source-name"
         :text-transform "uppercase"
         :letter-spacing "0.08em")

--- a/.config/nyxt/theme.lisp
+++ b/.config/nyxt/theme.lisp
@@ -26,13 +26,27 @@
         :box-shadow "0 0 16px rgba(246, 1, 157, 0.40)")
       '("#input"
         :box-shadow "inset 0 0 10px rgba(45, 226, 230, 0.12)")
+      '("#input:focus"
+        :border-color "#2de2e6"
+        :box-shadow "inset 0 0 10px rgba(45, 226, 230, 0.16), 0 0 8px rgba(45, 226, 230, 0.20)")
       '(".source-name"
         :text-transform "uppercase"
         :letter-spacing "0.08em")
       '("#selection"
+        :background-color "#202146"
+        :color "#f3f4f5"
+        :border "1px solid #2de2e6"
         :box-shadow "inset 4px 0 0 #2de2e6, 0 0 10px rgba(246, 1, 157, 0.28)")
+      '("tr:hover"
+        :background-color "#2a285b"
+        :color "#f3f4f5")
       '(".marked"
-        :box-shadow "inset 4px 0 0 #fba922"))))))
+        :background-color "#3a285d"
+        :color "#fba922"
+        :box-shadow "inset 4px 0 0 #fba922")
+      '(".selected"
+        :background-color "#202146"
+        :color "#f3f4f5"))))))
 
 (define-configuration status-buffer
   ((height 40)
@@ -82,7 +96,11 @@
         :color "#f3f4f5")
       '(a
         :color "#2de2e6")
+      '("a:visited"
+        :color "#92406e")
       '("a:hover"
+        :color "#f6019d")
+      '("a:active"
         :color "#f6019d")
       '(hr
         :border-color "#92406e")

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       url = "github:lost-rob0t/Mousetrap";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    quasar = {
+      url = "github:lost-rob0t/quasar/80553699fa6c9dec227d4ddff629c3ab3a8b8010";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -41,6 +45,7 @@
       zara,
       bixby-studio,
       mousetrap,
+      quasar,
     }:
     let
       system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -28,10 +28,6 @@
       url = "github:lost-rob0t/Mousetrap";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    quasar = {
-      url = "github:lost-rob0t/quasar/80553699fa6c9dec227d4ddff629c3ab3a8b8010";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -45,7 +41,6 @@
       zara,
       bixby-studio,
       mousetrap,
-      quasar,
     }:
     let
       system = "x86_64-linux";

--- a/nix/home-manager/systems/desktop/programs.nix
+++ b/nix/home-manager/systems/desktop/programs.nix
@@ -1,19 +1,80 @@
 { config, lib, pkgs, inputs, ... }:
 
-# this really doesnt work in nyxt yet
-#let
-#  nyxt = pkgs.nyxt.overrideAttrs (oldAttrs: {
-#    postFixup = ''
-#      wrapProgram $out/bin/nyxt \
-#        --set-default WEBKIT_FORCE_SANDBOX 0
-#    '';
-#  });
-#  in
-#
-{
+let
+  quasarRuntimeLibs = with pkgs; [
+    openssl
+    rabbitmq-c
+    libffi
+    sqlite
+    lmdb
+  ];
 
+  quasarStart = pkgs.writeShellApplication {
+    name = "quasar-start";
+    runtimeInputs = with pkgs; [
+      bash
+      coreutils
+      curl
+      git
+      nodejs_22
+      sbcl
+      pkg-config
+      chromium
+      gcc
+      gnumake
+    ] ++ quasarRuntimeLibs;
+    text = ''
+      pin="80553699fa6c9dec227d4ddff629c3ab3a8b8010"
+      cache_root="''${XDG_CACHE_HOME:-$HOME/.cache}/quasar-pinned"
+      workdir="$cache_root/$pin"
+      source_path='${inputs.quasar}'
+
+      if curl --fail --silent --max-time 1 http://127.0.0.1:5173/ >/dev/null 2>&1; then
+        echo "Quasar is already running at http://127.0.0.1:5173"
+        exit 0
+      fi
+
+      mkdir -p "$cache_root"
+      if [ ! -f "$workdir/.quasar-pin" ] || [ "$(cat "$workdir/.quasar-pin" 2>/dev/null || true)" != "$pin" ]; then
+        tmp="$cache_root/.tmp-$pin-$$"
+        rm -rf "$tmp"
+        mkdir -p "$tmp"
+        cp -a "$source_path"/. "$tmp"/
+        chmod -R u+w "$tmp"
+        printf '%s\n' "$pin" > "$tmp/.quasar-pin"
+        rm -rf "$workdir"
+        mv "$tmp" "$workdir"
+      fi
+
+      cd "$workdir"
+
+      export QUASAR_DEV_NIX_READY=1
+      export QUASAR_PRODUCTION_NIX_READY=1
+      export QUASAR_PRODUCTION_SMOKE_NIX_READY=1
+      export QUASAR_TEK9_PATH="''${QUASAR_TEK9_PATH:-$HOME/starintel/tek9}"
+      export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath quasarRuntimeLibs}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      export TMPDIR="/tmp"
+      export TMP="/tmp"
+      export TEMP="/tmp"
+      export XDG_CONFIG_HOME="''${XDG_CONFIG_HOME:-$HOME/.config}"
+      export XDG_CACHE_HOME="''${XDG_CACHE_HOME:-$HOME/.cache}"
+      export CL_SOURCE_REGISTRY="(:source-registry (:tree \"$QUASAR_TEK9_PATH/\") (:tree \"$HOME/quicklisp/local-projects/\") (:tree \"$HOME/quicklisp/dists/quicklisp/software/\") (:tree \"$PWD/systems/\") :ignore-inherited-configuration)"
+
+      mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"
+      bash scripts/bootstrap-lisp-deps
+
+      if [ ! -d node_modules ]; then
+        npm ci
+      fi
+
+      exec npm run dev
+    '';
+  };
+in
+{
   home.packages = with pkgs; [
     nyxt
+    quasarStart
     # Development
     gitRepo
     nodejs_24
@@ -64,7 +125,7 @@
     element-desktop
     thunderbird
     # Misc
-	# FIXME Broken package
+    # FIXME Broken package
     #monero-gui
     hugo
     #AI

--- a/nix/home-manager/systems/desktop/programs.nix
+++ b/nix/home-manager/systems/desktop/programs.nix
@@ -1,6 +1,12 @@
 { config, lib, pkgs, inputs, ... }:
 
 let
+  quasarPin = "80553699fa6c9dec227d4ddff629c3ab3a8b8010";
+  quasarSource = builtins.fetchGit {
+    url = "https://github.com/lost-rob0t/quasar.git";
+    rev = quasarPin;
+  };
+
   quasarRuntimeLibs = with pkgs; [
     openssl
     rabbitmq-c
@@ -24,10 +30,10 @@ let
       gnumake
     ] ++ quasarRuntimeLibs;
     text = ''
-      pin="80553699fa6c9dec227d4ddff629c3ab3a8b8010"
+      pin='${quasarPin}'
       cache_root="''${XDG_CACHE_HOME:-$HOME/.cache}/quasar-pinned"
       workdir="$cache_root/$pin"
-      source_path='${inputs.quasar}'
+      source_path='${quasarSource}'
 
       if curl --fail --silent --max-time 1 http://127.0.0.1:5173/ >/dev/null 2>&1; then
         echo "Quasar is already running at http://127.0.0.1:5173"

--- a/nix/home-manager/systems/desktop/programs.nix
+++ b/nix/home-manager/systems/desktop/programs.nix
@@ -15,6 +15,39 @@ let
     lmdb
   ];
 
+  starintelConfigure = pkgs.writeShellApplication {
+    name = "starintel-configure";
+    runtimeInputs = with pkgs; [ coreutils ];
+    text = ''
+      config_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/starintel"
+      default_url="http://127.0.0.1:5000"
+
+      umask 077
+      mkdir -p "$config_dir"
+      chmod 700 "$config_dir"
+
+      printf 'StarIntel API URL [%s]: ' "$default_url"
+      IFS= read -r url
+      url="''${url:-$default_url}"
+
+      printf 'StarIntel API key: '
+      IFS= read -r -s api_key
+      printf '\n'
+
+      if [ -z "$api_key" ]; then
+        echo "StarIntel API key cannot be blank." >&2
+        exit 1
+      fi
+
+      printf '%s\n' "$url" > "$config_dir/url"
+      printf '%s\n' "$api_key" > "$config_dir/api-key"
+      chmod 600 "$config_dir/url" "$config_dir/api-key"
+      unset api_key
+
+      echo "Saved StarIntel config under $config_dir (API key mode 0600)."
+    '';
+  };
+
   quasarStart = pkgs.writeShellApplication {
     name = "quasar-start";
     runtimeInputs = with pkgs; [
@@ -80,6 +113,7 @@ in
 {
   home.packages = with pkgs; [
     nyxt
+    starintelConfigure
     quasarStart
     # Development
     gitRepo


### PR DESCRIPTION
## What changed

- keep Nyxt on its built-in VI normal/insert workflow and extend VI normal mode with StarIntel/Quasar commands
- add a native `starintel:` Nyxt scheme with:
  - full-text search UI
  - query limit/sort/bookmark paging
  - canonical v0.9 result summaries from top-level metadata and dtype-specific `data`
  - result metadata + raw response inspection
  - authenticated document inspection
- add selection-driven StarIntel actions:
  - `g S` search highlighted text
  - `g d` create a canonical v0.9 document using highlighted text as a chosen `data` field
  - `g D` create/edit a complete canonical v0.9 JSON document from a generated valid envelope
  - `g s` open the full StarIntel search UI
- canonical document creation now supplies the required `_id`, `dataset`, `dtype`, `schema_version`, timestamps, common envelope, and `data` object before posting to the strict `/new/document/:dtype` boundary
- normalize custom-scheme URL designators through Nyxt's current `url` accessor before QURI query/path inspection
- use persistent XDG StarIntel config by default:
  - API URL: `~/.config/starintel/url`
  - API key: `~/.config/starintel/api-key`, required to be mode `0600`
  - `STARINTEL_URL` / `STARINTEL_API_KEY` remain optional per-process overrides
  - `starintel-configure` securely prompts for the key with terminal echo disabled and writes both files with restrictive permissions
  - bearer credentials never go into browser URLs or rendered request errors
- add Nyxt Quasar commands:
  - `g q` start the pinned Quasar stack as `quasar-nyxt.service` and open it
  - `g Q` open the Quasar UI
  - global start/stop/restart commands are also available
- pin Quasar to commit `80553699fa6c9dec227d4ddff629c3ab3a8b8010` in the desktop Home Manager module and expose `quasar-start`
- fix Nyxt synthwave UI colors:
  - prompt selection no longer uses the default bright blue
  - links use neon cyan `#2de2e6`
  - visited links use muted reddish/magenta `#92406e`
  - hover/active links use hot pink `#f6019d`

## Notes

Quasar's source is fetched by exact Git revision inside the Home Manager module, avoiding an incomplete flake input / lock-file update. The launcher copies the immutable source into a revision-keyed XDG cache before bootstrap/npm writes and then runs the canonical `npm run dev` stack.

The StarIntel routes used here match the current server contract (`GET /search`, `GET /document/:id`, `POST /new/document/:dtype`) and use the documented `Authorization: Bearer <api-key>` header. The create route is strict v0.9, so the Nyxt document helpers now construct the same common envelope shape as the canonical StarIntel document builder rather than posting legacy/ad-hoc top-level fields.

Current Nyxt still provides the selection/open-buffer primitives used here (`ffi-buffer-copy`, `ffi-buffer-load`, `make-buffer-focus`). Home Manager/Nix evaluation remains the packaged merge gate; the Nyxt commands should also be exercised interactively against a configured StarIntel server before relying on live document writes.