### PR TITLE
Add Star Intel Qtile workflow

### DIFF
--- a/.config/qtile/qtile-ai-windows.org
+++ b/.config/qtile/qtile-ai-windows.org
@@ -1,0 +1,157 @@
+#+title: Qtile Window Classification
+#+author: lost-rob0t
+#+startup: overview
+#+property: header-args:python :tangle ./qtile_ai_windows.py :mkdirp yes :comments no :results none
+
+* Purpose
+
+This is the canonical literate source for the shared Qtile window metadata
+classifiers used by Auto mode.  It also loads the declarative workflow runtime
+before the topology-aware desktop control module is installed, so workflow
+activation can extend =qtile_control.apply_workflow= without modifying the
+control layer itself.
+
+#+begin_src python
+"""Window metadata patterns for the Qtile AI workspace."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+import qtile_workflows as _qtile_workflows  # noqa: F401 - installs workflow runtime
+
+
+AI_APPLICATION_CLASSES = frozenset({
+    "claude",
+    "claude code",
+    "chatgpt",
+    "codex",
+    "copilot",
+    "deepseek",
+    "gemini",
+    "openai",
+    "opencode",
+    "perplexity",
+    "qwen",
+    "t3 code (alpha)",
+})
+
+TITLE_MATCHING_CLASSES = frozenset({
+    "brave",
+    "brave-browser",
+    "emacs",
+    "firefox",
+    "terminator",
+})
+
+MESSENGER_APPLICATION_CLASSES = frozenset({
+    "discord",
+    "discordcanary",
+    "discordptb",
+})
+
+MESSENGER_TITLE_MATCHING_CLASSES = frozenset({"brave-browser"})
+
+MESSENGER_TITLE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (r"\bdiscord\b",)
+)
+
+GAME_CLASS_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"^minecraft",
+        r"^war thunder",
+        r"^steam(?:_app_.*)?$",
+        r"^prismlauncher$",
+        r"^terraria(?:\.bin\.x86_64)?$",
+    )
+)
+
+VIDEO_APPLICATION_CLASSES = frozenset({
+    "celluloid",
+    "feishin",
+    "jellyfin",
+    "kodi",
+    "mpv",
+    "plex",
+    "totem",
+    "vlc",
+})
+
+VIDEO_TITLE_MATCHING_CLASSES = frozenset({"brave-browser"})
+
+VIDEO_TITLE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\byoutube(?: music)?\b",
+        r"\btwitch\b",
+        r"\bnetflix\b",
+        r"\bvimeo\b",
+        r"\bxvideos\b",
+        r"\bvideo\b",
+    )
+)
+
+AI_TITLE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bchatgpt\b",
+        r"\bopenai\b",
+        r"\bagent zero\b",
+        r"\bopenrouter\b",
+        r"\bclaude(?:\s+code)?\b",
+        r"\bgemini\b",
+        r"\bcopilot\b",
+        r"\bcodex\b",
+        r"\bopencode\b",
+        r"\bmcp\b",
+        r"\bllm\b",
+        r"\bgptel\b",
+        r"\bai\s+chat\b",
+        r"\bai\s+models?\b",
+        r"\bdeepseek\b",
+        r"\bqwen\b",
+        r"\bz\.ai\b",
+        r"\bzero-forge\b",
+        r"^oc\s*\|",
+    )
+)
+
+
+def is_ai_window(wm_classes: Iterable[str] | None, title: str | None) -> bool:
+    """Return whether X11 window metadata identifies an AI-related window."""
+    classes = {value.casefold() for value in (wm_classes or ()) if value}
+    if classes & AI_APPLICATION_CLASSES:
+        return True
+    if not classes & TITLE_MATCHING_CLASSES:
+        return False
+    return any(pattern.search(title or "") for pattern in AI_TITLE_PATTERNS)
+
+
+def is_messenger_window(wm_classes: Iterable[str] | None, title: str | None) -> bool:
+    """Return whether window metadata identifies Discord or a Discord tab."""
+    classes = {value.casefold() for value in (wm_classes or ()) if value}
+    if classes & MESSENGER_APPLICATION_CLASSES:
+        return True
+    if not classes & MESSENGER_TITLE_MATCHING_CLASSES:
+        return False
+    return any(pattern.search(title or "") for pattern in MESSENGER_TITLE_PATTERNS)
+
+
+def is_game_window(wm_classes: Iterable[str] | None) -> bool:
+    """Return whether window metadata identifies a game or game launcher."""
+    classes = [value for value in (wm_classes or ()) if value]
+    return any(pattern.search(value) for value in classes for pattern in GAME_CLASS_PATTERNS)
+
+
+def is_video_window(wm_classes: Iterable[str] | None, title: str | None) -> bool:
+    """Return whether window metadata identifies a video player or video site."""
+    classes = {value.casefold() for value in (wm_classes or ()) if value}
+    if classes & VIDEO_APPLICATION_CLASSES:
+        return True
+    if not classes & VIDEO_TITLE_MATCHING_CLASSES:
+        return False
+    return any(pattern.search(title or "") for pattern in VIDEO_TITLE_PATTERNS)
+#+end_src

--- a/.config/qtile/qtile-workflows.org
+++ b/.config/qtile/qtile-workflows.org
@@ -1,0 +1,287 @@
+#+title: Qtile Desktop Workflows
+#+author: lost-rob0t
+#+startup: overview
+#+property: header-args :mkdirp yes :comments no :results none
+
+* Purpose
+
+This is the canonical source for declarative Qtile desktop workflows and the
+small runtime layer that applies workflow lifecycle actions on top of
+=qtile_control.py=.  The existing Qtile workflow picker reads =workflows.json=;
+this source owns that JSON and the runtime that adds cleanup, Auto-mode state,
+per-group layout overrides, and launch plans.
+
+The workflow runtime deliberately leaves topology/bar ownership in
+=qtile_control.py=.  It monkey-patches only =apply_workflow= when
+=qtile_ai_windows.py= is imported by the main tangled Qtile config.
+
+* Runtime
+
+#+begin_src python :tangle ./qtile_workflows.py
+"""Declarative Qtile workflow actions layered over qtile_control."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import qtile_control
+
+
+_WORKFLOW_WRAPPER_ATTR = "_qtile_workflow_runtime_wrapper"
+_LAYOUT_WRAPPER_ATTR = "_qtile_workflow_layout_wrapper"
+_LAYOUT_OVERRIDES_ATTR = "_qtile_workflow_layout_overrides"
+_BASE_APPLY_WORKFLOW = qtile_control.apply_workflow
+
+
+def _notify(summary: str, body: str = "") -> None:
+    notifier = getattr(qtile_control, "_notify", None)
+    if callable(notifier):
+        notifier(summary, body)
+
+
+def _close_all_client_windows(qtile: Any) -> None:
+    """Kill every client window owned by a Qtile group, including scratchpads."""
+    seen: set[int] = set()
+    for group in tuple(getattr(qtile, "groups", ()) or ()):
+        for window in tuple(getattr(group, "windows", ()) or ()):
+            marker = id(window)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            try:
+                window.kill()
+            except Exception:
+                continue
+
+
+def _set_auto_mode(config_globals: dict[str, Any], enabled: bool) -> None:
+    """Set the real Auto-mode global and refresh its widgets/telemetry."""
+    previous = bool(config_globals.get("auto_group_mode", False))
+    config_globals["auto_group_mode"] = bool(enabled)
+
+    updater = config_globals.get("update_auto_group_buttons")
+    if callable(updater):
+        updater()
+
+    if previous == bool(enabled):
+        return
+    try:
+        from qtile_telemetry import telemetry_event
+
+        telemetry_event("auto_mode_changed", enabled=bool(enabled), source="workflow")
+    except (ImportError, AttributeError):
+        pass
+
+
+def _layout_wrapper(config_globals: dict[str, Any]):
+    updater = config_globals.get("update_group_layout")
+    if not callable(updater):
+        return None
+    if getattr(updater, _LAYOUT_WRAPPER_ATTR, False):
+        return updater
+
+    original = updater
+
+    def wrapped(group: Any) -> Any:
+        overrides = getattr(wrapped, _LAYOUT_OVERRIDES_ATTR)
+        desired = overrides.get(str(getattr(group, "name", "")))
+        if desired:
+            layout_name = getattr(getattr(group, "layout", None), "name", None)
+            if layout_name != desired:
+                group.setlayout(desired)
+            return None
+        return original(group)
+
+    setattr(wrapped, _LAYOUT_WRAPPER_ATTR, True)
+    setattr(wrapped, _LAYOUT_OVERRIDES_ATTR, {})
+    config_globals["update_group_layout"] = wrapped
+    return wrapped
+
+
+def _set_layout_overrides(
+    qtile: Any,
+    config_globals: dict[str, Any],
+    overrides: Mapping[str, Any] | None,
+) -> None:
+    wrapper = _layout_wrapper(config_globals)
+    if wrapper is None:
+        return
+
+    state = getattr(wrapper, _LAYOUT_OVERRIDES_ATTR)
+    state.clear()
+    for group_name, layout_name in (overrides or {}).items():
+        group_name = str(group_name).strip()
+        layout_name = str(layout_name).strip().lower()
+        if group_name and layout_name:
+            state[group_name] = layout_name
+
+    updater = config_globals.get("update_auto_layouts")
+    if callable(updater):
+        updater(qtile)
+
+
+def _expand_token(value: Any) -> str:
+    return os.path.expanduser(os.path.expandvars(str(value)))
+
+
+def _launch_one(spec: Mapping[str, Any]) -> None:
+    argv = spec.get("argv")
+    if not isinstance(argv, Iterable) or isinstance(argv, (str, bytes)):
+        raise ValueError("workflow launch entry requires an argv list")
+
+    command = [_expand_token(value) for value in argv]
+    if not command:
+        raise ValueError("workflow launch argv cannot be empty")
+
+    cwd_value = spec.get("cwd")
+    cwd = _expand_token(cwd_value) if cwd_value else None
+    subprocess.Popen(
+        command,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _launch_all(entries: Iterable[Any]) -> None:
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        try:
+            _launch_one(entry)
+        except (OSError, ValueError) as error:
+            _notify("Qtile workflow launch failed", str(error))
+
+
+def _launch_async(entries: Any) -> None:
+    if not isinstance(entries, Iterable) or isinstance(entries, (str, bytes, Mapping)):
+        return
+    entries = tuple(entries)
+    if not entries:
+        return
+    threading.Thread(
+        target=_launch_all,
+        args=(entries,),
+        name="qtile-workflow-launch",
+        daemon=True,
+    ).start()
+
+
+def apply_workflow(
+    qtile: Any,
+    workflow: dict[str, Any],
+    config_globals: dict[str, Any],
+) -> None:
+    """Apply base screen placement plus declarative lifecycle/actions."""
+    if workflow.get("close_all"):
+        _close_all_client_windows(qtile)
+
+    auto_mode = workflow.get("auto_mode")
+    if isinstance(auto_mode, bool):
+        _set_auto_mode(config_globals, auto_mode)
+
+    _set_layout_overrides(qtile, config_globals, workflow.get("layouts"))
+    _BASE_APPLY_WORKFLOW(qtile, workflow, config_globals)
+    _set_layout_overrides(qtile, config_globals, workflow.get("layouts"))
+    _launch_async(workflow.get("launch"))
+
+
+setattr(apply_workflow, _WORKFLOW_WRAPPER_ATTR, True)
+setattr(apply_workflow, "_qtile_workflow_base", _BASE_APPLY_WORKFLOW)
+
+if not getattr(qtile_control.apply_workflow, _WORKFLOW_WRAPPER_ATTR, False):
+    qtile_control.apply_workflow = apply_workflow
+#+end_src
+
+* Workflow definitions
+
+The =starintel= workflow is intentionally destructive on activation: it closes
+all existing client windows before rebuilding the desktop.  Auto mode is
+forced on so the normal routing rules remain authoritative after startup.
+
+Its visible groups are:
+- group 1 on the left: Brave opened to the Star Intel Forgejo instance;
+- group 2 in the center: a new Emacs client frame visiting =~/starintel=;
+- group 3 on the right: AI workspace forced to =max= with one Terminator
+  window titled =OpenCode= and running =opencode= from =~/starintel=;
+- group 8 remains on the auxiliary display when a fourth screen exists.
+
+The forced =OpenCode= Terminator title is deliberate: the existing Auto matcher
+recognizes OpenCode terminal windows and routes them to AI group 3.
+
+#+begin_src json :tangle ./workflows.json
+{
+  "desktop": {
+    "auto_group": true,
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "6",
+      "aux": "8"
+    }
+  },
+  "coding": {
+    "auto_group": true,
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "7",
+      "aux": "8"
+    }
+  },
+  "focus": {
+    "auto_group": true,
+    "screens": {
+      "center": "2"
+    }
+  },
+  "starintel": {
+    "auto_group": true,
+    "auto_mode": true,
+    "close_all": true,
+    "layouts": {
+      "3": "max"
+    },
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "3",
+      "aux": "8"
+    },
+    "launch": [
+      {
+        "argv": [
+          "brave",
+          "https://git.starintel.actor"
+        ]
+      },
+      {
+        "argv": [
+          "emacsclient",
+          "-c",
+          "-a",
+          "emacs",
+          "~/starintel"
+        ]
+      },
+      {
+        "argv": [
+          "terminator",
+          "-T",
+          "OpenCode",
+          "--working-directory",
+          "~/starintel",
+          "-x",
+          "opencode"
+        ]
+      }
+    ]
+  }
+}
+#+end_src

