### PR TITLE
feat(llm): add Org-first prompts-lib interface

### DIFF
--- a/lisp/llm/PROMPT-LIB.org
+++ b/lisp/llm/PROMPT-LIB.org
@@ -1,0 +1,62 @@
+#+title: Emacs prompts-lib client
+#+description: Versioned reusable prompts from lost-rob0t/prompts-lib.
+
+* Ownership
+
+The external =prompts-lib= repository owns reusable prompt content.  Dotfiles
+owns the Emacs client and rendering UI.  The client does not copy catalog
+prompts into dotfiles.
+
+By default the client looks for the checkout at
+=~/Documents/Projects/prompts-lib=.  Set =PROMPTS_LIB_DIR= to override it.
+When that checkout has a =prompts/= directory, it becomes
+=ai/prompt-template-directory=.  Otherwise the existing bundled
+=lisp/llm/prompts/= templates remain available.
+
+The catalog format is =prompts-lib.catalog.v1=.  Prompt bodies remain plain
+=.prompt= files and continue using the existing field syntax:
+
+- ={{NAME}}=
+- ={{NAME|default value}}=
+
+* Interface
+
+=M-x ai/prompt-lib-menu= opens the full Transient interface.
+
+Useful commands:
+
+#+begin_src emacs-lisp
+M-x ai/prompt-lib-browse
+M-x ai/prompt-lib-copy
+M-x ai/prompt-lib-insert
+M-x ai/prompt-lib-render
+M-x ai/prompt-lib-send
+M-x ai/prompt-lib-edit
+M-x ai/prompt-lib-new
+M-x ai/prompt-lib-refresh
+M-x ai/prompt-lib-open-repository
+#+end_src
+
+The browser uses =tabulated-list-mode=.  =RET= previews, =c= copies, =i=
+inserts into the previous window, =e= edits, and =g= refreshes.
+
+The existing =SPC y p= prompt menu continues to operate on the active prompt
+directory, so normal copy/insert/preview/image-template workflows immediately
+pick up the external library after =prompt-lib= loads.
+
+* Catalog behavior
+
+=prompt-lib.el= reads metadata from =catalog.json= and also discovers plain
+=.prompt= files that have not yet been cataloged.  Catalog paths are constrained
+to the repository root.  An uncataloged prompt can therefore be created from
+Emacs and used immediately without making catalog metadata a write-time
+requirement.
+
+The external catalog supplies stable IDs, titles, descriptions, tags, and
+aliases.  Prompt text stays client-neutral.
+
+* Verification
+
+ERT coverage lives in =prompt-lib-test.el= and checks catalog metadata,
+uncataloged discovery, repository-root confinement, external activation, and
+compatibility with the existing prompt renderer.

--- a/lisp/llm/PROMPT-LIB.org
+++ b/lisp/llm/PROMPT-LIB.org
@@ -21,7 +21,9 @@ The catalog format is =prompts-lib.catalog.v1=.  Prompt bodies remain plain
 
 * Interface
 
-=M-x ai/prompt-lib-menu= opens the full Transient interface.
+=M-x ai/prompt-lib-menu= opens the full Transient interface.  After
+=prompt-lib= loads it also replaces =ai/prompt-menu=, so the existing
+=SPC y p= entrypoint opens the full library UI.
 
 Useful commands:
 
@@ -40,9 +42,9 @@ M-x ai/prompt-lib-open-repository
 The browser uses =tabulated-list-mode=.  =RET= previews, =c= copies, =i=
 inserts into the previous window, =e= edits, and =g= refreshes.
 
-The existing =SPC y p= prompt menu continues to operate on the active prompt
-directory, so normal copy/insert/preview/image-template workflows immediately
-pick up the external library after =prompt-lib= loads.
+Existing image-template workflows continue to use
+=ai/prompt-template-directory=, so they automatically read the external
+library when it is active.
 
 * Catalog behavior
 

--- a/lisp/llm/PROMPT-LIB.org
+++ b/lisp/llm/PROMPT-LIB.org
@@ -1,20 +1,47 @@
 #+title: Emacs prompts-lib client
-#+description: Versioned reusable prompts from lost-rob0t/prompts-lib.
+#+description: Org-first reusable prompts from lost-rob0t/prompts-lib.
 
 * Ownership
 
 The external =prompts-lib= repository owns reusable prompt content.  Dotfiles
-owns the Emacs client and rendering UI.  The client does not copy catalog
-prompts into dotfiles.
+owns the Emacs client and rendering UI.  Prompt metadata and prompt text stay
+colocated in normal source files; there is no JSON catalog.
 
 By default the client looks for the checkout at
 =~/Documents/Projects/prompts-lib=.  Set =PROMPTS_LIB_DIR= to override it.
-When that checkout has a =prompts/= directory, it becomes
-=ai/prompt-template-directory=.  Otherwise the existing bundled
-=lisp/llm/prompts/= templates remain available.
+When that checkout has a =prompts/= directory it becomes the active library.
+Otherwise the existing bundled =lisp/llm/prompts/= raw templates remain as a
+legacy fallback.
 
-The catalog format is =prompts-lib.catalog.v1=.  Prompt bodies remain plain
-=.prompt= files and continue using the existing field syntax:
+* Formats
+
+Org is the default and canonical authoring format.
+
+#+begin_src org
+#+title: Implement bounded slice
+#+prompt_id: engineering.implement-slice
+#+description: Inspect first, implement narrowly, verify exact head.
+#+filetags: :engineering:implementation:tdd:git:
+#+prompt_aliases: implement | coding task | bounded slice
+
+* Prompt
+Work in {{REPO}}.
+#+end_src
+
+The top-level =* Prompt= subtree is rendered.  Other top-level headings can hold
+notes, examples, provenance, or design discussion without entering the prompt
+body.
+
+The client also supports:
+
+- Markdown files with flat =---= metadata and a =# Prompt= heading;
+- declarative Lisp plist files with =:id=, =:title=, =:tags=, =:aliases=, and
+  =:prompt= fields;
+- legacy raw =.prompt= files for the bundled fallback.
+
+Lisp prompt files are read as data and are not evaluated.
+
+Fields continue using the existing renderer:
 
 - ={{NAME}}=
 - ={{NAME|default value}}=
@@ -22,8 +49,8 @@ The catalog format is =prompts-lib.catalog.v1=.  Prompt bodies remain plain
 * Interface
 
 =M-x ai/prompt-lib-menu= opens the full Transient interface.  After
-=prompt-lib= loads it also replaces =ai/prompt-menu=, so the existing
-=SPC y p= entrypoint opens the full library UI.
+=prompt-lib= loads it also replaces =ai/prompt-menu=, so =SPC y p= opens the
+full library UI.
 
 Useful commands:
 
@@ -42,23 +69,25 @@ M-x ai/prompt-lib-open-repository
 The browser uses =tabulated-list-mode=.  =RET= previews, =c= copies, =i=
 inserts into the previous window, =e= edits, and =g= refreshes.
 
-Existing image-template workflows continue to use
-=ai/prompt-template-directory=, so they automatically read the external
-library when it is active.
+=M-x ai/prompt-lib-new= creates an Org prompt by default and opens it in
+=org-mode=.  Use a prefix argument to choose Markdown or Lisp explicitly.
 
-* Catalog behavior
+Existing image-template workflows are routed through the same normalized prompt
+records, so Org prompts remain usable by =ai/image-generate-template= and chat
+prompt-template tools.
 
-=prompt-lib.el= reads metadata from =catalog.json= and also discovers plain
-=.prompt= files that have not yet been cataloged.  Catalog paths are constrained
-to the repository root.  An uncataloged prompt can therefore be created from
-Emacs and used immediately without making catalog metadata a write-time
-requirement.
+* File-native discovery
 
-The external catalog supplies stable IDs, titles, descriptions, tags, and
-aliases.  Prompt text stays client-neutral.
+The prompt directory itself is the catalog.  Each supported file is parsed into
+a normalized record containing ID, title, description, tags, aliases, body,
+path, and source format.
+
+This keeps the storage model useful to Org, Git, grep, other editors, and other
+LLM clients without requiring Emacs-specific serialized state.
 
 * Verification
 
