### PR TITLE
llm-log: enable observe-only quant alerts via Dunst

### DIFF
--- a/nix/home-manager/mods/llm-log-quant-alerts.nix
+++ b/nix/home-manager/mods/llm-log-quant-alerts.nix
@@ -1,0 +1,78 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.llm-log;
+  alertScript = pkgs.writeShellApplication {
+    name = "llm-log-quant-alerts";
+    runtimeInputs = with pkgs; [ coreutils jq libnotify ];
+    text = ''
+      set -euo pipefail
+
+      alerts=${lib.escapeShellArg "${cfg.dataDir}/alerts.jsonl"}
+      declare -A last_seen=()
+
+      tail -n 0 -F "$alerts" 2>/dev/null | while IFS= read -r line; do
+        category=$(jq -er '.category // empty' <<<"$line") || continue
+        case "$category" in
+          low_quantization|possible_quantization_or_model_anomaly) ;;
+          *) continue ;;
+        esac
+
+        model=$(jq -r '.model // "unknown-model"' <<<"$line")
+        provider=$(jq -r '.selected_provider // .provider // "unknown-provider"' <<<"$line")
+        quant=$(jq -r '.quantization // "unknown"' <<<"$line")
+        detectors=$(jq -r '(.detectors // []) | join(",")' <<<"$line")
+        signature="$category|$model|$provider|$quant|$detectors"
+        now=$(date +%s)
+        previous=''${last_seen[$signature]:-0}
+        if (( now - previous < 60 )); then
+          continue
+        fi
+        last_seen[$signature]=$now
+
+        case "$category" in
+          low_quantization)
+            title="llm-log: low quantization detected"
+            ;;
+          *)
+            title="llm-log: possible quant/model anomaly"
+            ;;
+        esac
+
+        body="$model • $provider • quant=$quant"
+        if [[ -n "$detectors" ]]; then
+          body="$body • $detectors"
+        fi
+        notify-send -u critical -a llm-log "$title" "$body"
+      done
+    '';
+  };
+in
+{
+  config = lib.mkIf config.llm.enable {
+    # Observe only. Quantization routing/enforcement is intentionally NOT enabled
+    # in these dotfiles by default; this fragment only turns on anomaly detection.
+    xdg.configFile."llm-log/init.d/20-quant-detection.toml".text = ''
+      [quant_detection]
+      enabled = true
+      low_quantizations = ["fp4", "int4"]
+      alert_unknown_on_anomaly = true
+      repetition_window = 8
+      repetition_repeats = 4
+    '';
+
+    systemd.user.services.llm-log-quant-alerts = {
+      Unit = {
+        Description = "Dunst alerts for llm-log quantization anomalies";
+        After = [ "llm-log.service" "graphical-session.target" ];
+        Wants = [ "llm-log.service" ];
+      };
+      Service = {
+        ExecStart = "${alertScript}/bin/llm-log-quant-alerts";
+        Restart = "always";
+        RestartSec = 2;
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "d329fb1492ba54e217c2dde643afcbc2ad17ce7e";
+  llmLogRevision = "6a78b436346659550178c3a1f39b56e567469eb0";
   llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
   llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
   llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "7b1d4359764fcc87fb967ed6e6577a9eaf6f3045";
+  llmLogRevision = "d329fb1492ba54e217c2dde643afcbc2ad17ce7e";
   llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
   llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
   llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;
@@ -27,6 +27,7 @@ in
   imports = [
     llmLogModule
     ./brave-mcp.nix
+    ./llm-log-quant-alerts.nix
   ];
 
   options = with lib; {


### PR DESCRIPTION
Closes #209 when merged.

Depends on the draft llm-log stack #62 -> #63 -> #64.

## Dotfiles policy

- quantization routing/blocking remains disabled by default;
- observe-only anomaly detection is explicitly enabled through `~/.config/llm-log/init.d/20-quant-detection.toml`;
- low quantizations of interest are currently `fp4` and `int4`;
- unknown quantization only alerts when a behavioral anomaly is also detected;
- Dunst/`notify-send` notifications contain safe metadata only: model, selected provider, quantization, detector IDs;
- identical alerts are locally deduplicated for 60 seconds.

## Wiring

Adds a Home Manager systemd user service that tails llm-log `alerts.jsonl` and only notifies for:

- `low_quantization`
- `possible_quantization_or_model_anomaly`

The branch pins the exact llm-log anomaly-stack revision so it cannot accidentally consume incompatible moving code.

## Validation status

Diff is audited, but Nix evaluation/Home Manager activation has not been run in this environment. Keep draft until the llm-log stack passes local tests and this configuration evaluates on the target machine.