--- a/.config/qtile/qtile_ai_windows.py
+++ b/.config/qtile/qtile_ai_windows.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Iterable
 
+import qtile_workflows as _qtile_workflows  # noqa: F401 - installs workflow runtime
+
 
 AI_APPLICATION_CLASSES = frozenset({
     "claude",

--- a/.config/qtile/qtile_workflows.py
+++ b/.config/qtile/qtile_workflows.py
@@ -1,0 +1,179 @@
+"""Declarative Qtile workflow actions layered over qtile_control."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import qtile_control
+
+
+_WORKFLOW_WRAPPER_ATTR = "_qtile_workflow_runtime_wrapper"
+_LAYOUT_WRAPPER_ATTR = "_qtile_workflow_layout_wrapper"
+_LAYOUT_OVERRIDES_ATTR = "_qtile_workflow_layout_overrides"
+_BASE_APPLY_WORKFLOW = qtile_control.apply_workflow
+
+
+def _notify(summary: str, body: str = "") -> None:
+    notifier = getattr(qtile_control, "_notify", None)
+    if callable(notifier):
+        notifier(summary, body)
+
+
+def _close_all_client_windows(qtile: Any) -> None:
+    """Kill every client window owned by a Qtile group, including scratchpads."""
+    seen: set[int] = set()
+    for group in tuple(getattr(qtile, "groups", ()) or ()):
+        for window in tuple(getattr(group, "windows", ()) or ()):
+            marker = id(window)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            try:
+                window.kill()
+            except Exception:
+                continue
+
+
+def _set_auto_mode(config_globals: dict[str, Any], enabled: bool) -> None:
+    """Set the real Auto-mode global and refresh its widgets/telemetry."""
+    previous = bool(config_globals.get("auto_group_mode", False))
+    config_globals["auto_group_mode"] = bool(enabled)
+
+    updater = config_globals.get("update_auto_group_buttons")
+    if callable(updater):
+        updater()
+
+    if previous == bool(enabled):
+        return
+    try:
+        from qtile_telemetry import telemetry_event
+
+        telemetry_event("auto_mode_changed", enabled=bool(enabled), source="workflow")
+    except (ImportError, AttributeError):
+        pass
+
+
+def _layout_wrapper(config_globals: dict[str, Any]):
+    updater = config_globals.get("update_group_layout")
+    if not callable(updater):
+        return None
+    if getattr(updater, _LAYOUT_WRAPPER_ATTR, False):
+        return updater
+
+    original = updater
+
+    def wrapped(group: Any) -> Any:
+        overrides = getattr(wrapped, _LAYOUT_OVERRIDES_ATTR)
+        desired = overrides.get(str(getattr(group, "name", "")))
+        if desired:
+            layout_name = getattr(getattr(group, "layout", None), "name", None)
+            if layout_name != desired:
+                group.setlayout(desired)
+            return None
+        return original(group)
+
+    setattr(wrapped, _LAYOUT_WRAPPER_ATTR, True)
+    setattr(wrapped, _LAYOUT_OVERRIDES_ATTR, {})
+    config_globals["update_group_layout"] = wrapped
+    return wrapped
+
+
+def _set_layout_overrides(
+    qtile: Any,
+    config_globals: dict[str, Any],
+    overrides: Mapping[str, Any] | None,
+) -> None:
+    wrapper = _layout_wrapper(config_globals)
+    if wrapper is None:
+        return
+
+    state = getattr(wrapper, _LAYOUT_OVERRIDES_ATTR)
+    state.clear()
+    for group_name, layout_name in (overrides or {}).items():
+        group_name = str(group_name).strip()
+        layout_name = str(layout_name).strip().lower()
+        if group_name and layout_name:
+            state[group_name] = layout_name
+
+    updater = config_globals.get("update_auto_layouts")
+    if callable(updater):
+        updater(qtile)
+
+
+def _expand_token(value: Any) -> str:
+    return os.path.expanduser(os.path.expandvars(str(value)))
+
+
+def _launch_one(spec: Mapping[str, Any]) -> None:
+    argv = spec.get("argv")
+    if not isinstance(argv, Iterable) or isinstance(argv, (str, bytes)):
+        raise ValueError("workflow launch entry requires an argv list")
+
+    command = [_expand_token(value) for value in argv]
+    if not command:
+        raise ValueError("workflow launch argv cannot be empty")
+
+    cwd_value = spec.get("cwd")
+    cwd = _expand_token(cwd_value) if cwd_value else None
+    subprocess.Popen(
+        command,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _launch_all(entries: Iterable[Any]) -> None:
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        try:
+            _launch_one(entry)
+        except (OSError, ValueError) as error:
+            _notify("Qtile workflow launch failed", str(error))
+
+
+def _launch_async(entries: Any) -> None:
+    if not isinstance(entries, Iterable) or isinstance(entries, (str, bytes, Mapping)):
+        return
+    entries = tuple(entries)
+    if not entries:
+        return
+    threading.Thread(
+        target=_launch_all,
+        args=(entries,),
+        name="qtile-workflow-launch",
+        daemon=True,
+    ).start()
+
+
+def apply_workflow(
+    qtile: Any,
+    workflow: dict[str, Any],
+    config_globals: dict[str, Any],
+) -> None:
+    """Apply base screen placement plus declarative lifecycle/actions."""
+    if workflow.get("close_all"):
+        _close_all_client_windows(qtile)
+
+    auto_mode = workflow.get("auto_mode")
+    if isinstance(auto_mode, bool):
+        _set_auto_mode(config_globals, auto_mode)
+
+    _set_layout_overrides(qtile, config_globals, workflow.get("layouts"))
+    _BASE_APPLY_WORKFLOW(qtile, workflow, config_globals)
+    _set_layout_overrides(qtile, config_globals, workflow.get("layouts"))
+    _launch_async(workflow.get("launch"))
+
+
+setattr(apply_workflow, _WORKFLOW_WRAPPER_ATTR, True)
+setattr(apply_workflow, "_qtile_workflow_base", _BASE_APPLY_WORKFLOW)
+
+if not getattr(qtile_control.apply_workflow, _WORKFLOW_WRAPPER_ATTR, False):
+    qtile_control.apply_workflow = apply_workflow

--- a/.config/qtile/tests/test_qtile_workflow_literate.py
+++ b/.config/qtile/tests/test_qtile_workflow_literate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exact source/generated parity checks for Qtile workflow literate sources."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def source_blocks(path: Path, language: str):
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^#\+begin_src {re.escape(language)}(?P<header>[^\n]*)\n(?P<body>.*?)^#\+end_src\s*$",
+        re.MULTILINE | re.DOTALL,
+    )
+    return list(pattern.finditer(text))
+
+
+def tangle_for(path: Path, target: str, language: str) -> str:
+    blocks = []
+    default_target = None
+    property_match = re.search(
+        rf"^#\+property: header-args:{re.escape(language)} .*?:tangle\s+([^\s]+)",
+        path.read_text(encoding="utf-8"),
+        re.MULTILINE | re.IGNORECASE,
+    )
+    if property_match:
+        default_target = property_match.group(1)
+
+    for match in source_blocks(path, language):
+        header = match.group("header")
+        explicit = re.search(r":tangle\s+([^\s]+)", header)
+        destination = explicit.group(1) if explicit else default_target
+        if destination == target:
+            blocks.append(match.group("body"))
+    if not blocks:
+        raise AssertionError(f"no {language} blocks tangle to {target} in {path.name}")
+    return "".join(blocks)
+
+
+class LiterateParityTests(unittest.TestCase):
+    def test_ai_window_classifier_is_exact_tangle(self):
+        source = ROOT / "qtile-ai-windows.org"
+        generated = ROOT / "qtile_ai_windows.py"
+        self.assertEqual(
+            tangle_for(source, "./qtile_ai_windows.py", "python"),
+            generated.read_text(encoding="utf-8"),
+        )
+
+    def test_workflow_runtime_is_exact_tangle(self):
+        source = ROOT / "qtile-workflows.org"
+        generated = ROOT / "qtile_workflows.py"
+        self.assertEqual(
+            tangle_for(source, "./qtile_workflows.py", "python"),
+            generated.read_text(encoding="utf-8"),
+        )
+
+    def test_workflow_json_is_exact_tangle(self):
+        source = ROOT / "qtile-workflows.org"
+        generated = ROOT / "workflows.json"
+        self.assertEqual(
+            tangle_for(source, "./workflows.json", "json"),
+            generated.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/tests/test_qtile_workflows.py
+++ b/.config/qtile/tests/test_qtile_workflows.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Regression tests for declarative Qtile workflow lifecycle actions."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "qtile_workflows.py"
+WORKFLOWS = ROOT / "workflows.json"
+
+
+class Window:
+    def __init__(self):
+        self.killed = 0
+
+    def kill(self):
+        self.killed += 1
+
+
+class Layout:
+    def __init__(self, name):
+        self.name = name
+
+
+class Group:
+    def __init__(self, name, windows=()):
+        self.name = name
+        self.windows = list(windows)
+        self.layout = Layout("monadtall")
+        self.setlayouts = []
+
+    def setlayout(self, name):
+        self.setlayouts.append(name)
+        self.layout.name = name
+
+
+class Qtile:
+    def __init__(self, groups):
+        self.groups = groups
+        self.groups_map = {group.name: group for group in groups}
+
+
+class WorkflowRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.base_calls = []
+        fake = types.ModuleType("qtile_control")
+
+        def base_apply(qtile, workflow, config_globals):
+            self.base_calls.append((qtile, workflow, config_globals))
+
+        fake.apply_workflow = base_apply
+        fake._notify = mock.Mock()
+        self.fake_control = fake
+        self.previous_control = sys.modules.get("qtile_control")
+        sys.modules["qtile_control"] = fake
+
+        spec = importlib.util.spec_from_file_location("qtile_workflows_under_test", SOURCE)
+        self.module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(self.module)
+
+    def tearDown(self):
+        if self.previous_control is None:
+            sys.modules.pop("qtile_control", None)
+        else:
+            sys.modules["qtile_control"] = self.previous_control
+
+    def config(self, qtile):
+        calls = {"buttons": 0, "layouts": 0}
+
+        def update_buttons():
+            calls["buttons"] += 1
+
+        def update_group_layout(group):
+            desired = "max" if group.name == "1" else "monadtall"
+            if group.layout.name != desired:
+                group.setlayout(desired)
+
+        def update_auto_layouts(runtime):
+            calls["layouts"] += 1
+            for group in runtime.groups:
+                config["update_group_layout"](group)
+
+        config = {
+            "auto_group_mode": False,
+            "update_auto_group_buttons": update_buttons,
+            "update_group_layout": update_group_layout,
+            "update_auto_layouts": update_auto_layouts,
+        }
+        return config, calls
+
+    def test_import_installs_apply_workflow_wrapper(self):
+        self.assertIs(self.fake_control.apply_workflow, self.module.apply_workflow)
+
+    def test_starintel_actions_close_windows_enable_auto_and_hold_group_three_max(self):
+        windows = [Window(), Window(), Window()]
+        groups = [Group("1", windows[:1]), Group("2", windows[1:2]), Group("3", windows[2:])]
+        qtile = Qtile(groups)
+        config, calls = self.config(qtile)
+        workflow = {
+            "auto_group": True,
+            "auto_mode": True,
+            "close_all": True,
+            "layouts": {"3": "max"},
+            "launch": [{"argv": ["true"]}],
+        }
+
+        with mock.patch.object(self.module, "_launch_async") as launch:
+            self.module.apply_workflow(qtile, workflow, config)
+
+        self.assertEqual([window.killed for window in windows], [1, 1, 1])
+        self.assertTrue(config["auto_group_mode"])
+        self.assertEqual(calls["buttons"], 1)
+        self.assertEqual(groups[2].layout.name, "max")
+        self.assertGreaterEqual(calls["layouts"], 2)
+        self.assertEqual(len(self.base_calls), 1)
+        launch.assert_called_once_with(workflow["launch"])
+
+        config["update_group_layout"](groups[2])
+        self.assertEqual(groups[2].layout.name, "max")
+
+    def test_next_workflow_clears_layout_override(self):
+        groups = [Group("1"), Group("2"), Group("3")]
+        qtile = Qtile(groups)
+        config, _calls = self.config(qtile)
+
+        with mock.patch.object(self.module, "_launch_async"):
+            self.module.apply_workflow(qtile, {"layouts": {"3": "max"}}, config)
+            self.assertEqual(groups[2].layout.name, "max")
+            self.module.apply_workflow(qtile, {}, config)
+
+        self.assertEqual(groups[2].layout.name, "monadtall")
+
+    def test_workflow_definition_has_requested_starintel_slice(self):
+        payload = json.loads(WORKFLOWS.read_text(encoding="utf-8"))
+        starintel = payload["starintel"]
+        self.assertTrue(starintel["close_all"])
+        self.assertTrue(starintel["auto_mode"])
+        self.assertEqual(starintel["layouts"], {"3": "max"})
+        self.assertEqual(
+            starintel["screens"],
+            {"left": "1", "center": "2", "right": "3", "aux": "8"},
+        )
+        launches = [entry["argv"] for entry in starintel["launch"]]
+        self.assertEqual(launches[0], ["brave", "https://git.starintel.actor"])
+        self.assertEqual(launches[1][-1], "~/starintel")
+        self.assertEqual(launches[2][-1], "opencode")
+        self.assertIn("OpenCode", launches[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.config/qtile/workflows.json
+++ b/.config/qtile/workflows.json
@@ -22,5 +22,47 @@
     "screens": {
       "center": "2"
     }
+  },
+  "starintel": {
+    "auto_group": true,
+    "auto_mode": true,
+    "close_all": true,
+    "layouts": {
+      "3": "max"
+    },
+    "screens": {
+      "left": "1",
+      "center": "2",
+      "right": "3",
+      "aux": "8"
+    },
+    "launch": [
+      {
+        "argv": [
+          "brave",
+          "https://git.starintel.actor"
+        ]
+      },
+      {
+        "argv": [
+          "emacsclient",
+          "-c",
+          "-a",
+          "emacs",
+          "~/starintel"
+        ]
+      },
+      {
+        "argv": [
+          "terminator",
+          "-T",
+          "OpenCode",
+          "--working-directory",
+          "~/starintel",
+          "-x",
+          "opencode"
+        ]
+      }
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This repository uses literate Org configuration. Treat the Org files as source c
 
 - `bash.org` is the source of truth for `.bashrc`.
 - `.config/qtile/qtile-ai.org` is the main source of truth for `.config/qtile/config.py`.
+- `.config/qtile/qtile-ai-windows.org` is the source of truth for `.config/qtile/qtile_ai_windows.py`.
+- `.config/qtile/qtile-workflows.org` is the source of truth for `.config/qtile/qtile_workflows.py` and `.config/qtile/workflows.json`.
 - `.config/qtile/qtile-capture.org` is the source of truth for `.config/qtile/qtile_capture.py`.
 - `.config/qtile/qtile-openrouter.org` is the source of truth for `.config/qtile/qtile_openrouter.py`.
 - `.doom.d/autoload/gpt-todos.org` is the source of truth for `.doom.d/autoload/gpt-todos.el`.

--- a/docs/wiki/desktop.org
+++ b/docs/wiki/desktop.org
@@ -8,6 +8,8 @@ The primary Qtile configuration is literate:
 | Source | Generated output | Responsibility |
 |--------+------------------+----------------|
 | [[file:../../.config/qtile/qtile-ai.org][qtile-ai.org]] | [[file:../../.config/qtile/config.py][config.py]] | Core Qtile configuration, groups, layouts, keybindings, widgets, hooks, and screens. |
+| [[file:../../.config/qtile/qtile-workflows.org][qtile-workflows.org]] | [[file:../../.config/qtile/qtile_workflows.py][qtile_workflows.py]], [[file:../../.config/qtile/workflows.json][workflows.json]] | Declarative desktop workflow lifecycle, layout overrides, launches, and workflow definitions. |
+| [[file:../../.config/qtile/qtile-ai-windows.org][qtile-ai-windows.org]] | [[file:../../.config/qtile/qtile_ai_windows.py][qtile_ai_windows.py]] | Auto-mode window metadata routing and workflow-runtime bootstrap. |
 | [[file:../../.config/qtile/qtile-openrouter.org][qtile-openrouter.org]] | [[file:../../.config/qtile/qtile_openrouter.py][qtile_openrouter.py]] | OpenRouter telemetry and its dynamic sync/reload integration. |
 
 The main Org source describes itself as modular and self-documenting.  Prefer improving that source when documenting a concrete keybinding or widget rather than duplicating the detail here.
@@ -27,6 +29,28 @@ OpenRouter telemetry is rate-oriented rather than balance-oriented. The bar repo
 
 The dynamic =Super+Ctrl+Shift+R= binding belongs to the OpenRouter telemetry helper.  Keep its documentation and generated implementation synchronized with =qtile-openrouter.org=.
 
+* Desktop workflows
+The Emacs-backed workflow picker reads the tangled =workflows.json=.  The
+lifecycle extension in =qtile_workflows.py= keeps screen placement delegated to
+the existing =qtile_control.py= layer while allowing a workflow to request
+client cleanup, an explicit Auto-mode state, persistent per-group layout
+overrides, and non-blocking application launches.
+
+The =starintel= workflow is a clean-room desktop rebuild.  Selecting it closes
+all managed client windows, forces Auto mode on, places groups 1/2/3 on the
+left/center/right screens, keeps group 3 in =max= while the workflow is active,
+and launches:
+- Brave on group 1 at =https://git.starintel.actor=;
+- a new Emacs client frame on group 2 visiting =~/starintel=;
+- one Terminator on group 3 titled =OpenCode=, running =opencode= from
+  =~/starintel=.
+
+The OpenCode title is intentional: Auto routing recognizes OpenCode terminal
+windows as AI windows, so the normal routing policy remains authoritative after
+the workflow has bootstrapped the desktop.  Selecting another workflow clears
+the Star Intel group-layout override and restores the normal adaptive layout
+policy.
+
 * Auto workspace routing
 The Qtile Auto mode button routes newly managed windows while it is enabled;
 it does not poll or repeatedly reorganize existing windows.  AI-related
@@ -35,8 +59,8 @@ windows go to workspace 3, Discord goes to workspace 9, games go to workspace
 ChatGPT Desktop, AI tabs in Brave, T3 Code, Emacs LLM/OpenRouter/MCP buffers,
 OpenCode or Claude Code terminal windows, Steam/PrismLauncher/Minecraft/War
 Thunder, and YouTube/Twitch tabs.
-The matcher is maintained in [[file:../../.config/qtile/qtile_ai_windows.py][qtile_ai_windows.py]] and was seeded from the local ActivityWatch window bucket;
-ordinary Brave pages and terminal windows are not routed by title alone.  The
+The matcher is maintained in [[file:../../.config/qtile/qtile-ai-windows.org][qtile-ai-windows.org]] and tangles to [[file:../../.config/qtile/qtile_ai_windows.py][qtile_ai_windows.py]]; it was seeded from the local ActivityWatch window bucket.
+Ordinary Brave pages and terminal windows are not routed by title alone.  The
 focused newly routed window follows its destination group so it does not
 appear to disappear from the current screen.
 
@@ -52,14 +76,18 @@ Related desktop configuration is spread through =.config/= and Home Manager modu
 * Edit and test cycle
 1. Edit the relevant Qtile Org source.
 2. Tangle it.
-3. Confirm only the expected generated Python files changed.
+3. Confirm only the expected generated Python/JSON files changed.
 4. Compile the generated Python.
-5. Exercise the affected keybinding/widget/hook in a running Qtile session.
+5. Run the Qtile workflow regression/parity tests when workflow behavior changed.
+6. Exercise the affected keybinding/widget/hook in a running Qtile session.
 
 #+begin_src shell
   cd ~/.dotfiles
   python -m py_compile .config/qtile/config.py
   python -m py_compile .config/qtile/qtile_openrouter.py
+  python -m py_compile .config/qtile/qtile_workflows.py
+  python -m py_compile .config/qtile/qtile_ai_windows.py
+  python -m unittest discover -s .config/qtile/tests -p 'test_qtile_workflow*.py' -v
 #+end_src
 
 For a sync/reload change, test both successful and failed Git sync paths so notification and reload behavior do not quietly rot.

--- a/docs/wiki/index.org
+++ b/docs/wiki/index.org
@@ -13,7 +13,7 @@ The configuration itself remains the source of truth.  In particular, literate O
 - [[file:literate-config.org][Literate configuration]] - canonical Org sources, generated files, tangling, and consistency rules.
 - [[file:nix.org][Nix and Home Manager]] - flake outputs, hosts, profiles, installers, and module layout.
 - [[file:emacs.org][Emacs and Doom]] - Doom literate sources and Emacs-related code in the repository.
-- [[file:desktop.org][Desktop and Qtile]] - Qtile, widgets, keybindings, notifications, and desktop integration.
+- [[file:desktop.org][Desktop and Qtile]] - Qtile, widgets, keybindings, notifications, desktop workflows, and desktop integration.
 - [[file:screen-capture.org][Screen capture]] - stable screenshot/recording CLI, backends, Qtile bindings, Emacs picker, and Home Manager options.
 - [[file:../qtile-emacs-ui.org][Qtile and Emacs dropdown UI]] - shared popup lifecycle, widget-relative geometry, notification backends, and dashboard ownership.
 - [[file:maintenance.org][Maintenance]] - safe edit/tangle/test workflow and useful verification commands.
@@ -29,6 +29,8 @@ The configuration itself remains the source of truth.  In particular, literate O
 | Termux remote | [[file:../../scripts/termux-remote.org][scripts/termux-remote.org]] | Remote GUI recovery, mobile SSH keepalives, Agent Zero tunneling, and extra Termux:Widget shortcuts. |
 | Termux Doom | [[file:../../android/doom/config.org][android/doom/config.org]] | Phone-specific Doom source for StarIntel admin, Org/TODOs, languages, and AI. |
 | Qtile | [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | Main Qtile literate source; tangles to =config.py=. |
+| Qtile workflows | [[file:../../.config/qtile/qtile-workflows.org][.config/qtile/qtile-workflows.org]] | Desktop workflow lifecycle/actions and definitions; tangles to =qtile_workflows.py= and =workflows.json=. |
+| Qtile routing | [[file:../../.config/qtile/qtile-ai-windows.org][.config/qtile/qtile-ai-windows.org]] | Auto-mode window metadata classifiers; tangles to =qtile_ai_windows.py=. |
 | Qtile capture | [[file:../../.config/qtile/qtile-capture.org][.config/qtile/qtile-capture.org]] | Capture keybindings; tangles to =qtile_capture.py=. |
 | OpenRouter widget | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | Telemetry/widget helper; tangles to =qtile_openrouter.py=. |
 | Nix flake | [[file:../../flake.nix][flake.nix]] | NixOS, Home Manager, installer, and package outputs. |

--- a/docs/wiki/literate-config.org
+++ b/docs/wiki/literate-config.org
@@ -15,6 +15,9 @@ Never make a lasting change only in a generated file.  A generated-file-only edi
 | [[file:../../.doom.d/config.org][.doom.d/config.org]] | [[file:../../.doom.d/init.el][.doom.d/init.el]] | Doom module selection, tangled from an explicit block. |
 | [[file:../../.doom.d/packages.org][.doom.d/packages.org]] | [[file:../../.doom.d/packages.el][.doom.d/packages.el]] | Doom package declarations. |
 | [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | [[file:../../.config/qtile/config.py][.config/qtile/config.py]] | Main Qtile configuration. |
+| [[file:../../.config/qtile/qtile-workflows.org][.config/qtile/qtile-workflows.org]] | [[file:../../.config/qtile/qtile_workflows.py][.config/qtile/qtile_workflows.py]] | Qtile workflow lifecycle/action runtime. |
+| [[file:../../.config/qtile/qtile-workflows.org][.config/qtile/qtile-workflows.org]] | [[file:../../.config/qtile/workflows.json][.config/qtile/workflows.json]] | Declarative Qtile workflow definitions. |
+| [[file:../../.config/qtile/qtile-ai-windows.org][.config/qtile/qtile-ai-windows.org]] | [[file:../../.config/qtile/qtile_ai_windows.py][.config/qtile/qtile_ai_windows.py]] | Auto-mode window classification and workflow bootstrap. |
 | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | [[file:../../.config/qtile/qtile_openrouter.py][.config/qtile/qtile_openrouter.py]] | OpenRouter telemetry helper. |
 
 Other Org files may also tangle generated outputs.  Check their =#+property: header-args= lines and individual source-block =:tangle= arguments before editing related generated files.


### PR DESCRIPTION
## What changed

- add a literate `qtile-workflows.org` source that tangles the workflow runtime and `workflows.json`
- add a `starintel` workflow that closes managed windows, forces Auto mode on, keeps AI group 3 in `max`, and places groups 1/2/3 on left/center/right
- launch Brave at `https://git.starintel.actor`, an Emacs client at `~/starintel`, and one Terminator titled `OpenCode` running `opencode` from `~/starintel`
- make the existing Qtile AI window classifier literate and use it to bootstrap the workflow runtime
- add lifecycle and exact literate/generated parity regression tests
- document the new canonical sources and workflow behavior

## Verification

- `python -m py_compile qtile_workflows.py qtile_ai_windows.py`
- `python -m unittest discover -s tests -p 'test_qtile_workflow*.py' -v`
- local parity checks confirm the new Org blocks exactly match `qtile_workflows.py`, `qtile_ai_windows.py`, and `workflows.json`

The Forgejo URL is the same public root configured by `starintel-infra` (`https://git.starintel.actor/`).