### PR TITLE
Fix Zara listener for Arch desktop

### DIFF
--- a/.github/workflows/zara-workflows.yml
+++ b/.github/workflows/zara-workflows.yml
@@ -10,6 +10,7 @@ on:
       - 'nix/home-manager/mods/zara-workflows.nix'
       - 'nix/home-manager/systems/desktop/home.nix'
       - 'nix/home-manager/files/zarathushtra/**'
+      - 'nix/nixos/systems/flake/networking.nix'
       - 'docs/wiki/zara.org'
       - 'docs/wiki/index.org'
   push:
@@ -23,6 +24,7 @@ on:
       - 'nix/home-manager/mods/zara-workflows.nix'
       - 'nix/home-manager/systems/desktop/home.nix'
       - 'nix/home-manager/files/zarathushtra/**'
+      - 'nix/nixos/systems/flake/networking.nix'
       - 'docs/wiki/zara.org'
       - 'docs/wiki/index.org'
 

--- a/docs/wiki/zara.org
+++ b/docs/wiki/zara.org
@@ -19,6 +19,33 @@ helper without taking ownership of Zara's mutable private overlay.
 This split is deliberate: reproducible workflows belong in dotfiles; mutable
 private state does not.
 
+* Arch desktop remote listener
+The current desktop host is Arch Linux.  Zara's remote listener is therefore
+owned by the Home Manager user service, not by NixOS networking configuration.
+The desktop profile starts =zara-server= on =tcp://0.0.0.0:7731= with explicit
+persistent CURVE/ZAP security state under
+=~/.local/state/zarathushtra/security=.  The listener remains authenticated;
+there is no unauthenticated TCP fallback.
+
+Apply the desktop user-service configuration with:
+
+#+begin_src shell
+home-manager switch --flake ~/.dotfiles
+systemctl --user restart zara-server
+#+end_src
+
+Verify the local listener with:
+
+#+begin_src shell
+systemctl --user status zara-server --no-pager
+ss -ltnp | grep ':7731'
+journalctl --user -u zara-server -n 100 --no-pager
+#+end_src
+
+Firewall policy is host-local on Arch.  Do not model port 7731 in
+=nix/nixos/systems/flake/networking.nix=.  If an Arch firewall is enabled, its
+local policy must permit TCP 7731 from the intended LAN/VPN scope.
+
 * Operator workflows
 The canonical fact definitions live in
 [[file:../../nix/home-manager/files/zarathushtra/config.pl][config.pl]].  They cover

--- a/nix/nixos/systems/flake/networking.nix
+++ b/nix/nixos/systems/flake/networking.nix
@@ -6,7 +6,6 @@
   networking.firewall.enable = false;
   networking.firewall.allowedTCPPorts = [
     22 #ssh
-    7731 # Zara authenticated ZARA/1 listener
     8384 #syncthing
     22000 # syncthing
     5900 # spice

--- a/tests/zara-workflows.sh
+++ b/tests/zara-workflows.sh
@@ -6,6 +6,7 @@ config="$repo_root/nix/home-manager/files/zarathushtra/config.pl"
 workflow_module="$repo_root/nix/home-manager/mods/zara-workflows.nix"
 default_module="$repo_root/nix/home-manager/mods/default.nix"
 desktop="$repo_root/nix/home-manager/systems/desktop/home.nix"
+nixos_networking="$repo_root/nix/nixos/systems/flake/networking.nix"
 updater="$repo_root/nix/home-manager/files/zarathushtra/bin/zara-system-update"
 
 fail() {
@@ -21,6 +22,11 @@ grep -Fq './zara-workflows.nix' "$default_module" || fail "workflow module is no
 grep -Fq 'workflows.enable = true;' "$desktop" || fail "desktop profile does not enable Zara workflows"
 grep -Fq '".config/zarathushtra/config.pl"' "$workflow_module" || fail "workflow module does not own base config.pl"
 ! grep -Fq '".config/zarathushtra/config.local.pl"' "$workflow_module" || fail "Home Manager must not own mutable config.local.pl"
+
+grep -Fq -- '--endpoint tcp://0.0.0.0:7731' "$desktop" || fail "Arch desktop Zara listener is not exposed on TCP 7731"
+grep -Fq -- '--security-dir %h/.local/state/zarathushtra/security' "$desktop" || fail "Arch desktop Zara listener has no persistent security state"
+grep -Fq -- '--security-init' "$desktop" || fail "Arch desktop Zara security state is not initialized"
+! grep -Fq '7731 # Zara authenticated ZARA/1 listener' "$nixos_networking" || fail "Arch Zara listener must not be modeled as NixOS firewall state"
 
 grep -Fq 'search_engine("https://search.brave.com/search?q=~w").' "$config" || fail "Brave Search is not configured"
 grep -Fq 'app_mapping(browser, ["brave"]).' "$config" || fail "normal Brave browser workflow missing"


### PR DESCRIPTION
Corrects the previous Zara listener change for the current Arch + Home Manager desktop setup. Removes the stale NixOS firewall rule, documents that the authenticated TCP listener is owned by the Home Manager user service on Arch, and adds regression coverage so port 7731 stays on the Arch/Home Manager path rather than NixOS networking.