### PR TITLE
feat: finish screenshot and screen-recording desktop integration

### DIFF
--- a/.config/qtile/qtile-capture.org
+++ b/.config/qtile/qtile-capture.org
@@ -1,0 +1,68 @@
+#+title: Qtile Screen Capture Integration
+#+property: header-args:python :tangle qtile_capture.py :mkdirp yes :results none
+
+* Purpose
+This file is the canonical source for Qtile's screenshot and recording
+keybindings. Qtile only chooses the user action; the =screen-capture= CLI owns
+backend selection, clipboard behavior, recorder state, and finalization.
+
+The bindings preserve the existing screenshot muscle memory and add recording
+without a heavyweight desktop UI:
+
+| Binding         | Action                         |
+|-----------------+--------------------------------|
+| =Print=         | Full screenshot                |
+| =Super+Print=   | Select screenshot region       |
+| =Shift+Print=   | Open the Emacs recording UI    |
+| =Super+Shift+Print= | Stop/finalize recording   |
+
+* Bindings
+#+begin_src python
+from libqtile.config import Key
+from libqtile.lazy import lazy
+
+
+def install_capture_bindings(config_globals):
+    """Install the stable screen-capture bindings once per Qtile config load."""
+    keys = config_globals.get("keys")
+    if keys is None:
+        return
+
+    mod = config_globals.get("mod", "mod4")
+    bindings = [
+        Key(
+            [],
+            "Print",
+            lazy.spawn("screen-capture screenshot-screen"),
+            desc="Capture full screen",
+        ),
+        Key(
+            [mod],
+            "Print",
+            lazy.spawn("screen-capture screenshot-region"),
+            desc="Capture selected region",
+        ),
+        Key(
+            ["shift"],
+            "Print",
+            lazy.spawn("screen-capture record-ui"),
+            desc="Open screen-recording UI",
+        ),
+        Key(
+            [mod, "shift"],
+            "Print",
+            lazy.spawn("screen-capture stop"),
+            desc="Stop and finalize screen recording",
+        ),
+    ]
+
+    existing = {
+        (tuple(getattr(binding, "modifiers", ())), getattr(binding, "key", None))
+        for binding in keys
+    }
+    for binding in bindings:
+        signature = (tuple(binding.modifiers), binding.key)
+        if signature not in existing:
+            keys.append(binding)
+            existing.add(signature)
+#+end_src

--- a/.config/qtile/qtile.org
+++ b/.config/qtile/qtile.org
@@ -7,6 +7,8 @@ Do not make lasting edits directly in =config.py=. Edit =qtile-ai.org= first, ta
 
 The OpenRouter telemetry helper follows the same rule: [[file:qtile-openrouter.org][qtile-openrouter.org]] is canonical and generates =qtile_openrouter.py=.
 
+Qtile's screen-capture bindings are kept in [[file:qtile-capture.org][qtile-capture.org]], which generates =qtile_capture.py=. The extension is installed before key telemetry instrumentation so capture shortcuts remain visible in the same keymap telemetry as the main configuration.
+
 Complex click-driven bar panels use the shared [[file:../../docs/qtile-emacs-ui.org][Qtile and Emacs dropdown UI]]
 runtime helpers.  The canonical Qtile source still owns bar composition; the
 standalone =emacs_ui.py=, system telemetry, Dunst adapter, and =lisp/qtile/=
@@ -42,9 +44,19 @@ interactive Emacs window.
 Qtile owns the complete active keymap. The former SXHKD configuration was
 retired after its approved shortcuts were migrated to native =Key= entries.
 
-Spectacle is launched through =~/.local/bin/spectacle=. The wrapper prefers
-the current Arch build, which works with this X11 GLX configuration, over the
-older Nix profile build that requests an unavailable framebuffer configuration.
+Screen capture is routed through the stable =screen-capture= CLI rather than a
+desktop screenshot application. The direct screenshot bindings preserve the
+existing layout, while recording uses the thin Emacs picker:
+
+| Binding             | Action                         |
+|---------------------+--------------------------------|
+| =Print=             | Full screenshot                |
+| =Super+Print=       | Select screenshot region       |
+| =Shift+Print=       | Open the Emacs recording UI    |
+| =Super+Shift+Print= | Stop and finalize recording    |
+
+The CLI owns X11/Wayland backend selection, recorder state, clipboard behavior,
+and output paths. See [[file:../../docs/wiki/screen-capture.org][the screen-capture wiki page]] for the full command and Home Manager contract.
 
 Monitor focus and window movement use physical X coordinates, so Left and Right
 select the adjacent display instead of following XRandR's output enumeration.
