### PR TITLE
Bump zara-plugins pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787797243,
-        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
+        "lastModified": 1788229478,
+        "narHash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
+        "rev": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "prolog-rlm": "prolog-rlm"
       },
       "locked": {
-        "lastModified": 1788202304,
-        "narHash": "sha256-FIM6QWkngHrISieFMD7QoM5LYPHjY+KeQCc9FmdWnP0=",
+        "lastModified": 1788246962,
+        "narHash": "sha256-c/IU8yHUBfzCmQN1lyeIxZBzd6L8qvEqq8LL7UQRogA=",
         "owner": "lost-rob0t",
         "repo": "zara",
-        "rev": "de7c91c80a1380781ef41d0b6a85d0f1725d812a",
+        "rev": "4e539b5a74d95ccecf67976c132ccf68ed10485a",
         "type": "github"
       },
       "original": {
@@ -281,17 +281,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1788231232,
-        "narHash": "sha256-IYwJIhH/C8l3khTOzTm9F1I1OBYH6uQ9IenxpH7uc1Y=",
+        "lastModified": 1788232883,
+        "narHash": "sha256-biTYFQO3zclnyz8X+zFVMiyB7bg2NNqlSq5PS4uUQb0=",
         "owner": "lost-rob0t",
         "repo": "zara-plugins",
-        "rev": "60ed2d2f74874aa284db17a31700c1a99140f5d4",
+        "rev": "4f791d83b6d0a969c26f81273d075d5d78acd7db",
         "type": "github"
       },
       "original": {
         "owner": "lost-rob0t",
         "repo": "zara-plugins",
-        "rev": "60ed2d2f74874aa284db17a31700c1a99140f5d4",
+        "rev": "4f791d83b6d0a969c26f81273d075d5d78acd7db",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,8 @@
       url = "github:lost-rob0t/zara";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    zara-plugins = {
-      url = "github:lost-rob0t/zara-plugins/60ed2d2f74874aa284db17a31700c1a99140f5d4";
+      zara-plugins = {
+        url = "github:lost-rob0t/zara-plugins/4f791d83b6d0a969c26f81273d075d5d78acd7db";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     bixby-studio = {


### PR DESCRIPTION
## Summary
- Bump the pinned `zara-plugins` revision and the matching flake.lock entry.

## Validation
- Pinned revision updated to `4f791d83b6d0a969c26f81273d075d5d78acd7db`