### PR TITLE
Make Zara services and plugins declarative

### DIFF
--- a/.config/qtile/scripts/autostart.sh
+++ b/.config/qtile/scripts/autostart.sh
@@ -129,10 +129,3 @@ run brave
 run python3 /home/unseen/.dotfiles/.config/qtile/scripts/pinger.py -c "$HOME/.config/hosts.toml"
 run kdeconnect-indicator
 run aw-qt
-
-# Zara desktop copilot. The zara wrapper execs python, so the generic
-# PID-file guard above cannot match its cmdline (argv[0] becomes the
-# python binary); guard with pgrep on the module invocation instead.
-if ! pgrep -f -- "-m zara --desktop" >/dev/null 2>&1; then
-    setsid zara --desktop </dev/null >/dev/null 2>&1 &
-fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ tmp/
 .config/starintel/
 .local/bin/starintel-*
 .config/qtile/private.env
+.config/zarathushtra/secrets.env
+.config/zarathushtra/plugins/*/token
+.config/zarathushtra/plugins/*/settings.json
 .direnv/*
 .direnv
 /.config/variety/.firstrun

--- a/nix/home-manager/mods/zara.nix
+++ b/nix/home-manager/mods/zara.nix
@@ -3,10 +3,33 @@
 let
   cfg = config.zara;
   toml = pkgs.formats.toml { };
+
+  discoveryFiles = lib.mapAttrs'
+    (name: source:
+      lib.nameValuePair ".zarathushtra/plugins/${name}" {
+        inherit source;
+      })
+    cfg.plugins.discoveryFiles;
+
+  pluginConfigFiles = lib.mapAttrs'
+    (name: source:
+      lib.nameValuePair ".config/zarathushtra/plugins/${name}" {
+        inherit source;
+      })
+    cfg.plugins.configFiles;
+
+  sensitiveConfigNames = lib.filter
+    (name:
+      let lower = lib.toLower name;
+      in lib.hasInfix "token" lower
+        || lib.hasInfix "secret" lower
+        || lib.hasInfix "password" lower
+        || lib.hasInfix "credential" lower)
+    (lib.attrNames cfg.plugins.configFiles);
 in
 {
   options.zara = {
-    enable = lib.mkEnableOption "Zara assistant binaries and daemon";
+    enable = lib.mkEnableOption "Zara assistant binaries and services";
 
     package = lib.mkOption {
       type = lib.types.package;
@@ -30,15 +53,39 @@ in
       '';
     };
 
-    shutdownTimeout = lib.mkOption {
-      type = lib.types.ints.u32;
-      default = 240;
-      description = ''
-        Seconds passed to zara-server --shutdown-timeout. The daemon also
-        spends this budget waiting for runtime startup before declaring the
-        runtime degraded; the binary's 5 second default is far too short for
-        cold AgentManager/ChromaDB starts, which can take minutes.
-      '';
+    server = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Run zara-server as a Home Manager systemd user service.";
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "-%h/.config/zarathushtra/secrets.env";
+        description = ''
+          Optional systemd EnvironmentFile for zara-server. Keep this file
+          outside the Nix store and outside Git; use it for values such as
+          ZARA_DISCORD_TOKEN. Prefix the path with '-' to make a missing file
+          non-fatal.
+        '';
+      };
+
+      shutdownTimeout = lib.mkOption {
+        type = lib.types.ints.u32;
+        default = 240;
+        description = ''
+          Seconds passed to zara-server --shutdown-timeout. The daemon also
+          spends this budget waiting for runtime startup before declaring the
+          runtime degraded; the binary's 5 second default is far too short for
+          cold AgentManager/ChromaDB starts, which can take minutes.
+        '';
+      };
+    };
+
+    desktop = {
+      enable = lib.mkEnableOption "Zara desktop copilot systemd user service";
     };
 
     wake = {
@@ -49,6 +96,44 @@ in
         default = inputs.zara.packages.${pkgs.stdenv.hostPlatform.system}.zara-wake;
         defaultText = lib.literalExpression "inputs.zara.packages.\${pkgs.stdenv.hostPlatform.system}.zara-wake";
         description = "Zara flake package providing the zara-wake listener binary.";
+      };
+    };
+
+    plugins = {
+      packages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        description = ''
+          Extra plugin packages installed into the Home Manager profile.
+          Package selection belongs here; plugin discovery files are declared
+          separately with {option}`zara.plugins.discoveryFiles`.
+        '';
+      };
+
+      discoveryFiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            "starintel.py" = ../files/zarathushtra/plugins/starintel.py;
+          }
+        '';
+        description = ''
+          Declarative Zara discovery entries. Attribute names are filenames
+          placed under ~/.zarathushtra/plugins and values are immutable source
+          paths. Do not put secrets in these files.
+        '';
+      };
+
+      configFiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+        description = ''
+          Non-secret plugin runtime files placed below
+          ~/.config/zarathushtra/plugins. This is intended for immutable code
+          or assets such as a plugin library directory. Tokens, passwords,
+          credentials and mutable policy databases must stay outside Nix.
+        '';
       };
     };
 
@@ -67,31 +152,56 @@ in
       "zara.nixManaged is enabled while zara.settings is empty; activation will replace ~/.config/zarathushtra/config.toml with an empty configuration."
     ];
 
-    home.packages = [ cfg.package ];
+    assertions = [
+      {
+        assertion = sensitiveConfigNames == [ ];
+        message = ''
+          zara.plugins.configFiles must never contain secret-bearing paths.
+          Refusing: ${lib.concatStringsSep ", " sensitiveConfigNames}. Use
+          zara.server.environmentFile or another out-of-store secret source.
+        '';
+      }
+    ];
 
-    # Zara loads user tools from ~/.zarathushtra/plugins at startup.
-    home.file.".zarathushtra/plugins/starintel.py".source =
-      ../files/zarathushtra/plugins/starintel.py;
+    home.packages = [ cfg.package ] ++ cfg.plugins.packages;
 
-    home.file.".config/zarathushtra/config.toml" = lib.mkIf cfg.nixManaged {
-      source = toml.generate "zara-config.toml" cfg.settings;
+    home.file = discoveryFiles // pluginConfigFiles // {
+      ".config/zarathushtra/config.toml" = lib.mkIf cfg.nixManaged {
+        source = toml.generate "zara-config.toml" cfg.settings;
+      };
     };
 
-    systemd.user.services.zara-server = {
+    systemd.user.services.zara-server = lib.mkIf cfg.server.enable {
       Unit = {
         Description = "Long-lived Zara assistant daemon";
         After = [ "pipewire.service" "pipewire-pulse.service" ];
       };
       Service = {
-        ExecStart = "${cfg.package}/bin/zara-server --shutdown-timeout ${toString cfg.shutdownTimeout}";
+        ExecStart = "${cfg.package}/bin/zara-server --shutdown-timeout ${toString cfg.server.shutdownTimeout}";
+        EnvironmentFile = lib.optional (cfg.server.environmentFile != null) cfg.server.environmentFile;
         Restart = "on-failure";
         RestartSec = 5;
+        UMask = "0077";
       };
       Install.WantedBy = [ "default.target" ];
     };
 
-    # The wake listener owns the microphone and reads STT settings from the
-    # user's config.toml, so it belongs to the graphical session.
+    systemd.user.services.zara-desktop = lib.mkIf cfg.desktop.enable {
+      Unit = {
+        Description = "Zara desktop copilot";
+        After = [ "graphical-session.target" "zara-server.service" ];
+        Wants = lib.optional cfg.server.enable "zara-server.service";
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${cfg.package}/bin/zara-desktop";
+        Restart = "on-failure";
+        RestartSec = 3;
+        UMask = "0077";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+
     systemd.user.services.zara-wake = lib.mkIf cfg.wake.enable {
       Unit = {
         Description = "Zara wake-word voice listener";
@@ -102,6 +212,7 @@ in
         ExecStart = "${cfg.wake.package}/bin/zara-wake";
         Restart = "on-failure";
         RestartSec = 5;
+        UMask = "0077";
       };
       Install.WantedBy = [ "graphical-session.target" ];
     };

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -22,7 +22,18 @@
 
   zara = {
     enable = true;
+
+    server = {
+      enable = true;
+      environmentFile = "-%h/.config/zarathushtra/secrets.env";
+    };
+
+    desktop.enable = true;
     wake.enable = true;
+
+    plugins.discoveryFiles = {
+      "starintel.py" = ../../files/zarathushtra/plugins/starintel.py;
+    };
   };
 
   screenCapture = {
@@ -78,8 +89,8 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version
+  # You can update this value in your configuration without breakage.
+  # See the Home Manager release notes for a list of state version
   # changes.
 
   # Let Home Manager install and manage itself.


### PR DESCRIPTION
## Summary
- make `zara-server` an explicit Home Manager systemd user service option
- add a Home Manager-managed `zara-desktop` systemd user service
- remove the old Qtile `zara --desktop` autostart hook
- make Zara discovery/config plugin files declarative through `zara.plugins.*`
- move the StarIntel plugin declaration into the desktop host config instead of hardcoding it in the module
- add an out-of-store `zara.server.environmentFile` for secrets such as `ZARA_DISCORD_TOKEN`
- refuse secret-looking paths in Nix-managed plugin config files
- use `UMask=0077` for Zara user services
- ignore local Zara secrets, plugin tokens, and mutable plugin policy in Git

## Desktop configuration
The desktop host now declares:
- `zara.server.enable = true`
- `zara.desktop.enable = true`
- `zara.wake.enable = true`
- `zara.server.environmentFile = "-%h/.config/zarathushtra/secrets.env"`
- `starintel.py` through `zara.plugins.discoveryFiles`

The secret file is intentionally not generated by Nix and therefore never enters the Nix store or repository.

## Follow-up
Issue #187 tracks pinning the public `zara-plugins` registry itself as a flake input once its runtime packaging path is ready.