### PR TITLE
fix: keep Variety Qtile script writable

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
-          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
+          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
       - name: Run llm-log expert consumer contract
         run: bash tests/llm-log-expert-consumer.sh
       - name: Verify bash.org and .bashrc are tangled in sync
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/screen-capture.sh
       - name: Run Home Manager updater recovery tests
         run: bash tests/home-manager-updater.sh
+      - name: Run Variety Home Manager regression
+        run: bash tests/variety-home-manager.sh
       - name: Run skill sync tests
         run: bash tests/skill-sync.sh
       - name: Run GPT TODO bidirectional sync tests

--- a/nix/home-manager/mods/desktop.nix
+++ b/nix/home-manager/mods/desktop.nix
@@ -1,5 +1,20 @@
 { lib, pkgs, config, ... }:
 
+let
+  qtileWallpaperScript = pkgs.writeText "variety-set-qtile.sh" ''
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+
+    wallpaper="''${1:-}"
+    if [[ -z "$wallpaper" || ! -f "$wallpaper" ]]; then
+      printf 'set_qtile.sh: invalid wallpaper: %s\n' "$wallpaper" >&2
+      exit 2
+    fi
+
+    exec ${pkgs.feh}/bin/feh --bg-fill "$wallpaper"
+  '';
+  varietyQtileScript = "${config.xdg.configHome}/variety/scripts/set_qtile.sh";
+in
 {
   options = {
     desktop =  {
@@ -24,25 +39,17 @@
       force = true;
     };
 
-    # Variety's generated scripts are intentionally ignored by git. Keep the
-    # Qtile wallpaper hook declarative so a Home Manager activation restores
-    # the custom setter that variety.conf already references.
-    home.file.".config/variety/scripts/set_qtile.sh" = {
-      executable = true;
-      force = true;
-      text = ''
-        #!${pkgs.bash}/bin/bash
-        set -euo pipefail
-
-        wallpaper="''${1:-}"
-        if [[ -z "$wallpaper" || ! -f "$wallpaper" ]]; then
-          printf 'set_qtile.sh: invalid wallpaper: %s\n' "$wallpaper" >&2
-          exit 2
-        fi
-
-        exec ${pkgs.feh}/bin/feh --bg-fill "$wallpaper"
-      '';
-    };
+    # Variety chmods scripts in its live config directory during startup, so
+    # this path cannot be a Home Manager symlink into the immutable Nix store.
+    # Keep the source declarative, but install a fresh writable runtime copy on
+    # every activation. The rm also migrates the old store-backed symlink.
+    home.activation.varietyQtileScript = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      target=${lib.escapeShellArg varietyQtileScript}
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/rm -f "$target"
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/install -Dm700 \
+        ${qtileWallpaperScript} \
+        "$target"
+    '';
 
     # Put Brave in XDG_DATA_HOME as well as the Nix profile. j4-dmenu-desktop
     # always searches the user application directory, so discovery no longer

--- a/tests/variety-home-manager.sh
+++ b/tests/variety-home-manager.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+module="$repo_root/nix/home-manager/mods/desktop.nix"
+
+die() {
+  printf 'variety-home-manager: %s\n' "$*" >&2
+  exit 1
+}
+
+if grep -Fq 'home.file.".config/variety/scripts/set_qtile.sh"' "$module"; then
+  die 'Variety runtime script must not be managed with home.file'
+fi
+
+grep -Fq 'home.activation.varietyQtileScript' "$module" \
+  || die 'missing Variety activation installer'
+grep -Fq 'qtileWallpaperScript = pkgs.writeText' "$module" \
+  || die 'missing declarative Variety Qtile script source'
+grep -Fq '${pkgs.coreutils}/bin/rm -f "$target"' "$module" \
+  || die 'activation must remove an old Home Manager symlink before install'
+grep -Fq '${pkgs.coreutils}/bin/install -Dm700' "$module" \
+  || die 'activation must install a private writable executable copy'
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+source_script="$workdir/store-script"
+target="$workdir/config/variety/scripts/set_qtile.sh"
+
+mkdir -p "$(dirname "$target")"
+printf '#!/bin/sh\nexit 0\n' > "$source_script"
+chmod 0555 "$source_script"
+ln -s "$source_script" "$target"
+
+rm -f "$target"
+install -Dm700 "$source_script" "$target"
+
+[[ ! -L "$target" ]] || die 'installed runtime script is still a symlink'
+[[ -w "$target" ]] || die 'installed runtime script is not owner-writable'
+[[ -x "$target" ]] || die 'installed runtime script is not executable'
+
+printf 'variety-home-manager: ok\n'


### PR DESCRIPTION
## Summary

Fix Variety startup on Nix/Home Manager when `~/.config/variety/scripts/set_qtile.sh` is managed by `home.file`.

Variety chmods scripts in its live config directory during startup. A `home.file` entry makes that path a symlink into the immutable Nix store, so Variety crashes with `PermissionError: [Errno 1] Operation not permitted` while trying to chmod `set_qtile.sh`.

This change:

- keeps the Qtile wallpaper setter declarative as a Nix-generated source
- stops managing Variety's live script path with `home.file`
- installs a real writable/executable copy during Home Manager activation with mode `0700`
- removes the old store-backed symlink first, so the next activation migrates the broken state automatically
- adds a regression test that rejects `home.file` ownership and verifies the symlink-to-writable-copy migration pattern
- wires the regression into the Nix workflow

## Verification

CI runs:

- shell syntax + shellcheck for the new regression
- `bash tests/variety-home-manager.sh`
- existing literate/config tests
- `nix flake check --no-build --show-trace`
- desktop Home Manager evaluation
