### PR TITLE
Zara desktop workflow config and /pol/ aliases

### DIFF
--- a/.github/workflows/zara-workflows.yml
+++ b/.github/workflows/zara-workflows.yml
@@ -5,18 +5,26 @@ on:
     paths:
       - '.github/workflows/zara-workflows.yml'
       - 'tests/zara-workflows.sh'
+      - 'nix/home-manager/mods/default.nix'
       - 'nix/home-manager/mods/zara.nix'
+      - 'nix/home-manager/mods/zara-workflows.nix'
       - 'nix/home-manager/systems/desktop/home.nix'
       - 'nix/home-manager/files/zarathushtra/**'
+      - 'docs/wiki/zara.org'
+      - 'docs/wiki/index.org'
   push:
     branches:
       - master
     paths:
       - '.github/workflows/zara-workflows.yml'
       - 'tests/zara-workflows.sh'
+      - 'nix/home-manager/mods/default.nix'
       - 'nix/home-manager/mods/zara.nix'
+      - 'nix/home-manager/mods/zara-workflows.nix'
       - 'nix/home-manager/systems/desktop/home.nix'
       - 'nix/home-manager/files/zarathushtra/**'
+      - 'docs/wiki/zara.org'
+      - 'docs/wiki/index.org'
 
 permissions:
   contents: read
@@ -26,5 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install validation tools
+        run: sudo apt-get update && sudo apt-get install -y shellcheck swi-prolog-nox
+      - name: Check shell syntax and policy
+        run: |
+          set -euo pipefail
+          bash -n tests/zara-workflows.sh nix/home-manager/files/zarathushtra/bin/zara-system-update
+          shellcheck --severity=warning tests/zara-workflows.sh nix/home-manager/files/zarathushtra/bin/zara-system-update
+      - name: Check Zara Prolog base config syntax
+        run: swipl -q -t halt -s nix/home-manager/files/zarathushtra/config.pl
       - name: Check Zara workflow contract
         run: bash tests/zara-workflows.sh

--- a/.github/workflows/zara-workflows.yml
+++ b/.github/workflows/zara-workflows.yml
@@ -1,0 +1,30 @@
+name: Zara workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/zara-workflows.yml'
+      - 'tests/zara-workflows.sh'
+      - 'nix/home-manager/mods/zara.nix'
+      - 'nix/home-manager/systems/desktop/home.nix'
+      - 'nix/home-manager/files/zarathushtra/**'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/zara-workflows.yml'
+      - 'tests/zara-workflows.sh'
+      - 'nix/home-manager/mods/zara.nix'
+      - 'nix/home-manager/systems/desktop/home.nix'
+      - 'nix/home-manager/files/zarathushtra/**'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Zara workflow contract
+        run: bash tests/zara-workflows.sh

--- a/docs/wiki/index.org
+++ b/docs/wiki/index.org
@@ -14,6 +14,7 @@ The configuration itself remains the source of truth.  In particular, literate O
 - [[file:nix.org][Nix and Home Manager]] - flake outputs, hosts, profiles, installers, and module layout.
 - [[file:emacs.org][Emacs and Doom]] - Doom literate sources and Emacs-related code in the repository.
 - [[file:desktop.org][Desktop and Qtile]] - Qtile, widgets, keybindings, notifications, desktop workflows, and desktop integration.
+- [[file:zara.org][Zara workflows]] - declarative Zara base config, private-overlay ownership, desktop/voice workflows, and bounded system updates.
 - [[file:screen-capture.org][Screen capture]] - stable screenshot/recording CLI, backends, Qtile bindings, Emacs picker, and Home Manager options.
 - [[file:../qtile-emacs-ui.org][Qtile and Emacs dropdown UI]] - shared popup lifecycle, widget-relative geometry, notification backends, and dashboard ownership.
 - [[file:maintenance.org][Maintenance]] - safe edit/tangle/test workflow and useful verification commands.
