### PR TITLE
feat: add global Org research handoff policy

### DIFF
--- a/nix/home-manager/files/global-agents.md
+++ b/nix/home-manager/files/global-agents.md
@@ -18,6 +18,18 @@ Use Brave Search for external discovery. Prefer `prolog-verify brave --query <qu
 
 Do not perform web research when the user forbids it. Local-only work does not need a search; keep `research_required(false)` for those tasks.
 
+## Durable research artifacts
+
+For durable research, investigations, architectural analysis, source review, benchmark analysis, incident analysis, and similar work, default to Org rather than ephemeral chat-only prose.
+
+1. Resolve the user's configured Org-roam root instead of hardcoding a home-directory path.
+2. Write or update the artifact at `llm/research/<slug>.org` beneath that root. Use a stable lowercase filesystem-safe slug derived from the subject, and reuse an existing artifact for the same subject instead of creating near-duplicates.
+3. Use normal Org structure and preserve sources, exact commands, commit SHAs, evidence, uncertainty, and conclusions. Prefer headings, links, tables, source blocks, TODOs, and properties over Markdown pasted into Org.
+4. After the artifact is successfully written, use the `emacs-eval` skill to open that exact file in the user's running Emacs server.
+5. Do not claim the file was opened unless the Emacs operation actually succeeded.
+
+Do not create a durable research artifact for trivial scratch work unless the user asks for one.
+
 ## Code cleanup
 
 - Remove dead code, unreachable branches, obsolete compatibility paths, and unused helpers encountered within the task scope.


### PR DESCRIPTION
## Summary

Adds a concise global agent rule for durable research artifacts.

- durable research defaults to Org
- artifacts live under the configured Org-roam root at `llm/research/<slug>.org`
- stable slugs and reuse of existing subject artifacts are required
- evidence, commands, SHAs, uncertainty, and conclusions stay in normal Org structure
- after a successful write, agents use the `emacs-eval` skill to open that exact artifact in the running Emacs server
- agents must not claim the open succeeded without Emacs evidence

Companion skill PR: lost-rob0t/skills#41

No merge performed.