### PR TITLE
Install tea and forgejo-cli in base Home Manager module

### DIFF
--- a/nix/home-manager/mods/base.nix
+++ b/nix/home-manager/mods/base.nix
@@ -31,6 +31,8 @@ in
       progress
       starship
       curl
+      tea # Forgejo CLI for git.starintel.actor
+      forgejo-cli
 
     ]) ++ [ gitSync ];
   };


### PR DESCRIPTION
## Summary
- Add `tea` (Forgejo CLI) and `forgejo-cli` to the base Home Manager module so every host gets them for the `git.starintel.actor` migration.

## Validation
- `nix eval .#homeConfigurations."unseen@desktop".activationPackage.drvPath` green
- All `tests/*.sh` pass