-ERT coverage lives in =prompt-lib-test.el= and checks catalog metadata,
-uncataloged discovery, repository-root confinement, external activation, and
-compatibility with the existing prompt renderer.
+ERT coverage lives in =prompt-lib-test.el= and checks Org metadata/body parsing,
+Markdown parsing, declarative Lisp parsing without evaluation, legacy fallback,
+external activation, Org-default creation, and compatibility with the existing
+placeholder renderer and image/chat lookup surface.

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -96,7 +96,7 @@
   :backend (ai/llm-backend 'openrouter)
   :model 'anthropic/claude-opus-5:exacto
   :stream t
-  :request-params '(:reasoning (:effort "max")))
+  :request-params '(:reasoning (:effort "max"))
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'agent

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -2,6 +2,7 @@
 
 (require 'ai)
 (require 'ai-prompts)
+(require 'prompt-lib)
 (require 'ai-image)
 (require 'meme)
 (require 'ai-agent)
@@ -95,7 +96,7 @@
   :backend (ai/llm-backend 'openrouter)
   :model 'anthropic/claude-opus-5:exacto
   :stream t
-  :request-params '(:reasoning (:effort "max"))
+  :request-params '(:reasoning (:effort "max")))
   :include-reasoning 'ignore)
 
 (gptel-make-preset 'agent

--- a/lisp/llm/llm.org
+++ b/lisp/llm/llm.org
@@ -89,28 +89,42 @@ Available presets include:
 - =@agent-claude-opus-5= — fixed Claude Opus 5 Exacto with the same tool suite
 - =@agent-gpt-5.6-sol= — fixed GPT-5.6 Sol with the same tool suite
 
-* Reusable prompt templates
+* Reusable prompt library
 
-Reusable plain-text prompts live under =lisp/llm/prompts/= with a =.prompt=
-extension.  Fields use ={{NAME}}= syntax.  Defaults use
+Reusable prompts are owned by =lost-rob0t/prompts-lib=.  The Emacs client looks
+for its checkout at =~/Documents/Projects/prompts-lib= by default; set
+=PROMPTS_LIB_DIR= to override it.
+
+Org is the default and canonical authoring format.  Prompt metadata stays in
+normal Org keywords and =#+filetags:=, while the renderable body lives below a
+top-level =* Prompt= heading.  Fields use ={{NAME}}= syntax and defaults use
 ={{NAME|default value}}=.  Repeated fields are asked once and reused anywhere
-that field appears in the template.
+that field appears in the prompt.
 
-The included =starintel-visual.prompt= captures the black/gold StarIntel
-infographic design language as a reusable design-system prompt.
+The same client accepts Markdown and declarative Lisp prompt files as explicit
+alternate formats.  Lisp prompt records are read as data and are not evaluated.
+The old =lisp/llm/prompts/*.prompt= files remain only as a compatibility fallback
+when the external prompt library is absent.
 
 Useful commands:
 
 #+begin_src emacs-lisp
-M-x ai/prompt-menu
-M-x ai/prompt-template-render
-M-x ai/prompt-template-copy
-M-x ai/prompt-template-insert
-M-x ai/prompt-template-new
-M-x ai/prompt-template-edit
+M-x ai/prompt-lib-menu
+M-x ai/prompt-lib-browse
+M-x ai/prompt-lib-render
+M-x ai/prompt-lib-copy
+M-x ai/prompt-lib-insert
+M-x ai/prompt-lib-send
+M-x ai/prompt-lib-new
+M-x ai/prompt-lib-edit
 #+end_src
 
-Doom binds =SPC y p= to the prompt/image Transient menu.
+=M-x ai/prompt-lib-new= creates an Org file and opens it in =org-mode= by
+default.  A prefix argument chooses Markdown or Lisp.  Doom binds =SPC y p= to
+the full prompt/image Transient menu.
+
+The external library contains the StarIntel black/gold visual-system prompt, so
+activating it preserves the existing image-template workflow.
 
 * OpenRouter image tools
 
@@ -131,9 +145,9 @@ M-x ai/image-edit
 #+end_src
 
 =ai/image-generate= uses the active region as the prompt when a region is
-selected.  =ai/image-generate-template= fills one of the reusable templates and
-sends the rendered prompt directly to GPT Image 2.  =ai/image-edit= sends a
-local PNG, JPEG, or WebP as an OpenRouter reference image.
+selected.  =ai/image-generate-template= fills one of the reusable prompts and
+sends the rendered body directly to GPT Image 2.  =ai/image-edit= sends a local
+PNG, JPEG, or WebP as an OpenRouter reference image.
 
 Doom binds =SPC y i= directly to image generation.  The =SPC y p= Transient
 also exposes generation from a raw prompt, generation from a template, and
@@ -145,8 +159,8 @@ The Org chat registers four gptel tools:
 
 - =GenerateImage= — generate an image from a complete prompt
 - =EditImage= — edit a local image from a complete instruction
-- =ListPromptTemplates= — enumerate reusable =.prompt= templates
-- =ReadPromptTemplate= — load a named template verbatim
+- =ListPromptTemplates= — enumerate reusable normalized prompt records
+- =ReadPromptTemplate= — load a named prompt body verbatim
 
 When a chat request asks for an image, the agent can call =GenerateImage= or
 =EditImage= directly.  Image tool results are always retained in the Org chat,
@@ -158,12 +172,12 @@ than a separate command-only workflow.
 A named design prompt can therefore be used conversationally, for example:
 
 #+begin_example
-Use starintel-visual and generate an infographic for the actor system.
+Use design.starintel-visual and generate an infographic for the actor system.
 #+end_example
 
-The agent can read =starintel-visual.prompt=, compose the final image prompt,
-call GPT Image 2 through OpenRouter, and place the generated image directly in
-the chat transcript.
+The agent can read the Org-backed StarIntel prompt, compose the final image
+prompt, call GPT Image 2 through OpenRouter, and place the generated image
+directly in the chat transcript.
 
 * OpenAI subscription OAuth
 
@@ -254,6 +268,7 @@ Chats are stored below =~/Documents/Notes/org/roam/llm/=.
 
 #+INCLUDE: "ai.el" src emacs-lisp
 #+INCLUDE: "ai-prompts.el" src emacs-lisp
+#+INCLUDE: "prompt-lib.el" src emacs-lisp
 #+INCLUDE: "ai-image.el" src emacs-lisp
 #+INCLUDE: "ai-image-tools.el" src emacs-lisp
 #+INCLUDE: "ai-agent-core.el" src emacs-lisp

--- a/lisp/llm/prompt-lib-test.el
+++ b/lisp/llm/prompt-lib-test.el
@@ -10,41 +10,62 @@
           (ai/prompt-lib-directory (file-name-as-directory root))
           (ai/prompt-template-directory (expand-file-name "prompts/" root))
           (ai/prompt-lib--records-cache nil)
-          (ai/prompt-lib--active-directory nil))
+          (ai/prompt-lib--active-directory nil)
+          (ai/prompt-lib-formats '(org markdown lisp legacy)))
      (unwind-protect
          (progn
            (make-directory ai/prompt-template-directory t)
            ,@body)
        (delete-directory root t))))
 
-(ert-deftest ai/prompt-lib-catalog-loads-metadata ()
+(ert-deftest ai/prompt-lib-parses-org-metadata-and-body ()
   (ai/prompt-lib-test--with-library
-    (let ((prompt (expand-file-name "prompts/test.prompt" ai/prompt-lib-directory)))
-      (write-region "Hello {{NAME}}" nil prompt nil 'silent)
-      (write-region
-       "{\"schema\":\"prompts-lib.catalog.v1\",\"prompts\":[{\"id\":\"test.hello\",\"title\":\"Hello\",\"description\":\"Test\",\"path\":\"prompts/test.prompt\",\"tags\":[\"test\"],\"aliases\":[\"hi\"]}]}"
-       nil (ai/prompt-lib--catalog-path) nil 'silent)
-      (let ((record (car (ai/prompt-lib-records 'refresh))))
-        (should (equal (plist-get record :id) "test.hello"))
-        (should (equal (plist-get record :title) "Hello"))
-        (should (equal (plist-get record :tags) '("test")))
-        (should (equal (plist-get record :aliases) '("hi")))))))
+    (write-region
+     "#+title: Hello prompt\n#+prompt_id: test.hello\n#+description: Test prompt\n#+filetags: :test:org:\n#+prompt_aliases: hi | hello\n\n* Prompt\nHello {{NAME}}\n\n* Notes\nNot prompt text.\n"
+     nil (expand-file-name "prompts/hello.org" ai/prompt-lib-directory) nil 'silent)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "test.hello"))
+      (should (equal (plist-get record :title) "Hello prompt"))
+      (should (equal (plist-get record :description) "Test prompt"))
+      (should (equal (plist-get record :tags) '("test" "org")))
+      (should (equal (plist-get record :aliases) '("hi" "hello")))
+      (should (equal (plist-get record :body) "Hello {{NAME}}"))
+      (should (eq (plist-get record :format) 'org)))))
 
-(ert-deftest ai/prompt-lib-discovers-uncataloged-prompts ()
+(ert-deftest ai/prompt-lib-parses-markdown-adapter ()
   (ai/prompt-lib-test--with-library
-    (write-region "Plain prompt" nil
+    (write-region
+     "---\nprompt_id: test.markdown\ntitle: Markdown prompt\ndescription: Markdown adapter\ntags: test, markdown\naliases: md | markdown test\n---\n\n# Prompt\nHello {{NAME}}\n\n# Notes\nNot prompt text.\n"
+     nil (expand-file-name "prompts/markdown.md" ai/prompt-lib-directory) nil 'silent)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "test.markdown"))
+      (should (equal (plist-get record :tags) '("test" "markdown")))
+      (should (equal (plist-get record :aliases) '("md" "markdown test")))
+      (should (equal (plist-get record :body) "Hello {{NAME}}"))
+      (should (eq (plist-get record :format) 'markdown)))))
+
+(ert-deftest ai/prompt-lib-parses-lisp-as-data-without-eval ()
+  (ai/prompt-lib-test--with-library
+    (let ((ai/prompt-lib-test--evaluated nil))
+      (write-region
+       "(:id \"test.lisp\" :title \"Lisp prompt\" :description \"Lisp adapter\" :tags (\"test\" \"lisp\") :aliases (\"el\") :prompt \"Hello {{NAME}}\")\n(setq ai/prompt-lib-test--evaluated t)\n"
+       nil (expand-file-name "prompts/lisp.el" ai/prompt-lib-directory) nil 'silent)
+      (let ((record (car (ai/prompt-lib-records 'refresh))))
+        (should-not ai/prompt-lib-test--evaluated)
+        (should (equal (plist-get record :id) "test.lisp"))
+        (should (equal (plist-get record :tags) '("test" "lisp")))
+        (should (equal (plist-get record :body) "Hello {{NAME}}"))
+        (should (eq (plist-get record :format) 'lisp))))))
+
+(ert-deftest ai/prompt-lib-keeps-legacy-raw-prompt-fallback ()
+  (ai/prompt-lib-test--with-library
+    (write-region "Plain {{PROMPT}}" nil
                   (expand-file-name "prompts/plain.prompt" ai/prompt-lib-directory)
                   nil 'silent)
     (let ((record (car (ai/prompt-lib-records 'refresh))))
       (should (equal (plist-get record :id) "plain"))
-      (should (equal (plist-get record :source) 'scan)))))
-
-(ert-deftest ai/prompt-lib-rejects-catalog-path-escape ()
-  (ai/prompt-lib-test--with-library
-    (write-region
-     "{\"schema\":\"prompts-lib.catalog.v1\",\"prompts\":[{\"id\":\"bad\",\"path\":\"../escape.prompt\"}]}"
-     nil (ai/prompt-lib--catalog-path) nil 'silent)
-    (should-error (ai/prompt-lib-records 'refresh) :type 'user-error)))
+      (should (equal (plist-get record :body) "Plain {{PROMPT}}"))
+      (should (eq (plist-get record :format) 'legacy)))))
 
 (ert-deftest ai/prompt-lib-activate-selects-external-prompts-directory ()
   (ai/prompt-lib-test--with-library
@@ -53,17 +74,42 @@
           (progn
             (setq ai/prompt-template-directory fallback)
             (ai/prompt-lib-activate)
+            (should (equal ai/prompt-lib--active-directory
+                           (expand-file-name "prompts/" ai/prompt-lib-directory)))
             (should (equal ai/prompt-template-directory
                            (expand-file-name "prompts/" ai/prompt-lib-directory))))
         (delete-directory fallback t)))))
 
-(ert-deftest ai/prompt-lib-render-uses-existing-template-renderer ()
+(ert-deftest ai/prompt-lib-new-defaults-to-org-mode ()
   (ai/prompt-lib-test--with-library
-    (let ((template "Repo {{REPO}} task {{TASK|test}}"))
-      (should (equal
-               (ai/prompt-template-render-string
-                template '(("REPO" . "lost-rob0t/test")))
-               "Repo lost-rob0t/test task test")))))
+    (let ((ai/prompt-lib-default-format 'org)
+          buffer)
+      (unwind-protect
+          (progn
+            (ai/prompt-lib-activate)
+            (setq buffer (ai/prompt-lib-new "Hello Prompt" 'org))
+            (should (string-suffix-p ".org" buffer-file-name))
+            (should (eq major-mode 'org-mode))
+            (goto-char (point-min))
+            (should (search-forward "#+prompt_id: hello-prompt" nil t))
+            (should (search-forward "* Prompt" nil t)))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
+(ert-deftest ai/prompt-lib-template-compatibility-uses-normalized-record ()
+  (ai/prompt-lib-test--with-library
+    (write-region
+     "#+title: Render test\n#+prompt_id: test.render\n\n* Prompt\nRepo {{REPO}} task {{TASK|test}}\n"
+     nil (expand-file-name "prompts/render.org" ai/prompt-lib-directory) nil 'silent)
+    (ai/prompt-lib-activate)
+    (should (member "test.render" (ai/prompt-template-names)))
+    (should (equal (ai/prompt-template--read "test.render")
+                   "Repo {{REPO}} task {{TASK|test}}"))
+    (should (equal
+             (ai/prompt-template-render-string
+              (ai/prompt-template--read "test.render")
+              '(("REPO" . "lost-rob0t/test")))
+             "Repo lost-rob0t/test task test"))))
 
 (provide 'prompt-lib-test)
 ;;; prompt-lib-test.el ends here

--- a/lisp/llm/prompt-lib-test.el
+++ b/lisp/llm/prompt-lib-test.el
@@ -1,0 +1,69 @@
+;;; prompt-lib-test.el --- Tests for prompt-lib -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'prompt-lib)
+
+(defmacro ai/prompt-lib-test--with-library (&rest body)
+  "Run BODY with an isolated temporary prompt library."
+  (declare (indent 0) (debug t))
+  `(let* ((root (make-temp-file "prompt-lib-test-" t))
+          (ai/prompt-lib-directory (file-name-as-directory root))
+          (ai/prompt-template-directory (expand-file-name "prompts/" root))
+          (ai/prompt-lib--records-cache nil)
+          (ai/prompt-lib--active-directory nil))
+     (unwind-protect
+         (progn
+           (make-directory ai/prompt-template-directory t)
+           ,@body)
+       (delete-directory root t))))
+
+(ert-deftest ai/prompt-lib-catalog-loads-metadata ()
+  (ai/prompt-lib-test--with-library
+    (let ((prompt (expand-file-name "prompts/test.prompt" ai/prompt-lib-directory)))
+      (write-region "Hello {{NAME}}" nil prompt nil 'silent)
+      (write-region
+       "{\"schema\":\"prompts-lib.catalog.v1\",\"prompts\":[{\"id\":\"test.hello\",\"title\":\"Hello\",\"description\":\"Test\",\"path\":\"prompts/test.prompt\",\"tags\":[\"test\"],\"aliases\":[\"hi\"]}]}"
+       nil (ai/prompt-lib--catalog-path) nil 'silent)
+      (let ((record (car (ai/prompt-lib-records 'refresh))))
+        (should (equal (plist-get record :id) "test.hello"))
+        (should (equal (plist-get record :title) "Hello"))
+        (should (equal (plist-get record :tags) '("test")))
+        (should (equal (plist-get record :aliases) '("hi")))))))
+
+(ert-deftest ai/prompt-lib-discovers-uncataloged-prompts ()
+  (ai/prompt-lib-test--with-library
+    (write-region "Plain prompt" nil
+                  (expand-file-name "prompts/plain.prompt" ai/prompt-lib-directory)
+                  nil 'silent)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "plain"))
+      (should (equal (plist-get record :source) 'scan)))))
+
+(ert-deftest ai/prompt-lib-rejects-catalog-path-escape ()
+  (ai/prompt-lib-test--with-library
+    (write-region
+     "{\"schema\":\"prompts-lib.catalog.v1\",\"prompts\":[{\"id\":\"bad\",\"path\":\"../escape.prompt\"}]}"
+     nil (ai/prompt-lib--catalog-path) nil 'silent)
+    (should-error (ai/prompt-lib-records 'refresh) :type 'user-error)))
+
+(ert-deftest ai/prompt-lib-activate-selects-external-prompts-directory ()
+  (ai/prompt-lib-test--with-library
+    (let ((fallback (make-temp-file "prompt-lib-fallback-" t)))
+      (unwind-protect
+          (progn
+            (setq ai/prompt-template-directory fallback)
+            (ai/prompt-lib-activate)
+            (should (equal ai/prompt-template-directory
+                           (expand-file-name "prompts/" ai/prompt-lib-directory))))
+        (delete-directory fallback t)))))
+
+(ert-deftest ai/prompt-lib-render-uses-existing-template-renderer ()
+  (ai/prompt-lib-test--with-library
+    (let ((template "Repo {{REPO}} task {{TASK|test}}"))
+      (should (equal
+               (ai/prompt-template-render-string
+                template '(("REPO" . "lost-rob0t/test")))
+               "Repo lost-rob0t/test task test")))))
+
+(provide 'prompt-lib-test)
+;;; prompt-lib-test.el ends here

--- a/lisp/llm/prompt-lib.el
+++ b/lisp/llm/prompt-lib.el
@@ -179,19 +179,22 @@
     (ai/prompt-template-render-string
      template (ai/prompt-template--ask-values template))))
 
+(defun ai/prompt-lib--preview-string (rendered)
+  "Show RENDERED prompt in the prompt preview buffer."
+  (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (insert rendered)
+      (goto-char (point-min))
+      (text-mode))
+    (pop-to-buffer (current-buffer))))
+
 (defun ai/prompt-lib-render (&optional record)
   "Render RECORD or read one interactively and preview it."
   (interactive)
   (let ((rendered (ai/prompt-lib-render-record
                    (or record (ai/prompt-lib-read-record)))))
-    (when (called-interactively-p 'interactive)
-      (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
-        (let ((inhibit-read-only t))
-          (erase-buffer)
-          (insert rendered)
-          (goto-char (point-min))
-          (text-mode))
-        (pop-to-buffer (current-buffer))))
+    (ai/prompt-lib--preview-string rendered)
     rendered))
 
 (defun ai/prompt-lib-copy (&optional record)
@@ -338,6 +341,8 @@
     ("G" "Generate from prompt" ai/image-generate)
     ("T" "Generate from template" ai/image-generate-template)
     ("X" "Edit image" ai/image-edit)]])
+
+(defalias 'ai/prompt-menu #'ai/prompt-lib-menu)
 
 (ai/prompt-lib-activate)
 

--- a/lisp/llm/prompt-lib.el
+++ b/lisp/llm/prompt-lib.el
@@ -1,0 +1,345 @@
+;;; prompt-lib.el --- Versioned prompt library client -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'json)
+(require 'subr-x)
+(require 'tabulated-list)
+(require 'transient)
+(require 'ai-prompts)
+
+(defgroup ai/prompt-lib nil
+  "Client for the external prompts-lib repository."
+  :group 'ai/prompts
+  :prefix "ai/prompt-lib-")
+
+(defcustom ai/prompt-lib-directory
+  (file-name-as-directory
+   (expand-file-name
+    (or (getenv "PROMPTS_LIB_DIR") "~/Documents/Projects/prompts-lib")))
+  "Local checkout of the prompts-lib repository."
+  :type 'directory
+  :group 'ai/prompt-lib)
+
+(defcustom ai/prompt-lib-catalog-name "catalog.json"
+  "Catalog filename relative to `ai/prompt-lib-directory'."
+  :type 'string
+  :group 'ai/prompt-lib)
+
+(defvar ai/prompt-lib--records-cache nil)
+(defvar ai/prompt-lib--active-directory nil)
+
+(defun ai/prompt-lib--catalog-path ()
+  "Return the configured prompt catalog path."
+  (expand-file-name ai/prompt-lib-catalog-name ai/prompt-lib-directory))
+
+(defun ai/prompt-lib--prompts-directory ()
+  "Return the external prompt body directory."
+  (expand-file-name "prompts/" ai/prompt-lib-directory))
+
+(defun ai/prompt-lib--object-get (object key)
+  "Read KEY from JSON alist OBJECT regardless of string/symbol keys."
+  (cdr (or (assq key object)
+           (assoc (symbol-name key) object))))
+
+(defun ai/prompt-lib--normalize-tags (tags)
+  "Return TAGS as a list of non-empty strings."
+  (cl-remove-if #'string-empty-p
+                (mapcar (lambda (tag) (format "%s" tag)) (or tags nil))))
+
+(defun ai/prompt-lib--catalog-records ()
+  "Read and validate records from the external catalog."
+  (let ((catalog (ai/prompt-lib--catalog-path))
+        records)
+    (when (file-readable-p catalog)
+      (with-temp-buffer
+        (insert-file-contents catalog)
+        (let* ((data (json-parse-buffer :object-type 'alist :array-type 'list
+                                        :null-object nil :false-object nil))
+               (schema (ai/prompt-lib--object-get data 'schema)))
+          (unless (equal schema "prompts-lib.catalog.v1")
+            (user-error "Unsupported prompts-lib catalog schema: %S" schema))
+          (dolist (entry (ai/prompt-lib--object-get data 'prompts))
+            (let* ((id (format "%s" (ai/prompt-lib--object-get entry 'id)))
+                   (relative (format "%s" (ai/prompt-lib--object-get entry 'path)))
+                   (path (expand-file-name relative ai/prompt-lib-directory)))
+              (unless (file-in-directory-p path ai/prompt-lib-directory)
+                (user-error "Prompt escapes library root: %s" relative))
+              (push (list :id id
+                          :title (or (ai/prompt-lib--object-get entry 'title) id)
+                          :description (or (ai/prompt-lib--object-get entry 'description) "")
+                          :tags (ai/prompt-lib--normalize-tags
+                                 (ai/prompt-lib--object-get entry 'tags))
+                          :aliases (ai/prompt-lib--normalize-tags
+                                    (ai/prompt-lib--object-get entry 'aliases))
+                          :path path
+                          :source 'catalog)
+                    records))))))
+    (nreverse records)))
+
+(defun ai/prompt-lib--prompt-files (directory)
+  "Return prompt files recursively below DIRECTORY."
+  (when (file-directory-p directory)
+    (directory-files-recursively
+     directory (concat (regexp-quote ai/prompt-template-extension) "\\'") nil)))
+
+(defun ai/prompt-lib--title-from-path (path)
+  "Build a readable title from prompt PATH."
+  (capitalize
+   (replace-regexp-in-string "[-_.]+" " " (file-name-base path))))
+
+(defun ai/prompt-lib--uncataloged-records (records)
+  "Return prompt records not already represented by RECORDS."
+  (let* ((known (mapcar (lambda (record) (file-truename (plist-get record :path)))
+                        records))
+         (directory ai/prompt-template-directory)
+         extras)
+    (dolist (path (ai/prompt-lib--prompt-files directory))
+      (unless (member (file-truename path) known)
+        (push (list :id (file-name-base path)
+                    :title (ai/prompt-lib--title-from-path path)
+                    :description "Uncataloged prompt template"
+                    :tags '("uncataloged")
+                    :aliases nil
+                    :path path
+                    :source 'scan)
+              extras)))
+    (nreverse extras)))
+
+(defun ai/prompt-lib-records (&optional refresh)
+  "Return prompt records, optionally forcing REFRESH."
+  (when refresh
+    (setq ai/prompt-lib--records-cache nil))
+  (or ai/prompt-lib--records-cache
+      (let* ((catalog (ai/prompt-lib--catalog-records))
+             (records (append catalog (ai/prompt-lib--uncataloged-records catalog))))
+        (setq ai/prompt-lib--records-cache records))))
+
+(defun ai/prompt-lib-activate ()
+  "Use the external prompts-lib checkout when it is available."
+  (interactive)
+  (let ((directory (ai/prompt-lib--prompts-directory)))
+    (when (file-directory-p directory)
+      (setq ai/prompt-template-directory directory
+            ai/prompt-lib--active-directory directory))
+    (ai/prompt-lib-records 'refresh)
+    (when (called-interactively-p 'interactive)
+      (message "Prompt library: %s (%d prompts)"
+               ai/prompt-template-directory
+               (length (ai/prompt-lib-records))))))
+
+(defun ai/prompt-lib-refresh ()
+  "Refresh the prompt library from disk."
+  (interactive)
+  (ai/prompt-lib-activate))
+
+(defun ai/prompt-lib--record-search-text (record)
+  "Return completion search text for RECORD."
+  (string-join
+   (delq nil
+         (list (plist-get record :id)
+               (plist-get record :title)
+               (plist-get record :description)
+               (string-join (plist-get record :tags) " ")
+               (string-join (plist-get record :aliases) " ")))
+   " "))
+
+(defun ai/prompt-lib--completion-candidates ()
+  "Return completion candidates paired with prompt records."
+  (mapcar
+   (lambda (record)
+     (let ((label (format "%s  [%s]  %s"
+                          (plist-get record :title)
+                          (plist-get record :id)
+                          (string-join (plist-get record :tags) ","))))
+       (cons (propertize label 'ai/prompt-search
+                         (ai/prompt-lib--record-search-text record))
+             record)))
+   (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-read-record (&optional prompt)
+  "Read and return a prompt record using PROMPT."
+  (let ((candidates (ai/prompt-lib--completion-candidates)))
+    (unless candidates
+      (user-error "No prompt templates found"))
+    (cdr (assoc (completing-read (or prompt "Prompt: ") candidates nil t)
+                candidates))))
+
+(defun ai/prompt-lib--read-template (record)
+  "Read prompt body for RECORD."
+  (let ((path (plist-get record :path)))
+    (unless (file-readable-p path)
+      (user-error "Prompt file is not readable: %s" path))
+    (with-temp-buffer
+      (insert-file-contents path)
+      (buffer-string))))
+
+(defun ai/prompt-lib-render-record (record)
+  "Fill placeholders and return rendered prompt RECORD."
+  (let ((template (ai/prompt-lib--read-template record)))
+    (ai/prompt-template-render-string
+     template (ai/prompt-template--ask-values template))))
+
+(defun ai/prompt-lib-render (&optional record)
+  "Render RECORD or read one interactively and preview it."
+  (interactive)
+  (let ((rendered (ai/prompt-lib-render-record
+                   (or record (ai/prompt-lib-read-record)))))
+    (when (called-interactively-p 'interactive)
+      (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (insert rendered)
+          (goto-char (point-min))
+          (text-mode))
+        (pop-to-buffer (current-buffer))))
+    rendered))
+
+(defun ai/prompt-lib-copy (&optional record)
+  "Render RECORD and copy it to the kill ring."
+  (interactive)
+  (let ((rendered (ai/prompt-lib-render-record
+                   (or record (ai/prompt-lib-read-record "Copy prompt: ")))))
+    (kill-new rendered)
+    (message "Prompt copied (%d chars)" (length rendered))))
+
+(defun ai/prompt-lib-insert (&optional record)
+  "Render RECORD and insert it at point."
+  (interactive)
+  (insert (ai/prompt-lib-render-record
+           (or record (ai/prompt-lib-read-record "Insert prompt: ")))))
+
+(defun ai/prompt-lib-send (&optional record)
+  "Render RECORD and submit it through gptel."
+  (interactive)
+  (require 'gptel)
+  (gptel-send
+   (ai/prompt-lib-render-record
+    (or record (ai/prompt-lib-read-record "Send prompt: ")))))
+
+(defun ai/prompt-lib-edit (&optional record)
+  "Open prompt RECORD for editing."
+  (interactive)
+  (find-file
+   (plist-get (or record (ai/prompt-lib-read-record "Edit prompt: ")) :path)))
+
+(defun ai/prompt-lib-open-repository ()
+  "Open the prompt library repository in Dired."
+  (interactive)
+  (unless (file-directory-p ai/prompt-lib-directory)
+    (user-error "Prompt library checkout does not exist: %s" ai/prompt-lib-directory))
+  (dired ai/prompt-lib-directory))
+
+(defun ai/prompt-lib-new (name)
+  "Create uncataloged prompt NAME in the active prompt directory."
+  (interactive "sNew prompt name: ")
+  (ai/prompt-template-new name))
+
+(defun ai/prompt-lib--record-by-id (id)
+  "Return prompt record matching ID."
+  (cl-find id (ai/prompt-lib-records) :key (lambda (record) (plist-get record :id))
+           :test #'equal))
+
+(defun ai/prompt-lib--entry-record ()
+  "Return the prompt record at point in the browser."
+  (or (ai/prompt-lib--record-by-id (tabulated-list-get-id))
+      (user-error "No prompt on this line")))
+
+(defun ai/prompt-lib-browser-preview ()
+  "Preview the prompt at point."
+  (interactive)
+  (ai/prompt-lib-render (ai/prompt-lib--entry-record)))
+
+(defun ai/prompt-lib-browser-copy ()
+  "Copy the prompt at point."
+  (interactive)
+  (ai/prompt-lib-copy (ai/prompt-lib--entry-record)))
+
+(defun ai/prompt-lib-browser-insert ()
+  "Insert the prompt at point in the previously selected window."
+  (interactive)
+  (let ((record (ai/prompt-lib--entry-record)))
+    (quit-window)
+    (ai/prompt-lib-insert record)))
+
+(defun ai/prompt-lib-browser-edit ()
+  "Edit the prompt at point."
+  (interactive)
+  (ai/prompt-lib-edit (ai/prompt-lib--entry-record)))
+
+(defun ai/prompt-lib-browser-refresh ()
+  "Refresh records shown in the prompt browser."
+  (interactive)
+  (ai/prompt-lib-refresh)
+  (ai/prompt-lib--browser-entries)
+  (tabulated-list-print t))
+
+(defun ai/prompt-lib--browser-entries ()
+  "Populate `tabulated-list-entries' from prompt records."
+  (setq tabulated-list-entries
+        (mapcar
+         (lambda (record)
+           (list (plist-get record :id)
+                 (vector (plist-get record :id)
+                         (plist-get record :title)
+                         (string-join (plist-get record :tags) ", ")
+                         (symbol-name (plist-get record :source)))))
+         (ai/prompt-lib-records))))
+
+(defvar ai/prompt-lib-browser-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "RET") #'ai/prompt-lib-browser-preview)
+    (define-key map (kbd "c") #'ai/prompt-lib-browser-copy)
+    (define-key map (kbd "i") #'ai/prompt-lib-browser-insert)
+    (define-key map (kbd "e") #'ai/prompt-lib-browser-edit)
+    (define-key map (kbd "g") #'ai/prompt-lib-browser-refresh)
+    map)
+  "Keymap for `ai/prompt-lib-browser-mode'.")
+
+(define-derived-mode ai/prompt-lib-browser-mode tabulated-list-mode "Prompt-Lib"
+  "Browse reusable prompts."
+  (setq tabulated-list-format
+        [("ID" 34 t)
+         ("Title" 30 t)
+         ("Tags" 36 t)
+         ("Source" 10 t)]
+        tabulated-list-padding 2
+        tabulated-list-sort-key (cons "Title" nil))
+  (ai/prompt-lib--browser-entries)
+  (tabulated-list-init-header))
+
+(defun ai/prompt-lib-browse ()
+  "Open the reusable prompt library browser."
+  (interactive)
+  (ai/prompt-lib-refresh)
+  (let ((buffer (get-buffer-create "*Prompt Library*")))
+    (with-current-buffer buffer
+      (ai/prompt-lib-browser-mode)
+      (tabulated-list-print t))
+    (pop-to-buffer buffer)))
+
+(declare-function ai/image-generate "ai-image")
+(declare-function ai/image-generate-template "ai-image")
+(declare-function ai/image-edit "ai-image")
+
+(transient-define-prefix ai/prompt-lib-menu ()
+  "Prompt library and image-generation commands."
+  [["Prompt library"
+    ("b" "Browse" ai/prompt-lib-browse)
+    ("c" "Copy" ai/prompt-lib-copy)
+    ("i" "Insert" ai/prompt-lib-insert)
+    ("s" "Send to gptel" ai/prompt-lib-send)
+    ("p" "Preview" ai/prompt-lib-render)
+    ("e" "Edit" ai/prompt-lib-edit)
+    ("n" "New" ai/prompt-lib-new)
+    ("g" "Refresh" ai/prompt-lib-refresh)
+    ("o" "Open repo" ai/prompt-lib-open-repository)]
+   ["Image tools"
+    ("G" "Generate from prompt" ai/image-generate)
+    ("T" "Generate from template" ai/image-generate-template)
+    ("X" "Edit image" ai/image-edit)]])
+
+(ai/prompt-lib-activate)
+
+(provide 'prompt-lib)
+;;; prompt-lib.el ends here

--- a/lisp/llm/prompt-lib.el
+++ b/lisp/llm/prompt-lib.el
@@ -1,7 +1,6 @@
-;;; prompt-lib.el --- Versioned prompt library client -*- lexical-binding: t; -*-
+;;; prompt-lib.el --- Org-first versioned prompt library client -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
-(require 'json)
 (require 'subr-x)
 (require 'tabulated-list)
 (require 'transient)
@@ -20,181 +19,312 @@
   :type 'directory
   :group 'ai/prompt-lib)
 
-(defcustom ai/prompt-lib-catalog-name "catalog.json"
-  "Catalog filename relative to `ai/prompt-lib-directory'."
-  :type 'string
+(defcustom ai/prompt-lib-default-format 'org
+  "Default file format for newly created prompts."
+  :type '(choice (const :tag "Org" org)
+                 (const :tag "Markdown" markdown)
+                 (const :tag "Lisp data" lisp))
+  :group 'ai/prompt-lib)
+
+(defcustom ai/prompt-lib-formats '(org markdown lisp legacy)
+  "Prompt formats discovered by the library client."
+  :type '(set (const org) (const markdown) (const lisp) (const legacy))
   :group 'ai/prompt-lib)
 
 (defvar ai/prompt-lib--records-cache nil)
 (defvar ai/prompt-lib--active-directory nil)
 
-(defun ai/prompt-lib--catalog-path ()
-  "Return the configured prompt catalog path."
-  (expand-file-name ai/prompt-lib-catalog-name ai/prompt-lib-directory))
-
 (defun ai/prompt-lib--prompts-directory ()
-  "Return the external prompt body directory."
+  "Return the external prompt directory."
   (expand-file-name "prompts/" ai/prompt-lib-directory))
 
-(defun ai/prompt-lib--object-get (object key)
-  "Read KEY from JSON alist OBJECT regardless of string/symbol keys."
-  (cdr (or (assq key object)
-           (assoc (symbol-name key) object))))
+(defun ai/prompt-lib--library-root ()
+  "Return the active prompt directory."
+  (or ai/prompt-lib--active-directory ai/prompt-template-directory))
 
-(defun ai/prompt-lib--normalize-tags (tags)
-  "Return TAGS as a list of non-empty strings."
-  (cl-remove-if #'string-empty-p
-                (mapcar (lambda (tag) (format "%s" tag)) (or tags nil))))
+(defun ai/prompt-lib--format-extension (format)
+  "Return filename extension for FORMAT."
+  (pcase format
+    ('org "org")
+    ('markdown "md")
+    ('lisp "el")
+    ('legacy "prompt")
+    (_ (user-error "Unsupported prompt format: %S" format))))
 
-(defun ai/prompt-lib--catalog-records ()
-  "Read and validate records from the external catalog."
-  (let ((catalog (ai/prompt-lib--catalog-path))
-        records)
-    (when (file-readable-p catalog)
-      (with-temp-buffer
-        (insert-file-contents catalog)
-        (let* ((data (json-parse-buffer :object-type 'alist :array-type 'list
-                                        :null-object nil :false-object nil))
-               (schema (ai/prompt-lib--object-get data 'schema)))
-          (unless (equal schema "prompts-lib.catalog.v1")
-            (user-error "Unsupported prompts-lib catalog schema: %S" schema))
-          (dolist (entry (ai/prompt-lib--object-get data 'prompts))
-            (let* ((id (format "%s" (ai/prompt-lib--object-get entry 'id)))
-                   (relative (format "%s" (ai/prompt-lib--object-get entry 'path)))
-                   (path (expand-file-name relative ai/prompt-lib-directory)))
-              (unless (file-in-directory-p path ai/prompt-lib-directory)
-                (user-error "Prompt escapes library root: %s" relative))
-              (push (list :id id
-                          :title (or (ai/prompt-lib--object-get entry 'title) id)
-                          :description (or (ai/prompt-lib--object-get entry 'description) "")
-                          :tags (ai/prompt-lib--normalize-tags
-                                 (ai/prompt-lib--object-get entry 'tags))
-                          :aliases (ai/prompt-lib--normalize-tags
-                                    (ai/prompt-lib--object-get entry 'aliases))
-                          :path path
-                          :source 'catalog)
-                    records))))))
-    (nreverse records)))
+(defun ai/prompt-lib--path-format (path)
+  "Return prompt format for PATH or nil."
+  (pcase (downcase (or (file-name-extension path) ""))
+    ("org" 'org)
+    ((or "md" "markdown") 'markdown)
+    ("el" 'lisp)
+    ("prompt" 'legacy)
+    (_ nil)))
 
-(defun ai/prompt-lib--prompt-files (directory)
-  "Return prompt files recursively below DIRECTORY."
-  (when (file-directory-p directory)
-    (directory-files-recursively
-     directory (concat (regexp-quote ai/prompt-template-extension) "\\'") nil)))
+(defun ai/prompt-lib--prompt-files ()
+  "Return prompt files below the active library root."
+  (let ((root (ai/prompt-lib--library-root))
+        files)
+    (when (file-directory-p root)
+      (dolist (path (directory-files-recursively root "." nil))
+        (let ((format (ai/prompt-lib--path-format path)))
+          (when (and format (memq format ai/prompt-lib-formats))
+            (push path files)))))
+    (nreverse files)))
 
 (defun ai/prompt-lib--title-from-path (path)
-  "Build a readable title from prompt PATH."
+  "Build a readable title from PATH."
   (capitalize
    (replace-regexp-in-string "[-_.]+" " " (file-name-base path))))
 
-(defun ai/prompt-lib--uncataloged-records (records)
-  "Return prompt records not already represented by RECORDS."
-  (let* ((known (mapcar (lambda (record) (file-truename (plist-get record :path)))
-                        records))
-         (directory ai/prompt-template-directory)
-         extras)
-    (dolist (path (ai/prompt-lib--prompt-files directory))
-      (unless (member (file-truename path) known)
-        (push (list :id (file-name-base path)
-                    :title (ai/prompt-lib--title-from-path path)
-                    :description "Uncataloged prompt template"
-                    :tags '("uncataloged")
-                    :aliases nil
-                    :path path
-                    :source 'scan)
-              extras)))
-    (nreverse extras)))
+(defun ai/prompt-lib--split-list (value separator)
+  "Split VALUE by SEPARATOR and trim empty items."
+  (when value
+    (cl-remove-if #'string-empty-p
+                  (mapcar #'string-trim (split-string value separator)))))
+
+(defun ai/prompt-lib--org-keyword (name)
+  "Read Org keyword NAME from the current buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward
+           (format "^#\\+%s:[ \t]*\\(.*\\)$" (regexp-quote name)) nil t)
+      (string-trim (match-string-no-properties 1)))))
+
+(defun ai/prompt-lib--org-body ()
+  "Return the body of the top-level Org `Prompt' heading."
+  (save-excursion
+    (goto-char (point-min))
+    (unless (re-search-forward "^\\* Prompt[ \t]*$" nil t)
+      (user-error "Org prompt has no top-level `* Prompt' heading: %s"
+                  (or buffer-file-name (buffer-name))))
+    (forward-line 1)
+    (let ((start (point)))
+      (if (re-search-forward "^\\* [^*]" nil t)
+          (string-trim-right
+           (buffer-substring-no-properties start (match-beginning 0)))
+        (string-trim-right
+         (buffer-substring-no-properties start (point-max)))))))
+
+(defun ai/prompt-lib--parse-org (path)
+  "Parse Org prompt PATH into a normalized record."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (let* ((id (or (ai/prompt-lib--org-keyword "prompt_id")
+                   (file-name-base path)))
+           (title (or (ai/prompt-lib--org-keyword "title")
+                      (ai/prompt-lib--title-from-path path)))
+           (description (or (ai/prompt-lib--org-keyword "description") ""))
+           (filetags (ai/prompt-lib--org-keyword "filetags"))
+           (aliases (ai/prompt-lib--org-keyword "prompt_aliases")))
+      (list :id id
+            :title title
+            :description description
+            :tags (ai/prompt-lib--split-list
+                   (string-trim (or filetags "") ":" ":") ":")
+            :aliases (ai/prompt-lib--split-list aliases "|")
+            :body (ai/prompt-lib--org-body)
+            :path path
+            :format 'org))))
+
+(defun ai/prompt-lib--markdown-frontmatter ()
+  "Return flat Markdown frontmatter as an alist.
+The supported syntax is deliberately limited to `key: value' lines between
+opening and closing `---' delimiters."
+  (save-excursion
+    (goto-char (point-min))
+    (let (metadata)
+      (when (looking-at-p "---[ \t]*$")
+        (forward-line 1)
+        (while (and (not (eobp)) (not (looking-at-p "---[ \t]*$")))
+          (when (looking-at "\\([^:#\n]+\\):[ \t]*\\(.*\\)$")
+            (push (cons (downcase (string-trim (match-string-no-properties 1)))
+                        (string-trim (match-string-no-properties 2)))
+                  metadata))
+          (forward-line 1)))
+      metadata)))
+
+(defun ai/prompt-lib--markdown-body ()
+  "Return body below a Markdown `# Prompt' heading."
+  (save-excursion
+    (goto-char (point-min))
+    (unless (re-search-forward "^# Prompt[ \t]*$" nil t)
+      (user-error "Markdown prompt has no `# Prompt' heading: %s"
+                  (or buffer-file-name (buffer-name))))
+    (forward-line 1)
+    (let ((start (point)))
+      (if (re-search-forward "^# [^#]" nil t)
+          (string-trim-right
+           (buffer-substring-no-properties start (match-beginning 0)))
+        (string-trim-right
+         (buffer-substring-no-properties start (point-max)))))))
+
+(defun ai/prompt-lib--parse-markdown (path)
+  "Parse Markdown prompt PATH into a normalized record."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (let* ((metadata (ai/prompt-lib--markdown-frontmatter))
+           (get (lambda (key) (cdr (assoc key metadata))))
+           (id (or (funcall get "prompt_id") (file-name-base path)))
+           (title (or (funcall get "title") (ai/prompt-lib--title-from-path path))))
+      (list :id id
+            :title title
+            :description (or (funcall get "description") "")
+            :tags (ai/prompt-lib--split-list (funcall get "tags") ",")
+            :aliases (ai/prompt-lib--split-list (funcall get "aliases") "|")
+            :body (ai/prompt-lib--markdown-body)
+            :path path
+            :format 'markdown))))
+
+(defun ai/prompt-lib--parse-lisp (path)
+  "Parse declarative Lisp prompt PATH without evaluating it."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (goto-char (point-min))
+    (let ((data (condition-case error
+                    (read (current-buffer))
+                  (error (user-error "Invalid Lisp prompt %s: %s"
+                                     path (error-message-string error))))))
+      (unless (and (listp data) (plist-get data :prompt))
+        (user-error "Lisp prompt must be a plist containing :prompt: %s" path))
+      (list :id (or (plist-get data :id) (file-name-base path))
+            :title (or (plist-get data :title) (ai/prompt-lib--title-from-path path))
+            :description (or (plist-get data :description) "")
+            :tags (mapcar (lambda (tag) (format "%s" tag)) (plist-get data :tags))
+            :aliases (mapcar (lambda (alias) (format "%s" alias))
+                             (plist-get data :aliases))
+            :body (format "%s" (plist-get data :prompt))
+            :path path
+            :format 'lisp))))
+
+(defun ai/prompt-lib--parse-legacy (path)
+  "Parse legacy raw `.prompt' PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (list :id (file-name-base path)
+          :title (ai/prompt-lib--title-from-path path)
+          :description "Legacy raw prompt"
+          :tags '("legacy")
+          :aliases nil
+          :body (buffer-string)
+          :path path
+          :format 'legacy)))
+
+(defun ai/prompt-lib--parse-file (path)
+  "Parse prompt PATH according to its extension."
+  (pcase (ai/prompt-lib--path-format path)
+    ('org (ai/prompt-lib--parse-org path))
+    ('markdown (ai/prompt-lib--parse-markdown path))
+    ('lisp (ai/prompt-lib--parse-lisp path))
+    ('legacy (ai/prompt-lib--parse-legacy path))
+    (_ nil)))
 
 (defun ai/prompt-lib-records (&optional refresh)
-  "Return prompt records, optionally forcing REFRESH."
+  "Return normalized prompt records, optionally forcing REFRESH."
   (when refresh
     (setq ai/prompt-lib--records-cache nil))
   (or ai/prompt-lib--records-cache
-      (let* ((catalog (ai/prompt-lib--catalog-records))
-             (records (append catalog (ai/prompt-lib--uncataloged-records catalog))))
-        (setq ai/prompt-lib--records-cache records))))
+      (setq ai/prompt-lib--records-cache
+            (delq nil (mapcar #'ai/prompt-lib--parse-file
+                              (ai/prompt-lib--prompt-files))))))
 
 (defun ai/prompt-lib-activate ()
-  "Use the external prompts-lib checkout when it is available."
+  "Activate external prompts-lib when its prompt directory is available."
   (interactive)
-  (let ((directory (ai/prompt-lib--prompts-directory)))
-    (when (file-directory-p directory)
-      (setq ai/prompt-template-directory directory
-            ai/prompt-lib--active-directory directory))
+  (let ((external (ai/prompt-lib--prompts-directory)))
+    (setq ai/prompt-lib--active-directory
+          (if (file-directory-p external)
+              external
+            ai/prompt-template-directory))
+    (when (file-directory-p external)
+      (setq ai/prompt-template-directory external))
     (ai/prompt-lib-records 'refresh)
     (when (called-interactively-p 'interactive)
       (message "Prompt library: %s (%d prompts)"
-               ai/prompt-template-directory
+               ai/prompt-lib--active-directory
                (length (ai/prompt-lib-records))))))
 
 (defun ai/prompt-lib-refresh ()
-  "Refresh the prompt library from disk."
+  "Refresh prompt records from disk."
   (interactive)
   (ai/prompt-lib-activate))
-
-(defun ai/prompt-lib--record-search-text (record)
-  "Return completion search text for RECORD."
-  (string-join
-   (delq nil
-         (list (plist-get record :id)
-               (plist-get record :title)
-               (plist-get record :description)
-               (string-join (plist-get record :tags) " ")
-               (string-join (plist-get record :aliases) " ")))
-   " "))
 
 (defun ai/prompt-lib--completion-candidates ()
   "Return completion candidates paired with prompt records."
   (mapcar
    (lambda (record)
-     (let ((label (format "%s  [%s]  %s"
-                          (plist-get record :title)
-                          (plist-get record :id)
-                          (string-join (plist-get record :tags) ","))))
-       (cons (propertize label 'ai/prompt-search
-                         (ai/prompt-lib--record-search-text record))
-             record)))
+     (let* ((aliases (string-join (plist-get record :aliases) ", "))
+            (description (plist-get record :description))
+            (label (format "%s  [%s]  %s%s"
+                           (plist-get record :title)
+                           (plist-get record :id)
+                           (string-join (plist-get record :tags) ",")
+                           (if (string-empty-p aliases) ""
+                             (format "  {%s}" aliases)))))
+       (cons (propertize label 'ai/prompt-description description) record)))
    (ai/prompt-lib-records)))
 
 (defun ai/prompt-lib-read-record (&optional prompt)
   "Read and return a prompt record using PROMPT."
   (let ((candidates (ai/prompt-lib--completion-candidates)))
     (unless candidates
-      (user-error "No prompt templates found"))
+      (user-error "No prompts found in %s" (ai/prompt-lib--library-root)))
     (cdr (assoc (completing-read (or prompt "Prompt: ") candidates nil t)
                 candidates))))
 
-(defun ai/prompt-lib--read-template (record)
-  "Read prompt body for RECORD."
-  (let ((path (plist-get record :path)))
-    (unless (file-readable-p path)
-      (user-error "Prompt file is not readable: %s" path))
-    (with-temp-buffer
-      (insert-file-contents path)
-      (buffer-string))))
+(defun ai/prompt-lib--record-by-name (name)
+  "Find a prompt record by ID, file base name, title, or alias NAME."
+  (cl-find-if
+   (lambda (record)
+     (or (equal name (plist-get record :id))
+         (equal name (file-name-base (plist-get record :path)))
+         (equal name (plist-get record :title))
+         (member name (plist-get record :aliases))))
+   (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-template-names ()
+  "Return prompt IDs for compatibility with `ai-prompts'."
+  (mapcar (lambda (record) (plist-get record :id)) (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-template-read (name)
+  "Return raw prompt body for NAME."
+  (let ((record (ai/prompt-lib--record-by-name name)))
+    (unless record
+      (user-error "Unknown prompt: %s" name))
+    (plist-get record :body)))
+
+(defun ai/prompt-lib-template-path (name)
+  "Return prompt path for NAME."
+  (let ((record (ai/prompt-lib--record-by-name name)))
+    (unless record
+      (user-error "Unknown prompt: %s" name))
+    (plist-get record :path)))
 
 (defun ai/prompt-lib-render-record (record)
   "Fill placeholders and return rendered prompt RECORD."
-  (let ((template (ai/prompt-lib--read-template record)))
+  (let ((template (plist-get record :body)))
     (ai/prompt-template-render-string
      template (ai/prompt-template--ask-values template))))
 
-(defun ai/prompt-lib--preview-string (rendered)
-  "Show RENDERED prompt in the prompt preview buffer."
+(defun ai/prompt-lib--preview-string (rendered format)
+  "Show RENDERED prompt using FORMAT-appropriate major mode."
   (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
     (let ((inhibit-read-only t))
       (erase-buffer)
       (insert rendered)
       (goto-char (point-min))
-      (text-mode))
+      (pcase format
+        ('org (org-mode))
+        ('markdown (if (fboundp 'markdown-mode) (markdown-mode) (text-mode)))
+        ('lisp (emacs-lisp-mode))
+        (_ (text-mode))))
     (pop-to-buffer (current-buffer))))
 
 (defun ai/prompt-lib-render (&optional record)
   "Render RECORD or read one interactively and preview it."
   (interactive)
-  (let ((rendered (ai/prompt-lib-render-record
-                   (or record (ai/prompt-lib-read-record)))))
-    (ai/prompt-lib--preview-string rendered)
+  (let* ((record (or record (ai/prompt-lib-read-record)))
+         (rendered (ai/prompt-lib-render-record record)))
+    (ai/prompt-lib--preview-string rendered (plist-get record :format))
     rendered))
 
 (defun ai/prompt-lib-copy (&optional record)
@@ -220,7 +350,7 @@
     (or record (ai/prompt-lib-read-record "Send prompt: ")))))
 
 (defun ai/prompt-lib-edit (&optional record)
-  "Open prompt RECORD for editing."
+  "Open prompt RECORD for editing in its native major mode."
   (interactive)
   (find-file
    (plist-get (or record (ai/prompt-lib-read-record "Edit prompt: ")) :path)))
@@ -232,40 +362,86 @@
     (user-error "Prompt library checkout does not exist: %s" ai/prompt-lib-directory))
   (dired ai/prompt-lib-directory))
 
-(defun ai/prompt-lib-new (name)
-  "Create uncataloged prompt NAME in the active prompt directory."
-  (interactive "sNew prompt name: ")
-  (ai/prompt-template-new name))
+(defun ai/prompt-lib--slug (name)
+  "Return filesystem-safe slug derived from NAME."
+  (let ((slug (downcase (string-trim name))))
+    (setq slug (replace-regexp-in-string "[^[:alnum:]._-]+" "-" slug))
+    (replace-regexp-in-string "^-+\\|-+$" "" slug)))
+
+(defun ai/prompt-lib--new-org (path id title)
+  "Create Org prompt PATH with ID and TITLE."
+  (write-region
+   (format "#+title: %s\n#+prompt_id: %s\n#+description: \n#+filetags: :prompt:\n#+prompt_aliases: \n\n* Prompt\n\n"
+           title id)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib--new-markdown (path id title)
+  "Create Markdown prompt PATH with ID and TITLE."
+  (write-region
+   (format "---\nprompt_id: %s\ntitle: %s\ndescription: \ntags: prompt\naliases: \n---\n\n# Prompt\n\n"
+           id title)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib--new-lisp (path id title)
+  "Create declarative Lisp prompt PATH with ID and TITLE."
+  (write-region
+   (format "(:id %S\n :title %S\n :description \"\"\n :tags (\"prompt\")\n :aliases ()\n :prompt \"\")\n"
+           id title)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib-new (name &optional format)
+  "Create prompt NAME using FORMAT.
+Org is the default.  With a prefix argument, choose Markdown or Lisp instead."
+  (interactive
+   (list (read-string "New prompt name: ")
+         (when current-prefix-arg
+           (intern (completing-read "Format: " '("org" "markdown" "lisp") nil t)))))
+  (let* ((format (or format ai/prompt-lib-default-format))
+         (root (ai/prompt-lib--library-root))
+         (slug (ai/prompt-lib--slug name))
+         (id slug)
+         (path (expand-file-name
+                (format "%s.%s" slug (ai/prompt-lib--format-extension format)) root)))
+    (unless (file-directory-p root)
+      (make-directory root t))
+    (when (file-exists-p path)
+      (user-error "Prompt already exists: %s" path))
+    (pcase format
+      ('org (ai/prompt-lib--new-org path id name))
+      ('markdown (ai/prompt-lib--new-markdown path id name))
+      ('lisp (ai/prompt-lib--new-lisp path id name)))
+    (ai/prompt-lib-records 'refresh)
+    (find-file path)))
 
 (defun ai/prompt-lib--record-by-id (id)
   "Return prompt record matching ID."
-  (cl-find id (ai/prompt-lib-records) :key (lambda (record) (plist-get record :id))
-           :test #'equal))
+  (cl-find id (ai/prompt-lib-records)
+           :key (lambda (record) (plist-get record :id)) :test #'equal))
 
 (defun ai/prompt-lib--entry-record ()
-  "Return the prompt record at point in the browser."
+  "Return prompt record at point in the browser."
   (or (ai/prompt-lib--record-by-id (tabulated-list-get-id))
       (user-error "No prompt on this line")))
 
 (defun ai/prompt-lib-browser-preview ()
-  "Preview the prompt at point."
+  "Preview prompt at point."
   (interactive)
   (ai/prompt-lib-render (ai/prompt-lib--entry-record)))
 
 (defun ai/prompt-lib-browser-copy ()
-  "Copy the prompt at point."
+  "Copy prompt at point."
   (interactive)
   (ai/prompt-lib-copy (ai/prompt-lib--entry-record)))
 
 (defun ai/prompt-lib-browser-insert ()
-  "Insert the prompt at point in the previously selected window."
+  "Insert prompt at point in the previously selected window."
   (interactive)
   (let ((record (ai/prompt-lib--entry-record)))
     (quit-window)
     (ai/prompt-lib-insert record)))
 
 (defun ai/prompt-lib-browser-edit ()
-  "Edit the prompt at point."
+  "Edit prompt at point."
   (interactive)
   (ai/prompt-lib-edit (ai/prompt-lib--entry-record)))
 
@@ -285,7 +461,7 @@
                  (vector (plist-get record :id)
                          (plist-get record :title)
                          (string-join (plist-get record :tags) ", ")
-                         (symbol-name (plist-get record :source)))))
+                         (symbol-name (plist-get record :format)))))
          (ai/prompt-lib-records))))
 
 (defvar ai/prompt-lib-browser-mode-map
@@ -305,7 +481,7 @@
         [("ID" 34 t)
          ("Title" 30 t)
          ("Tags" 36 t)
-         ("Source" 10 t)]
+         ("Format" 10 t)]
         tabulated-list-padding 2
         tabulated-list-sort-key (cons "Title" nil))
   (ai/prompt-lib--browser-entries)
@@ -334,7 +510,7 @@
     ("s" "Send to gptel" ai/prompt-lib-send)
     ("p" "Preview" ai/prompt-lib-render)
     ("e" "Edit" ai/prompt-lib-edit)
-    ("n" "New" ai/prompt-lib-new)
+    ("n" "New Org prompt" ai/prompt-lib-new)
     ("g" "Refresh" ai/prompt-lib-refresh)
     ("o" "Open repo" ai/prompt-lib-open-repository)]
    ["Image tools"
@@ -342,6 +518,12 @@
     ("T" "Generate from template" ai/image-generate-template)
     ("X" "Edit image" ai/image-edit)]])
 
+;; Existing image/chat integrations call these ai-prompts functions.  Route
+;; their lookup through the normalized multi-format library without changing
+;; the existing placeholder renderer.
+(defalias 'ai/prompt-template-names #'ai/prompt-lib-template-names)
+(defalias 'ai/prompt-template--read #'ai/prompt-lib-template-read)
+(defalias 'ai/prompt-template-path #'ai/prompt-lib-template-path)
 (defalias 'ai/prompt-menu #'ai/prompt-lib-menu)
 
 (ai/prompt-lib-activate)


### PR DESCRIPTION
## Summary

Adds the Emacs client for `lost-rob0t/prompts-lib` with **Org as the default authoring format** while preserving the existing placeholder renderer.

- loads the external prompt library from `~/Documents/Projects/prompts-lib/prompts/` or `PROMPTS_LIB_DIR`
- falls back to the existing bundled raw `.prompt` directory when the external checkout is absent
- discovers prompt files directly; no JSON catalog
- parses Org metadata from `#+prompt_id`, `#+description`, `#+filetags`, and `#+prompt_aliases`
- renders the body below a top-level `* Prompt` heading
- supports Markdown frontmatter + `# Prompt` as an alternate adapter
- supports declarative Lisp plist records as an alternate adapter without evaluating them
- normalizes all formats into the same record shape
- defaults `ai/prompt-lib-new` to `.org` and `org-mode`; prefix arg selects Markdown or Lisp
- adds completion selection plus a `tabulated-list-mode` browser
- adds preview, copy, insert, edit, new, refresh, open-repo, and direct `gptel-send` actions
- routes existing image/chat prompt-template lookup through the normalized library
- aliases the existing `ai/prompt-menu`, so `SPC y p` opens the full prompt-library Transient
- updates the LLM Org documentation and adds ERT coverage

## Scope discipline

The existing `lisp/llm/ai-init.el` change remains a single added `(require 'prompt-lib)`. Prompt-library behavior is contained in `lisp/llm/prompt-lib.el`, its ERT tests, and Org docs.

## Verification

ERT coverage now includes:

- Org metadata/body parsing
- Markdown adapter parsing
- declarative Lisp parsing without evaluation
- legacy raw `.prompt` fallback
- external-library activation
- Org-default prompt creation and `org-mode`
- compatibility with the existing placeholder renderer and prompt-template lookup used by image/chat integrations

The remote execution environment used to prepare this PR does not contain the user's real Emacs/Doom environment, so the real local ERT/Doom gate is still required before merge.

No merge performed.