@@ -104,7 +116,7 @@ The raw telemetry includes window titles. Browser page names, document names, te
 After modifying =qtile-ai.org= or related Qtile sources, tangle first and then run:
 
 #+begin_src sh
-python -m py_compile config.py qtile_telemetry.py scripts/qtile-telemetry-summary.py
+python -m py_compile config.py qtile_capture.py qtile_telemetry.py scripts/qtile-telemetry-summary.py
 qtile check -c config.py
 #+end_src
 

--- a/.config/qtile/qtile_capture.py
+++ b/.config/qtile/qtile_capture.py
@@ -1,0 +1,47 @@
+from libqtile.config import Key
+from libqtile.lazy import lazy
+
+
+def install_capture_bindings(config_globals):
+    """Install the stable screen-capture bindings once per Qtile config load."""
+    keys = config_globals.get("keys")
+    if keys is None:
+        return
+
+    mod = config_globals.get("mod", "mod4")
+    bindings = [
+        Key(
+            [],
+            "Print",
+            lazy.spawn("screen-capture screenshot-screen"),
+            desc="Capture full screen",
+        ),
+        Key(
+            [mod],
+            "Print",
+            lazy.spawn("screen-capture screenshot-region"),
+            desc="Capture selected region",
+        ),
+        Key(
+            ["shift"],
+            "Print",
+            lazy.spawn("screen-capture record-ui"),
+            desc="Open screen-recording UI",
+        ),
+        Key(
+            [mod, "shift"],
+            "Print",
+            lazy.spawn("screen-capture stop"),
+            desc="Stop and finalize screen recording",
+        ),
+    ]
+
+    existing = {
+        (tuple(getattr(binding, "modifiers", ())), getattr(binding, "key", None))
+        for binding in keys
+    }
+    for binding in bindings:
+        signature = (tuple(binding.modifiers), binding.key)
+        if signature not in existing:
+            keys.append(binding)
+            existing.add(signature)

--- a/.config/qtile/qtile_telemetry.py
+++ b/.config/qtile/qtile_telemetry.py
@@ -157,6 +157,10 @@ def _instrument_keys(mappings, chord=()):
 def install_telemetry(config_globals):
     global _config
     _config = config_globals
+
+    from qtile_capture import install_capture_bindings
+
+    install_capture_bindings(config_globals)
     _instrument_keys(config_globals.get("keys", ()))
 
     from qtile_openrouter import install_openrouter_widget

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Check Qtile Python helpers
         run: >-
           python3 -m py_compile
+          .config/qtile/qtile_capture.py
+          .config/qtile/qtile_telemetry.py
           .config/qtile/qtile_openrouter.py
           .config/qtile/scripts/openrouter_status.py
       - name: Run Qtile helper tests
@@ -86,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Emacs
         run: sudo apt-get update && sudo apt-get install -y emacs-nox
-      - name: Run image progress ERT tests
+      - name: Run image progress ERT test
         run: >-
           emacs -Q --batch
           -L lisp/llm

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Emacs
         run: sudo apt-get update && sudo apt-get install -y emacs-nox
-      - name: Run image progress ERT test
+      - name: Run image progress ERT tests
         run: >-
           emacs -Q --batch
           -L lisp/llm