@@ -35,6 +36,7 @@ The configuration itself remains the source of truth.  In particular, literate O
 | OpenRouter widget | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | Telemetry/widget helper; tangles to =qtile_openrouter.py=. |
 | Nix flake | [[file:../../flake.nix][flake.nix]] | NixOS, Home Manager, installer, and package outputs. |
 | Home Manager | [[file:../../nix/home-manager/][nix/home-manager/]] | Shared modules/files and per-system profiles. |
+| Zara workflows | [[file:../../nix/home-manager/mods/zara-workflows.nix][zara-workflows.nix]] | Home Manager-owned Zara base workflow config and bounded system-update helper; private =config.local.pl= remains unmanaged. |
 | Agent verification | [[file:../../nix/home-manager/mods/agent-verification.nix][agent-verification.nix]] | Global Codex/OpenCode policy, durable Prolog gate, and Codex lifecycle hooks. |
 | NixOS | [[file:../../nix/nixos/][nix/nixos/]] | Hosts and installer definitions. |
 | Scripts | [[file:../../scripts/][scripts/]] | Provisioning/install/maintenance helpers. |

--- a/docs/wiki/zara.org
+++ b/docs/wiki/zara.org
@@ -1,0 +1,57 @@
+#+TITLE: Zara workflow ownership
+#+AUTHOR: nsaspy
+#+STARTUP: overview
+
+* Scope
+The desktop Home Manager profile enables =zara.workflows=.  That module installs
+non-secret operator workflow defaults and the bounded =zara-system-update=
+helper without taking ownership of Zara's mutable private overlay.
+
+* Configuration ownership
+- =nix/home-manager/files/zarathushtra/config.pl= is the declarative base layer
+  and Home Manager may replace it on activation.
+- =~/.config/zarathushtra/config.local.pl= is intentionally not managed by Home
+  Manager.  Keep secrets, machine-private facts, experiments, and temporary
+  overrides there.  Zara loads it after =config.pl= so local facts win.
+- =~/.config/zarathushtra/secrets.env= remains outside Git/Nix and is consumed
+  by the existing =zara-server= EnvironmentFile integration.
+
+This split is deliberate: reproducible workflows belong in dotfiles; mutable
+private state does not.
+
+* Operator workflows
+The canonical fact definitions live in
+[[file:../../nix/home-manager/files/zarathushtra/config.pl][config.pl]].  They cover
+Brave/search, Emacs scratch, org-roam daily followed by the existing
+=zara-dictate= path, Thunderbird, Tor Browser, Feishin, YouTube Music, GitHub PR
+compatibility, Magit project aliases, and =/pol/=.  The 4chan mapping carries a
+small explicit alias set for common text/ASR forms; general edit-distance/fuzzy
+resolution belongs in Zara Core rather than being simulated by an unbounded
+alias list here.
+
+* System update boundary
+=update system= resolves to =zara-system-update=.  The helper performs the three
+operator-requested steps in order:
+
+1. =pkexec /usr/bin/pacman -Syu=;
+2. =git -C "$DOTFILES" pull --ff-only=;
+3. =home-manager switch --flake ...=.
+
+A failing step aborts the sequence and the helper never reports complete unless
+all three succeeded.  It never embeds or pipes a password and does not add a
+passwordless privilege rule.
+
+The default dotfiles checkout is =~/Documents/Projects/dotfiles=.  Override it
+with =ZARA_DOTFILES_DIR=; =ZARA_HOME_MANAGER_FLAKE= and
+=ZARA_HOME_MANAGER_TARGET= control the Home Manager invocation when needed.
+
+* Verification
+Run:
+
+#+begin_src shell
+bash tests/zara-workflows.sh
+nix eval --raw '.#homeConfigurations."unseen@desktop".activationPackage.drvPath'
+#+end_src
+
+The dedicated Zara workflow Actions job also runs the contract on relevant
+changes.

