### PR TITLE
fix(emacs): disable crashing Hackmode package

### DIFF
--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -83,7 +83,11 @@
 
 (package! magit-todos :recipe (:type git :host github :repo "alphapapa/magit-todos"))
 
-(package! hackmode :recipe (:type git :host github :repo "lost-rob0t/emacs-hackmode"))
+;; (package! hackmode
+;;   :recipe (:type git
+;;            :host github
+;;            :repo "lost-rob0t/hackmode"
+;;            :files ("emacs/*.el")))
 
 (package! webpaste :recipe (:type git :host github :repo "etu/webpaste.el"))
 

--- a/.doom.d/packages.org
+++ b/.doom.d/packages.org
@@ -211,10 +211,19 @@ Org babel functions for prolog.
 
 * utilities
 ** Hack mode
-Hack banks from emacs
-jk, package full of utilities for pentesting
+Hackmode now lives in the canonical =lost-rob0t/hackmode= monorepo under
+=emacs/=, but that migration is still in progress.  Keep the optional Emacs
+package disabled so a Hackmode failure cannot take down Doom startup or
+=emacsclient= desktop integrations.
+
+Re-enable this monorepo recipe after =lost-rob0t/hackmode#4= completes and the
+package passes against the current Emacs:
 #+begin_src emacs-lisp
-(package! hackmode :recipe (:type git :host github :repo "lost-rob0t/emacs-hackmode"))
+;; (package! hackmode
+;;   :recipe (:type git
+;;            :host github
+;;            :repo "lost-rob0t/hackmode"
+;;            :files ("emacs/*.el")))
 #+end_src
 ** webpaste.el
 paste your buffer to a pastebin like service.


### PR DESCRIPTION
## What changed

- disable the optional Hackmode Doom package so it cannot break Emacs startup or `emacsclient` desktop integrations
- remove the stale active recipe for `lost-rob0t/emacs-hackmode`
- document the canonical `lost-rob0t/hackmode` monorepo recipe under `emacs/`, but keep it commented out until `lost-rob0t/hackmode#4` completes
- keep `.doom.d/packages.org` and tangled `.doom.d/packages.el` synchronized

## Why

The canonical Hackmode monorepo currently carries essentially the same legacy Emacs package while its migration is explicitly still in progress. Repointing Doom would preserve the startup risk; disabling it restores the screenshot/recording Emacs client path without lying about compatibility.

## Verification

- exact Hackmode block parity between `packages.org` and `packages.el`
- no active `(package! hackmode ...)` form remains
- no reference to the retired `lost-rob0t/emacs-hackmode` recipe remains