--- a/.local/bin/screen-capture
+++ b/.local/bin/screen-capture
@@ -181,6 +181,7 @@ run_recorder() {
     shift
     ensure_dirs
     have flock || die "flock is required for recorder locking"
+    have timeout || die "GNU timeout is required for recorder signal supervision"
 
     local lock_fd
     exec {lock_fd}>"$lock_file"
@@ -206,13 +207,12 @@ run_recorder() {
     trap forward_signal INT TERM HUP
     trap cleanup_recording EXIT
 
-    # Non-interactive Bash otherwise starts asynchronous children with SIGINT
-    # ignored. Briefly enable job control so FFmpeg/wf-recorder retain a real
-    # interrupt handler, then return this wrapper to normal script semantics.
-    set -m
-    "$@" &
+    # Bash starts asynchronous commands with SIGINT ignored when this wrapper is
+    # itself backgrounded. GNU timeout is used only as a signal-forwarding
+    # supervisor (duration 0 means no timeout), so the actual recorder receives
+    # SIGINT and can finalize its container correctly.
+    timeout --preserve-status 0 "$@" &
     recorder_pid=$!
-    set +m
 
     printf '%s\n' "$recorder_pid" > "$pid_file"
     printf '%s\n' "$output" > "$path_file"

--- a/.local/bin/screen-capture
+++ b/.local/bin/screen-capture
@@ -10,12 +10,13 @@ copy_recording_path="${SCREEN_CAPTURE_COPY_RECORDING_PATH:-1}"
 runtime_dir="${SCREEN_CAPTURE_RUNTIME_DIR:-${XDG_RUNTIME_DIR:-/tmp}/screen-capture-${UID}}"
 pid_file="$runtime_dir/recorder.pid"
 path_file="$runtime_dir/recorder.path"
+lock_file="$runtime_dir/recorder.lock"
 
 log() { printf '%s: %s\n' "$program" "$*" >&2; }
 die() { log "$*"; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
 notify() { have notify-send && notify-send -a screen-capture "$1" "${2:-}" >/dev/null 2>&1 || true; }
-timestamp() { date '+%Y-%m-%d_%H-%M-%S'; }
+timestamp() { date '+%Y-%m-%d_%H-%M-%S-%N'; }
 
 session_type() {
     if [[ -n "${SCREEN_CAPTURE_SESSION:-}" ]]; then
@@ -85,16 +86,28 @@ screenshot_region() {
             have grim || die "grim is required for Wayland screenshots"
             have slurp || die "slurp is required for Wayland region selection"
             local geometry
-            geometry="$(slurp)" || exit 130
+            if ! geometry="$(slurp)"; then
+                rm -f -- "$file"
+                exit 130
+            fi
             [[ -n "$geometry" ]] || exit 130
-            grim -g "$geometry" "$file"
+            if ! grim -g "$geometry" "$file"; then
+                rm -f -- "$file"
+                die "grim failed to capture the selected region"
+            fi
             ;;
         x11)
             have maim || die "maim is required for X11 screenshots"
-            maim -s "$file" || exit 130
+            if ! maim -s "$file"; then
+                rm -f -- "$file"
+                exit 130
+            fi
             ;;
     esac
-    [[ -s "$file" ]] || die "screenshot backend did not produce $file"
+    if [[ ! -s "$file" ]]; then
+        rm -f -- "$file"
+        die "screenshot backend did not produce an image"
+    fi
     copy_image "$file"
     notify "Screenshot saved" "$file"
     printf '%s\n' "$file"
@@ -107,14 +120,23 @@ screenshot_screen() {
     case "$(session_type)" in
         wayland)
             have grim || die "grim is required for Wayland screenshots"
-            grim "$file"
+            if ! grim "$file"; then
+                rm -f -- "$file"
+                die "grim failed to capture the screen"
+            fi
             ;;
         x11)
             have maim || die "maim is required for X11 screenshots"
-            maim "$file"
+            if ! maim "$file"; then
+                rm -f -- "$file"
+                die "maim failed to capture the screen"
+            fi
             ;;
     esac
-    [[ -s "$file" ]] || die "screenshot backend did not produce $file"
+    if [[ ! -s "$file" ]]; then
+        rm -f -- "$file"
+        die "screenshot backend did not produce an image"
+    fi
     copy_image "$file"
     notify "Screenshot saved" "$file"
     printf '%s\n' "$file"
@@ -158,6 +180,12 @@ run_recorder() {
     local output="$1"
     shift
     ensure_dirs
+    have flock || die "flock is required for recorder locking"
+
+    local lock_fd
+    exec {lock_fd}>"$lock_file"
+    flock -n "$lock_fd" || die "a recording is already starting or active"
+
     clean_stale_state
     if active_pid >/dev/null 2>&1; then
         die "a recording is already active (PID $(active_pid))"
@@ -173,13 +201,19 @@ run_recorder() {
         fi
     }
     forward_signal() {
-        [[ -n "${recorder_pid:-}" ]] && kill -TERM "$recorder_pid" 2>/dev/null || true
+        [[ -n "${recorder_pid:-}" ]] && kill -INT "$recorder_pid" 2>/dev/null || true
     }
     trap forward_signal INT TERM HUP
     trap cleanup_recording EXIT
 
+    # Non-interactive Bash otherwise starts asynchronous children with SIGINT
+    # ignored. Briefly enable job control so FFmpeg/wf-recorder retain a real
+    # interrupt handler, then return this wrapper to normal script semantics.
+    set -m
     "$@" &
     recorder_pid=$!
+    set +m
+
     printf '%s\n' "$recorder_pid" > "$pid_file"
     printf '%s\n' "$output" > "$path_file"
     notify "Recording started" "$output"
@@ -270,7 +304,7 @@ stop_recording() {
         notify "No active recording" "Nothing to stop"
         return 0
     fi
-    kill -TERM "$pid" 2>/dev/null || {
+    kill -INT "$pid" 2>/dev/null || {
         clean_stale_state
         die "recording process $pid is no longer running"
     }
@@ -279,9 +313,10 @@ stop_recording() {
 
 status_recording() {
     ensure_dirs
-    local pid
+    local pid path=""
     if pid="$(active_pid)"; then
-        printf 'recording\t%s\t%s\n' "$pid" "$(<"$path_file")"
+        [[ -f "$path_file" ]] && path="$(<"$path_file")"
+        printf 'recording\t%s\t%s\n' "$pid" "$path"
     else
         printf 'idle\n'
         return 1
@@ -298,7 +333,7 @@ Commands:
   record-window [PATH]    Select a window/area and record it.
   record-screen [PATH]    Record the current X11 monitor or selected Wayland output.
   record-ui               Open the Emacs quick recording UI.
-  stop                    Gracefully stop and finalize the active recording.
+  stop                    Interrupt and finalize the active recording.
   status                  Print active recording state.
 
 Environment:

--- a/.local/bin/spectacle
+++ b/.local/bin/spectacle
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Arch Spectacle 6.7.4 works with the X11 GLX configuration.  The older Nix
-# profile build requests an unavailable single-buffered framebuffer config.
-if [ -x /usr/bin/spectacle ]; then
-    exec /usr/bin/spectacle "$@"
-fi
-
-exec "$HOME/.nix-profile/bin/spectacle" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This repository uses literate Org configuration. Treat the Org files as source c
 
 - `bash.org` is the source of truth for `.bashrc`.
 - `.config/qtile/qtile-ai.org` is the main source of truth for `.config/qtile/config.py`.
+- `.config/qtile/qtile-capture.org` is the source of truth for `.config/qtile/qtile_capture.py`.
 - `.config/qtile/qtile-openrouter.org` is the source of truth for `.config/qtile/qtile_openrouter.py`.
 - `.doom.d/autoload/gpt-todos.org` is the source of truth for `.doom.d/autoload/gpt-todos.el`.
 - `scripts/gpt-todos-sync.org` is the source of truth for `scripts/gpt-todos-sync` and `scripts/install-gpt-todos-cron`.

--- a/docs/wiki/index.org
+++ b/docs/wiki/index.org
@@ -14,6 +14,7 @@ The configuration itself remains the source of truth.  In particular, literate O
 - [[file:nix.org][Nix and Home Manager]] - flake outputs, hosts, profiles, installers, and module layout.
 - [[file:emacs.org][Emacs and Doom]] - Doom literate sources and Emacs-related code in the repository.
 - [[file:desktop.org][Desktop and Qtile]] - Qtile, widgets, keybindings, notifications, and desktop integration.
+- [[file:screen-capture.org][Screen capture]] - stable screenshot/recording CLI, backends, Qtile bindings, Emacs picker, and Home Manager options.
 - [[file:../qtile-emacs-ui.org][Qtile and Emacs dropdown UI]] - shared popup lifecycle, widget-relative geometry, notification backends, and dashboard ownership.
 - [[file:maintenance.org][Maintenance]] - safe edit/tangle/test workflow and useful verification commands.
 
@@ -28,6 +29,7 @@ The configuration itself remains the source of truth.  In particular, literate O
 | Termux remote | [[file:../../scripts/termux-remote.org][scripts/termux-remote.org]] | Remote GUI recovery, mobile SSH keepalives, Agent Zero tunneling, and extra Termux:Widget shortcuts. |
 | Termux Doom | [[file:../../android/doom/config.org][android/doom/config.org]] | Phone-specific Doom source for StarIntel admin, Org/TODOs, languages, and AI. |
 | Qtile | [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | Main Qtile literate source; tangles to =config.py=. |
+| Qtile capture | [[file:../../.config/qtile/qtile-capture.org][.config/qtile/qtile-capture.org]] | Capture keybindings; tangles to =qtile_capture.py=. |
 | OpenRouter widget | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | Telemetry/widget helper; tangles to =qtile_openrouter.py=. |
 | Nix flake | [[file:../../flake.nix][flake.nix]] | NixOS, Home Manager, installer, and package outputs. |
 | Home Manager | [[file:../../nix/home-manager/][nix/home-manager/]] | Shared modules/files and per-system profiles. |

--- a/docs/wiki/screen-capture.org
+++ b/docs/wiki/screen-capture.org
@@ -1,0 +1,95 @@
+#+TITLE: Screen Capture
+#+STARTUP: overview
+
+* Architecture
+=screen-capture= is the single desktop-facing interface for screenshots and
+screen recordings. Qtile and Emacs call the stable CLI; display-server-specific
+commands stay behind it.
+
+Canonical integration points:
+- [[file:../../.local/bin/screen-capture][=.local/bin/screen-capture=]] - capture engine and recorder lifecycle.
+- [[file:../../.doom.d/autoload/screen-capture.org][=.doom.d/autoload/screen-capture.org=]] - thin Emacs recorder picker.
+- [[file:../../.config/qtile/qtile-capture.org][=.config/qtile/qtile-capture.org=]] - canonical Qtile keybindings.
+- [[file:../../nix/home-manager/mods/screen-capture.nix][=screen-capture.nix=]] - reproducible package, dependencies, defaults, and directories.
+
+* Commands
+| Command | Behavior |
+|---------+----------|
+| =screen-capture screenshot-region= | Select a region, save PNG, and copy the image by default. |
+| =screen-capture screenshot-screen= | Capture the full desktop/screen and copy the image by default. |
+| =screen-capture record-window [PATH]= | Select a window/area and record it. |
+| =screen-capture record-screen [PATH]= | Record the current X11 monitor or selected Wayland output. |
+| =screen-capture record-ui= | Open the Emacs recording picker. |
+| =screen-capture stop= | Interrupt and finalize the active recorder. |
+| =screen-capture status= | Print =idle= or the live recorder PID/path. |
+
+Only one recorder may be active. Recorder startup is lock-protected, runtime
+state lives below =$XDG_RUNTIME_DIR= when available, and =stop= delivers
+=SIGINT= so FFmpeg/wf-recorder can finalize the output rather than being killed
+blindly.
+
+* Defaults
+- Screenshots: =~/Pictures/screen-shots=.
+- Recordings: =~/Videos=.
+- Recording frame rate: 60 FPS.
+- Screenshot PNG data is copied to the clipboard after a successful capture.
+- The final recording path is copied to the clipboard after successful finalization.
+- Timestamped filenames include sub-second precision so rapid captures do not overwrite each other.
+- Failed or canceled screenshot captures remove any partial output.
+
+* Backends
+** X11
+- Screenshots: =maim=.
+- Window selection: =slop=.
+- Recording: FFmpeg =x11grab=.
+- Current monitor selection for whole-output recording: =xrandr= + =xdotool=.
+- Clipboard: =xclip=.
+
+** Wayland / wlroots
+- Screenshots: =grim= + =slurp=.
+- Recording: =wf-recorder=.
+- Clipboard: =wl-copy=.
+
+The session is selected automatically from the display environment and can be
+overridden for testing with =SCREEN_CAPTURE_SESSION=x11|wayland=.
+
+* Qtile bindings
+| Binding | Action |
+|---------+--------|
+| =Print= | Full screenshot. |
+| =Super+Print= | Region screenshot. |
+| =Shift+Print= | Emacs recording UI. |
+| =Super+Shift+Print= | Stop/finalize active recording. |
+
+These bindings are generated from =.config/qtile/qtile-capture.org=. The old
+Spectacle path is retired; do not add a second capture frontend to Qtile.
+
+* Home Manager
+The reusable =screenCapture= module is imported through
+=nix/home-manager/mods/default.nix= and enabled by the desktop profile.
+
+Options:
+| Option | Default |
+|--------+---------|
+| =screenCapture.enable= | disabled at module level; enabled by desktop profile |
+| =screenCapture.screenshotDirectory= | =~/Pictures/screen-shots= |
+| =screenCapture.recordingDirectory= | =~/Videos= |
+| =screenCapture.fps= | =60= |
+| =screenCapture.copyScreenshots= | =true= |
+| =screenCapture.copyRecordingPath= | =true= |
+
+The module installs the capture CLI and both X11 and wlroots dependencies,
+exports the corresponding =SCREEN_CAPTURE_*= runtime defaults, and creates the
+configured output directories during activation.
+
+* Verification
+The display-independent regression gate is:
+
+#+begin_src sh
+bash tests/screen-capture.sh
+#+end_src
+
+It covers screenshot/clipboard behavior, rapid path uniqueness, failed-capture
+cleanup, empty recorder output, single-recorder enforcement, SIGINT stop
+finalization, Qtile command coverage, retirement of the old capture frontend,
+and literate/generated parity for the Qtile capture module.

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -76,7 +76,6 @@
         firefox
         xsettingsd
         scrot
-        kdePackages.spectacle
         keepassxc
         xdg-utils
         dunst

--- a/nix/home-manager/mods/screen-capture.nix
+++ b/nix/home-manager/mods/screen-capture.nix
@@ -12,6 +12,7 @@ let
       maim
       slop
       slurp
+      util-linux
       wf-recorder
       wl-clipboard
       xclip

--- a/nix/home-manager/mods/screen-capture.nix
+++ b/nix/home-manager/mods/screen-capture.nix
@@ -6,6 +6,7 @@ let
   screenCapturePackage = pkgs.writeShellApplication {
     name = "screen-capture";
     runtimeInputs = with pkgs; [
+      coreutils
       ffmpeg
       grim
       libnotify

--- a/tests/screen-capture.sh
+++ b/tests/screen-capture.sh
@@ -3,6 +3,9 @@ set -Eeuo pipefail
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 subject="${SUBJECT:-$repo_root/.local/bin/screen-capture}"
+qtile_capture_org="$repo_root/.config/qtile/qtile-capture.org"
+qtile_capture_py="$repo_root/.config/qtile/qtile_capture.py"
+qtile_docs="$repo_root/.config/qtile/qtile.org"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 fake="$tmp/bin"
@@ -14,12 +17,22 @@ export SCREEN_CAPTURE_RUNTIME_DIR="$tmp/runtime"
 export SCREEN_CAPTURE_SCREENSHOT_DIR="$tmp/shots"
 export SCREEN_CAPTURE_VIDEO_DIR="$tmp/videos"
 export SCREEN_CAPTURE_TEST_CLIPBOARD="$tmp/clipboard"
+export SCREEN_CAPTURE_TEST_SIGNAL="$tmp/signal"
 export PATH="$fake:/usr/bin:/bin"
+
+fail() {
+  printf 'screen-capture: %s\n' "$*" >&2
+  exit 1
+}
 
 cat > "$fake/maim" <<'SH'
 #!/usr/bin/env bash
 set -e
 out="${@: -1}"
+if [[ "${SCREEN_CAPTURE_TEST_MAIM_FAIL:-0}" == "1" ]]; then
+  printf 'partial' > "$out"
+  exit 1
+fi
 printf 'png' > "$out"
 SH
 
@@ -55,10 +68,12 @@ if [[ "${SCREEN_CAPTURE_TEST_EMPTY:-0}" == "1" ]]; then
   exit 0
 fi
 finish() {
+  printf '%s\n' "$1" > "${SCREEN_CAPTURE_TEST_SIGNAL:?}"
   printf 'video' > "$out"
   exit 0
 }
-trap finish INT TERM
+trap 'finish INT' INT
+trap 'finish TERM' TERM
 while :; do sleep 0.05; done
 SH
 
@@ -77,10 +92,19 @@ full="$($subject screenshot-screen)"
 [[ -s "$full" ]]
 [[ "$(cat "$SCREEN_CAPTURE_TEST_CLIPBOARD")" == png ]]
 
+second_full="$($subject screenshot-screen)"
+[[ "$second_full" != "$full" ]] || fail "two captures reused the same path"
+
+before_failed_capture="$(find "$SCREEN_CAPTURE_SCREENSHOT_DIR" -type f | wc -l)"
+if SCREEN_CAPTURE_TEST_MAIM_FAIL=1 "$subject" screenshot-region >/dev/null 2>&1; then
+  fail "failed screenshot backend unexpectedly succeeded"
+fi
+after_failed_capture="$(find "$SCREEN_CAPTURE_SCREENSHOT_DIR" -type f | wc -l)"
+[[ "$before_failed_capture" == "$after_failed_capture" ]] || fail "failed screenshot left a partial file"
+
 empty="$tmp/custom/empty.mp4"
 if SCREEN_CAPTURE_TEST_EMPTY=1 "$subject" record-window "$empty"; then
-  printf 'screen-capture: empty recorder output unexpectedly succeeded\n' >&2
-  exit 1
+  fail "empty recorder output unexpectedly succeeded"
 fi
 [[ ! -e "$empty" ]]
 
@@ -93,10 +117,32 @@ for _ in $(seq 1 100); do
 done
 
 [[ "$($subject status)" == recording$'\t'*"$video" ]]
+if "$subject" record-window "$tmp/custom/second.mp4" >/dev/null 2>&1; then
+  fail "second recorder started while one was active"
+fi
 $subject stop
 wait "$runner"
 [[ -s "$video" ]]
+[[ "$(cat "$SCREEN_CAPTURE_TEST_SIGNAL")" == INT ]] || fail "stop did not deliver SIGINT"
 [[ "$(cat "$SCREEN_CAPTURE_TEST_CLIPBOARD")" == "$video" ]]
 [[ "$($subject status 2>/dev/null || true)" == idle ]]
+
+[[ -r "$qtile_capture_org" ]] || fail "missing canonical Qtile capture source"
+[[ -r "$qtile_capture_py" ]] || fail "missing generated Qtile capture module"
+awk '
+  /^#\+begin_src python$/ { in_block = 1; next }
+  /^#\+end_src$/ { in_block = 0; next }
+  in_block { print }
+' "$qtile_capture_org" > "$tmp/qtile_capture.py"
+cmp -s "$tmp/qtile_capture.py" "$qtile_capture_py" || fail "Qtile capture literate/generated drift"
+
+for command in screenshot-screen screenshot-region record-ui stop; do
+  grep -Fq "screen-capture $command" "$qtile_capture_org" || fail "Org source missing $command binding"
+  grep -Fq "screen-capture $command" "$qtile_capture_py" || fail "generated Qtile module missing $command binding"
+done
+
+if grep -qi 'spectacle' "$qtile_capture_org" "$qtile_capture_py" "$qtile_docs"; then
+  fail "Spectacle remains in the active capture path or docs"
+fi
 
 printf 'screen-capture: ok\n'


### PR DESCRIPTION
Finishes the remaining screen-capture desktop slice from #111/#112 and the open integration gate in #116.

### What changed
- adds a canonical literate Qtile capture module with:
  - `Print` → full screenshot
  - `Super+Print` → region screenshot
  - `Shift+Print` → Emacs recording UI
  - `Super+Shift+Print` → stop/finalize recording
- installs capture bindings before Qtile key telemetry instrumentation
- retires the Spectacle wrapper and desktop package from the active capture path
- hardens `screen-capture`:
  - nanosecond timestamped paths to prevent rapid overwrite
  - removes partial files after failed/cancelled screenshot capture
  - lock-protects recorder startup
  - launches recorders with SIGINT handling enabled
  - stops via SIGINT for clean finalization
- adds regression coverage for clipboard behavior, path uniqueness, failed-capture cleanup, recorder exclusivity, SIGINT finalization, Qtile binding coverage, Spectacle retirement, and literate/generated parity
- documents commands, backends, defaults, keybindings, and Home Manager options in the wiki

### Source-of-truth handling
`qtile-capture.org` is canonical for `qtile_capture.py`; the mapping is registered in `AGENTS.md` and the wiki. The existing `qtile-ai.org`/`config.py` pair is left untouched, avoiding another generated-only edit.

Closes #113
Closes #114
Closes #115
Closes #116