--- a/nix/home-manager/files/zarathushtra/bin/zara-system-update
+++ b/nix/home-manager/files/zarathushtra/bin/zara-system-update
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DOTFILES="${ZARA_DOTFILES_DIR:-$HOME/Documents/Projects/dotfiles}"
+HM_FLAKE="${ZARA_HOME_MANAGER_FLAKE:-$DOTFILES}"
+HM_TARGET="${ZARA_HOME_MANAGER_TARGET:-}"
+
+notify() {
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "$@" || true
+  fi
+}
+
+fail() {
+  local rc=$?
+  notify "Zara system update failed" "exit ${rc}"
+  exit "$rc"
+}
+trap fail ERR
+
+notify "Zara system update" "Updating Arch packages"
+pkexec /usr/bin/pacman -Syu
+
+notify "Zara system update" "Pulling dotfiles"
+git -C "$DOTFILES" pull --ff-only
+
+notify "Zara system update" "Applying Home Manager"
+if [[ -n "$HM_TARGET" ]]; then
+  home-manager switch --flake "${HM_FLAKE}#${HM_TARGET}"
+else
+  home-manager switch --flake "$HM_FLAKE"
+fi
+
+notify "Zara system update complete" "pacman, dotfiles, and Home Manager succeeded"

--- a/nix/home-manager/files/zarathushtra/config.pl
+++ b/nix/home-manager/files/zarathushtra/config.pl
@@ -63,13 +63,15 @@ app_mapping(youtube_music, ["brave", "--new-window", "https://music.youtube.com/
 
 % Keep a small deterministic alias set until Zara Core owns bounded fuzzy
 % matching/edit distance. The '4' and `four` aliases intentionally tolerate
-% ASR/tokenization splitting "4 chan" / "four chan" into two tokens.
+% ASR/tokenization splitting "4 chan" / "four chan" into two tokens; the
+% `politically` alias similarly covers "politically incorrect".
 app_mapping('4chan', ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping('4', ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping(fourchan, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping(four, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping(chan, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping(pol, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(politically, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 app_mapping(politically_incorrect, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
 
 % ----------------------------------------------------------------------

--- a/nix/home-manager/files/zarathushtra/config.pl
+++ b/nix/home-manager/files/zarathushtra/config.pl
@@ -1,0 +1,142 @@
+% Zara non-secret base configuration managed by Home Manager.
+%
+% Ownership contract:
+%   - This file is declarative dotfiles state and may be replaced by Home Manager.
+%   - ~/.config/zarathushtra/config.local.pl is mutable/private operator state.
+%   - Keep secrets, machine-private experiments, and temporary overrides in
+%     config.local.pl; Zara loads it after this base file so local facts win.
+
+% ----------------------------------------------------------------------
+% Search / browser
+% ----------------------------------------------------------------------
+
+search_engine("https://search.brave.com/search?q=~w").
+app_mapping(browser, ["brave"]).
+app_mapping(brave, ["brave"]).
+direct_app(brave).
+
+% ----------------------------------------------------------------------
+% Emacs / Org-roam
+% ----------------------------------------------------------------------
+
+% "open scratch"
+app_mapping(scratch,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (switch-to-buffer \"*scratch*\") (goto-char (point-max)))"]).
+
+% Current open-intent parsing consumes the first app token, so both
+% "open roam" and "open roam daily" resolve through `roam`.
+% Use the canonical Zara dictation command immediately after entering today's
+% org-roam daily rather than starting a second microphone/runtime.
+app_mapping(roam,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'org-roam-dailies) (org-roam-dailies-goto-today) (start-process \"zara-dictate\" nil \"zara-dictate\"))"]).
+
+app_mapping(emacs, ["emacsclient", "-c", "-a", ""]).
+direct_app(emacsclient).
+
+% ----------------------------------------------------------------------
+% Desktop apps / media
+% ----------------------------------------------------------------------
+
+app_mapping(thunderbird, ["thunderbird"]).
+app_mapping(email, ["thunderbird"]).
+app_mapping(mail, ["thunderbird"]).
+direct_app(thunderbird).
+
+app_mapping(tor, ["torbrowser-launcher"]).
+app_mapping(tor_browser, ["torbrowser-launcher"]).
+direct_app(torbrowser-launcher).
+
+app_mapping(music, ["feishin"]).
+app_mapping(feishin, ["feishin"]).
+direct_app(feishin).
+
+% Current open parsing consumes one app token. Point both the common single
+% token and canonical alias at YouTube Music.
+app_mapping(youtube, ["brave", "--new-window", "https://music.youtube.com/"]).
+app_mapping(youtube_music, ["brave", "--new-window", "https://music.youtube.com/"]).
+
+% ----------------------------------------------------------------------
+% 4chan /pol/
+% ----------------------------------------------------------------------
+
+% Keep a small deterministic alias set until Zara Core owns bounded fuzzy
+% matching/edit distance. The '4' and `four` aliases intentionally tolerate
+% ASR/tokenization splitting "4 chan" / "four chan" into two tokens.
+app_mapping('4chan', ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping('4', ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(fourchan, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(four, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(chan, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(pol, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+app_mapping(politically_incorrect, ["brave", "--new-window", "https://boards.4chan.org/pol/"]).
+
+% ----------------------------------------------------------------------
+% GitHub / PR compatibility workflow
+% ----------------------------------------------------------------------
+
+% Temporary compatibility bridge until Zara Core exposes the requested typed
+% GitHub PR query/merge capability directly. `latest prs` opens an Emacs buffer
+% populated by gh; it does not fake static PR data.
+verb_intent(latest, open, 1).
+app_mapping(prs,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(let ((buf (get-buffer-create \"*zara-latest-prs*\"))) (with-current-buffer buf (erase-buffer)) (async-shell-command \"gh search prs --author @me --state open --sort updated --order desc --limit 100\" buf) (pop-to-buffer buf))"]).
+
+% ----------------------------------------------------------------------
+% System update
+% ----------------------------------------------------------------------
+
+% External todo replacement is intentionally paused. While it is paused,
+% "update system" resolves to the bounded helper installed by Home Manager.
+verb_intent(update, open, 1).
+app_mapping(system, ["zara-system-update"]).
+
+% ----------------------------------------------------------------------
+% Magit project aliases
+% ----------------------------------------------------------------------
+
+% Current Zara does not yet expose a general known_project/2 user-config fact,
+% so `magit <alias>` is the loader-compatible project KB for now.
+verb_intent(magit, open, 1).
+
+app_mapping(zara,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/zara\")))"]).
+app_mapping(prolog,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/prolog-rlm\")))"]).
+app_mapping(agent,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/agentProlog\")))"]).
+app_mapping(hackmode,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/hackmode\")))"]).
+app_mapping(symbolic,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/symbolic-memory\")))"]).
+app_mapping(dotfiles,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/dotfiles\")))"]).
+app_mapping(quasar,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/quasar\")))"]).
+app_mapping(tek9,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/tek9\")))"]).
+app_mapping(plugins,
+    ["emacsclient", "-c", "-a", "", "--eval",
+     "(progn (require 'magit) (magit-status (expand-file-name \"~/Documents/Projects/zara-plugins\")))"]).
+
+% ----------------------------------------------------------------------
+% Voice / dictation
+% ----------------------------------------------------------------------
+
+dictation_command(["zara-dictate"]).
+wake_word("zara").
+wake_word("hey zara").
+wake_word("zarathushtra").
+
+% Timers use Zara's native timer semantic path; no todo backend is configured
+% here and no second timer store is introduced.

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -25,6 +25,7 @@
     ./pentesting.nix
     ./llm.nix
     ./zara.nix
+    ./zara-workflows.nix
     ./screen-capture.nix
     ./prolog-mcp.nix
     ./proxmox-mcp.nix

--- a/nix/home-manager/mods/zara-workflows.nix
+++ b/nix/home-manager/mods/zara-workflows.nix
@@ -1,0 +1,37 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.zara.workflows;
+  systemUpdate = pkgs.writeShellApplication {
+    name = "zara-system-update";
+    runtimeInputs = [
+      pkgs.git
+      pkgs.libnotify
+      pkgs.polkit
+    ];
+    text = builtins.readFile ../files/zarathushtra/bin/zara-system-update;
+  };
+in
+{
+  options.zara.workflows = {
+    enable = lib.mkEnableOption "operator Zara desktop/voice workflow configuration";
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.zara.enable;
+        message = "zara.workflows.enable requires zara.enable.";
+      }
+    ];
+
+    # Home Manager owns only the non-secret provisioned/base layer. Zara's
+    # config.local.pl remains mutable, private, and deliberately unmanaged.
+    home.file.".config/zarathushtra/config.pl" = {
+      source = ../files/zarathushtra/config.pl;
+      force = true;
+    };
+
+    home.packages = [ systemUpdate ];
+  };
+}

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -24,6 +24,7 @@
 
   zara = {
     enable = true;
+    workflows.enable = true;
 
     server = {
       enable = true;
@@ -94,9 +95,8 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage.
-  # See the Home Manager release notes for a list of state version
-  # changes.
+  # You can update this value in your configuration without breakage
+  # and Home Manager should remain compatible with earlier releases.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -95,8 +95,9 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage
-  # and Home Manager should remain compatible with earlier releases.
+  # You can update this value in your configuration without breakage.
+  # See the Home Manager release notes for a list of state version
+  # changes.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/tests/zara-workflows.sh
+++ b/tests/zara-workflows.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+config="$repo_root/nix/home-manager/files/zarathushtra/config.pl"
+module="$repo_root/nix/home-manager/mods/zara.nix"
+desktop="$repo_root/nix/home-manager/systems/desktop/home.nix"
+updater="$repo_root/nix/home-manager/files/zarathushtra/bin/zara-system-update"
+
+fail() {
+  printf 'zara-workflows: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f "$config" ]] || fail "missing Home Manager-owned Zara base config"
+[[ -f "$updater" ]] || fail "missing structured Zara system-update helper"
+
+grep -Fq 'prologBaseConfigFile' "$module" || fail "Zara module lacks explicit base Prolog config ownership option"
+grep -Fq 'prologBaseConfigFile = ../../files/zarathushtra/config.pl;' "$desktop" || fail "desktop profile does not select the workflow base config"
+
+grep -Fq 'search_engine("https://search.brave.com/search?q=~w").' "$config" || fail "Brave Search is not configured"
+grep -Fq 'app_mapping(scratch,' "$config" || fail "Emacs scratch workflow missing"
+grep -Fq 'org-roam-dailies-goto-today' "$config" || fail "org-roam daily workflow missing"
+grep -Fq 'zara-dictate' "$config" || fail "org-roam daily does not enter Zara dictation"
+grep -Fq 'app_mapping(thunderbird, ["thunderbird"]).' "$config" || fail "Thunderbird workflow missing"
+grep -Fq 'app_mapping(tor, ["torbrowser-launcher"]).' "$config" || fail "Tor Browser workflow missing"
+grep -Fq 'app_mapping(feishin, ["feishin"]).' "$config" || fail "Feishin workflow missing"
+grep -Fq 'https://music.youtube.com/' "$config" || fail "YouTube Music workflow missing"
+
+for alias in "app_mapping('4chan'," 'app_mapping(fourchan,' 'app_mapping(chan,' 'app_mapping(pol,' 'app_mapping(politically_incorrect,'; do
+  grep -Fq "$alias" "$config" || fail "missing 4chan /pol/ alias: $alias"
+done
+[[ "$(grep -Fc 'https://boards.4chan.org/pol/' "$config")" -ge 5 ]] || fail "4chan variants do not all target /pol/"
+
+grep -Fq 'verb_intent(magit, open, 1).' "$config" || fail "Magit project workflow missing"
+grep -Fq 'app_mapping(dotfiles,' "$config" || fail "dotfiles Magit alias missing"
+grep -Fq 'verb_intent(update, open, 1).' "$config" || fail "update-system phrase mapping missing"
+grep -Fq 'app_mapping(system, ["zara-system-update"]).' "$config" || fail "update-system helper mapping missing"
+
+grep -Fq 'pkexec /usr/bin/pacman -Syu' "$updater" || fail "system update does not cross polkit boundary"
+grep -Fq 'git -C "$DOTFILES" pull --ff-only' "$updater" || fail "system update dotfiles pull is not fast-forward-only"
+grep -Fq 'home-manager switch --flake' "$updater" || fail "system update does not apply Home Manager"
+! grep -Eqi '(sudo -S|NOPASSWD|password=|echo .+\| *sudo)' "$updater" || fail "system update contains forbidden password/sudo bypass"
+
+printf 'zara-workflows: ok\n'

--- a/tests/zara-workflows.sh
+++ b/tests/zara-workflows.sh
@@ -32,10 +32,10 @@ grep -Fq 'app_mapping(tor, ["torbrowser-launcher"]).' "$config" || fail "Tor Bro
 grep -Fq 'app_mapping(feishin, ["feishin"]).' "$config" || fail "Feishin workflow missing"
 grep -Fq 'https://music.youtube.com/' "$config" || fail "YouTube Music workflow missing"
 
-for alias in "app_mapping('4chan'," "app_mapping('4'," 'app_mapping(fourchan,' 'app_mapping(four,' 'app_mapping(chan,' 'app_mapping(pol,' 'app_mapping(politically_incorrect,'; do
+for alias in "app_mapping('4chan'," "app_mapping('4'," 'app_mapping(fourchan,' 'app_mapping(four,' 'app_mapping(chan,' 'app_mapping(pol,' 'app_mapping(politically,' 'app_mapping(politically_incorrect,'; do
   grep -Fq "$alias" "$config" || fail "missing 4chan /pol/ alias: $alias"
 done
-[[ "$(grep -Fc 'https://boards.4chan.org/pol/' "$config")" -ge 7 ]] || fail "4chan variants do not all target /pol/"
+[[ "$(grep -Fc 'https://boards.4chan.org/pol/' "$config")" -ge 8 ]] || fail "4chan variants do not all target /pol/"
 
 grep -Fq 'verb_intent(latest, open, 1).' "$config" || fail "latest-PR compatibility phrase missing"
 grep -Fq 'app_mapping(prs,' "$config" || fail "latest-PR compatibility mapping missing"

--- a/tests/zara-workflows.sh
+++ b/tests/zara-workflows.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 config="$repo_root/nix/home-manager/files/zarathushtra/config.pl"
-module="$repo_root/nix/home-manager/mods/zara.nix"
+workflow_module="$repo_root/nix/home-manager/mods/zara-workflows.nix"
+default_module="$repo_root/nix/home-manager/mods/default.nix"
 desktop="$repo_root/nix/home-manager/systems/desktop/home.nix"
 updater="$repo_root/nix/home-manager/files/zarathushtra/bin/zara-system-update"
 
@@ -13,12 +14,16 @@ fail() {
 }
 
 [[ -f "$config" ]] || fail "missing Home Manager-owned Zara base config"
+[[ -f "$workflow_module" ]] || fail "missing Zara workflow Home Manager module"
 [[ -f "$updater" ]] || fail "missing structured Zara system-update helper"
 
-grep -Fq 'prologBaseConfigFile' "$module" || fail "Zara module lacks explicit base Prolog config ownership option"
-grep -Fq 'prologBaseConfigFile = ../../files/zarathushtra/config.pl;' "$desktop" || fail "desktop profile does not select the workflow base config"
+grep -Fq './zara-workflows.nix' "$default_module" || fail "workflow module is not imported"
+grep -Fq 'workflows.enable = true;' "$desktop" || fail "desktop profile does not enable Zara workflows"
+grep -Fq '".config/zarathushtra/config.pl"' "$workflow_module" || fail "workflow module does not own base config.pl"
+! grep -Fq '".config/zarathushtra/config.local.pl"' "$workflow_module" || fail "Home Manager must not own mutable config.local.pl"
 
 grep -Fq 'search_engine("https://search.brave.com/search?q=~w").' "$config" || fail "Brave Search is not configured"
+grep -Fq 'app_mapping(browser, ["brave"]).' "$config" || fail "normal Brave browser workflow missing"
 grep -Fq 'app_mapping(scratch,' "$config" || fail "Emacs scratch workflow missing"
 grep -Fq 'org-roam-dailies-goto-today' "$config" || fail "org-roam daily workflow missing"
 grep -Fq 'zara-dictate' "$config" || fail "org-roam daily does not enter Zara dictation"
@@ -27,11 +32,13 @@ grep -Fq 'app_mapping(tor, ["torbrowser-launcher"]).' "$config" || fail "Tor Bro
 grep -Fq 'app_mapping(feishin, ["feishin"]).' "$config" || fail "Feishin workflow missing"
 grep -Fq 'https://music.youtube.com/' "$config" || fail "YouTube Music workflow missing"
 
-for alias in "app_mapping('4chan'," 'app_mapping(fourchan,' 'app_mapping(chan,' 'app_mapping(pol,' 'app_mapping(politically_incorrect,'; do
+for alias in "app_mapping('4chan'," "app_mapping('4'," 'app_mapping(fourchan,' 'app_mapping(four,' 'app_mapping(chan,' 'app_mapping(pol,' 'app_mapping(politically_incorrect,'; do
   grep -Fq "$alias" "$config" || fail "missing 4chan /pol/ alias: $alias"
 done
-[[ "$(grep -Fc 'https://boards.4chan.org/pol/' "$config")" -ge 5 ]] || fail "4chan variants do not all target /pol/"
+[[ "$(grep -Fc 'https://boards.4chan.org/pol/' "$config")" -ge 7 ]] || fail "4chan variants do not all target /pol/"
 
+grep -Fq 'verb_intent(latest, open, 1).' "$config" || fail "latest-PR compatibility phrase missing"
+grep -Fq 'app_mapping(prs,' "$config" || fail "latest-PR compatibility mapping missing"
 grep -Fq 'verb_intent(magit, open, 1).' "$config" || fail "Magit project workflow missing"
 grep -Fq 'app_mapping(dotfiles,' "$config" || fail "dotfiles Magit alias missing"
 grep -Fq 'verb_intent(update, open, 1).' "$config" || fail "update-system phrase mapping missing"


### PR DESCRIPTION
TDD-first dotfiles integration for the operator's current Zara desktop/voice workflows.

RED was proven on test-only head `fc603449ed41ab5f3abeb3afa6c90141c3839111`: dedicated run `33948077873`, job `101257665600` failed exactly because the Home Manager-owned Zara base config did not exist.

Implementation now adds:
- a declarative, non-secret `~/.config/zarathushtra/config.pl` base through Home Manager while explicitly leaving `config.local.pl` mutable/private and unmanaged;
- Brave browser/search, Emacs scratch, org-roam daily -> existing `zara-dictate`, Thunderbird, Tor Browser, Feishin, and YouTube Music workflows;
- practical `/pol/` variants for `4chan`, split-ASR `4 chan` / `four chan`, `fourchan`, `chan`, `pol`, and `politically incorrect`;
- current-loader-compatible Magit project aliases;
- a live `latest prs` compatibility bridge via `gh search` rather than fake static text;
- bounded `zara-system-update`: `pkexec pacman -Syu`, dotfiles `pull --ff-only`, then Home Manager, aborting on any failed step;
- dedicated shell/Prolog/workflow contract CI and ownership documentation.

General edit-distance/fuzzy resolution is deliberately not faked with an unbounded dotfiles alias list; that belongs in Zara Core's resolver. No secrets are committed and the todo subsystem is untouched.

Keep draft until the exact current head passes both the dedicated Zara workflow gate and the repository Nix/Home Manager gate.