### PR TITLE
nix: install VibeMon hooks via AttemptDB

### DIFF
--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -31,6 +31,7 @@
     ./proxmox-mcp.nix
     ./discord-mcp.nix
     ./unifi-mcp.nix
+    ./vibemon.nix
     ./home-manager-updater.nix
     ./skill-sync.nix
     ./nix-gl.nix

--- a/nix/home-manager/mods/vibemon.nix
+++ b/nix/home-manager/mods/vibemon.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.vibemon;
+  attemptdb = pkgs.callPackage ../../packages/attemptdb.nix { };
+in
+{
+  options.vibemon = {
+    enable = lib.mkEnableOption "VibeMon/AttemptDB coding-agent hooks";
+
+    daemon.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Run the AttemptDB user daemon so hook events are imported continuously.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ attemptdb ];
+
+    # AttemptDB's installer structurally merges its hooks with existing agent
+    # configuration and is idempotent. It currently supports Claude Code,
+    # Codex, Cursor, and Gemini CLI; only detected clients are touched.
+    home.activation.vibemonHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if ! ${attemptdb}/bin/attempt status >/dev/null 2>&1; then
+        ${attemptdb}/bin/attempt init \
+          --capture-mode metadata_only \
+          --source vibemon >/dev/null
+      fi
+
+      ${attemptdb}/bin/attempt hook install \
+        --scope user \
+        --remove-legacy vibemon \
+        --no-verify
+    '';
+
+    systemd.user.services.attemptdb = lib.mkIf cfg.daemon.enable {
+      Unit = {
+        Description = "AttemptDB capture daemon";
+        After = [ "default.target" ];
+      };
+
+      Service = {
+        ExecStart = "${attemptdb}/bin/attempt daemon run";
+        Restart = "on-failure";
+        RestartSec = 2;
+      };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -62,6 +62,10 @@
     enable = true;
   };
 
+  vibemon = {
+    enable = true;
+  };
+
   emacs = {
     enable = true;
     # I mostly use magit hence configured in the ./nixos/mods/emacs.nix module
@@ -95,9 +99,8 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage.
-  # See the Home Manager release notes for a list of state version
-  # changes.
+  # You can update this value in your configuration without breakage
+  # incompatibilities.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -99,8 +99,9 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage
-  # incompatibilities.
+  # You can update this value in your configuration without breakage.
+  # See the Home Manager release notes for a list of state version
+  # changes.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/packages/attemptdb.nix
+++ b/nix/packages/attemptdb.nix
@@ -1,0 +1,66 @@
+{
+  fetchurl,
+  gzip,
+  gnutar,
+  lib,
+  stdenvNoCC,
+}:
+
+let
+  version = "0.2.9";
+  assets = {
+    "x86_64-linux" = {
+      target = "x86_64-unknown-linux-musl";
+      hash = "sha256-tGOCPVXtFVtDcVEnBXl8opsXqlOyauB2xgzHqUB/xbU=";
+    };
+    "aarch64-linux" = {
+      target = "aarch64-unknown-linux-musl";
+      hash = "sha256-BaK6cge5mcITooAeOloiTBRbDVnkj7S0DkW8x64WfUo=";
+    };
+    "x86_64-darwin" = {
+      target = "x86_64-apple-darwin";
+      hash = "sha256-Jec6W+9OjM91hw7JNpmV6gFRkL7z38zAeqTDrJjUhdw=";
+    };
+    "aarch64-darwin" = {
+      target = "aarch64-apple-darwin";
+      hash = "sha256-vUAsoMTbVZ6t0Netx+NLoKtUwQMNdlnXZWJAvYHpdik=";
+    };
+  };
+  system = stdenvNoCC.hostPlatform.system;
+  asset = assets.${system} or (throw "attemptdb: unsupported system ${system}");
+  stem = "attempt-${version}-${asset.target}";
+in
+stdenvNoCC.mkDerivation {
+  pname = "attemptdb";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/nullarch/attemptdb/releases/download/v${version}/${stem}.tar.gz";
+    inherit (asset) hash;
+  };
+
+  dontUnpack = true;
+  nativeBuildInputs = [
+    gzip
+    gnutar
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    tar -xzf "$src"
+    mkdir -p "$out/bin"
+    install -m755 "${stem}/attempt" "$out/bin/attempt"
+    install -m755 "${stem}/attempt-hook" "$out/bin/attempt-hook"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Local-first coding-agent activity database used by VibeMon";
+    homepage = "https://github.com/nullarch/attemptdb";
+    license = lib.licenses.asl20;
+    mainProgram = "attempt";
+    platforms = builtins.attrNames assets;
+  };
+}


### PR DESCRIPTION
## What

- package AttemptDB 0.2.9 from pinned upstream release artifacts
- add a small Home Manager `vibemon` module
- initialize metadata-only local capture on first activation
- install/refresh VibeMon/AttemptDB hooks for every *detected native-supported* client (Claude Code, Codex, Cursor, Gemini CLI)
- run the AttemptDB capture daemon as a Home Manager-owned user service
- enable it on the desktop profile

## Scope

This is intentionally a fun, disposable integration. It does not make VibeMon part of StarIntel observability.

OpenCode and gptel/Emacs are **not falsely reported as another agent**. AttemptDB 0.2.9 has no normalizer for them yet, so they need real adapters before they are wired in.

## Privacy

First-time initialization uses `metadata_only`, matching VibeMon's migration default. No VibeMon sync key is stored in Nix or Git.
