### PR TITLE
Expose authenticated Zara listener for Android

### DIFF
--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -42,6 +42,13 @@
     };
   };
 
+  # Android/remote Zara clients use authenticated ZARA/1 over CURVE/ZAP.
+  # Keep key material in mutable owner-private state, never in the Nix store.
+  systemd.user.services.zara-server.Service = {
+    ExecStartPre = "${config.zara.package}/bin/zara-server --security-dir %h/.local/state/zarathushtra/security --security-init";
+    ExecStart = lib.mkForce "${config.zara.package}/bin/zara-server --shutdown-timeout ${toString config.zara.server.shutdownTimeout} --endpoint tcp://0.0.0.0:7731 --security-dir %h/.local/state/zarathushtra/security";
+  };
+
   screenCapture = {
     enable = true;
   };
@@ -99,9 +106,8 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage.
-  # See the Home Manager release notes for a list of state version
-  # changes.
+  # You can update this value in your configuration without breakage
+  # implications and the Home Manager release notes should be read first.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -106,8 +106,9 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage
-  # implications and the Home Manager release notes should be read first.
+  # You can update this value in your configuration without breakage.
+  # See the Home Manager release notes for a list of state version
+  # changes.
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/nix/nixos/systems/flake/networking.nix
+++ b/nix/nixos/systems/flake/networking.nix
@@ -6,6 +6,7 @@
   networking.firewall.enable = false;
   networking.firewall.allowedTCPPorts = [
     22 #ssh
+    7731 # Zara authenticated ZARA/1 listener
     8384 #syncthing
     22000 # syncthing
     5900 # spice


### PR DESCRIPTION
Configures the desktop Zara user service to bind authenticated ZARA/1 on `tcp://0.0.0.0:7731`, initializes owner-private CURVE state under `%h/.local/state/zarathushtra/security`, and records TCP port 7731 in the NixOS firewall allowlist. Zara still requires CURVE/ZAP authentication; this does not expose an unauthenticated listener.