### PR TITLE
feat: restore prompt-lib UI and add Super-e y p

### DIFF
--- a/.config/qtile/qtile-capture.org
+++ b/.config/qtile/qtile-capture.org
@@ -1,20 +1,25 @@
-#+title: Qtile Screen Capture Integration
+#+title: Qtile Screen Capture and Auxiliary Bindings
 #+property: header-args:python :tangle qtile_capture.py :mkdirp yes :results none
 
 * Purpose
-This file is the canonical source for Qtile's screenshot and recording
-keybindings. Qtile only chooses the user action; the =screen-capture= CLI owns
-backend selection, clipboard behavior, recorder state, and finalization.
+This file is the canonical source for Qtile's stable auxiliary keybinding
+installer. The screenshot and recording bindings remain here, and the installer
+also invokes narrowly scoped extension modules before telemetry instruments the
+final keymap.
 
-The bindings preserve the existing screenshot muscle memory and add recording
-without a heavyweight desktop UI:
+Qtile only chooses the capture user action; the =screen-capture= CLI owns backend
+selection, clipboard behavior, recorder state, and finalization. Prompt-library
+behavior stays in =qtile_prompt_lib.py= and Emacs; this file only calls its
+idempotent keymap installer.
 
-| Binding         | Action                         |
-|-----------------+--------------------------------|
-| =Print=         | Full screenshot                |
-| =Super+Print=   | Select screenshot region       |
-| =Shift+Print=   | Open the Emacs recording UI    |
-| =Super+Shift+Print= | Stop/finalize recording   |
+| Binding             | Action                         |
+|---------------------+--------------------------------|
+| =Print=             | Full screenshot                |
+| =Super+Print=       | Select screenshot region       |
+| =Shift+Print=       | Open the Emacs recording UI    |
+| =Super+Shift+Print= | Stop/finalize recording        |
+| =Super e y y=       | Existing GPTel chat            |
+| =Super e y p=       | Emacs prompt-library browser   |
 
 * Bindings
 #+begin_src python
@@ -23,7 +28,7 @@ from libqtile.lazy import lazy
 
 
 def install_capture_bindings(config_globals):
-    """Install the stable screen-capture bindings once per Qtile config load."""
+    """Install stable auxiliary Qtile bindings once per config load."""
     keys = config_globals.get("keys")
     if keys is None:
         return
@@ -65,4 +70,10 @@ def install_capture_bindings(config_globals):
         if signature not in existing:
             keys.append(binding)
             existing.add(signature)
+
+    # Auxiliary bindings are installed here because this function is already
+    # the single pre-telemetry keymap extension seam called by config.py.
+    from qtile_prompt_lib import install_prompt_lib_bindings
+
+    install_prompt_lib_bindings(config_globals)
 #+end_src

--- a/.config/qtile/qtile-prompt-lib.org
+++ b/.config/qtile/qtile-prompt-lib.org
@@ -1,0 +1,116 @@
+#+title: Qtile Prompt Library Integration
+#+property: header-args:python :tangle qtile_prompt_lib.py :mkdirp yes :results none
+
+* Purpose
+Qtile owns only the keyboard route into the existing Emacs prompt-library UI.
+Prompt discovery, rendering, copying, editing, and sending remain Emacs/prompt-lib
+responsibilities.
+
+The existing =Super e= Emacs chord keeps its meaning. Its former direct =y=
+GPTel action becomes an AI sub-chord:
+
+| Binding       | Action                       |
+|---------------+------------------------------|
+| =Super e y y= | Existing GPTel chat          |
+| =Super e y p= | Emacs prompt-library browser |
+
+The installer mutates the already-declared Emacs chord once, before keymap
+telemetry instrumentation. Re-running it is idempotent.
+
+* Binding installer
+#+begin_src python
+from libqtile.config import Key, KeyChord
+from libqtile.lazy import lazy
+
+
+PROMPT_LIB_COMMAND = (
+    "emacsclient -c -a 'emacs' --eval "
+    '"(progn (require \'prompt-lib) (ai/prompt-lib-browse))"'
+)
+GPTEL_COMMAND = "emacsclient -c -a 'emacs' --eval '(+gptel/here)'"
+
+
+def _is_binding(mapping, modifiers, key):
+    return (
+        tuple(getattr(mapping, "modifiers", ())) == tuple(modifiers)
+        and getattr(mapping, "key", None) == key
+    )
+
+
+def install_prompt_lib_bindings(config_globals):
+    """Install `Super e y p` without stealing the existing GPTel shortcut.
+
+    The existing `Super e` Emacs KeyChord remains authoritative. Its former
+    direct `y` GPTel action becomes an `AI` sub-chord:
+
+      Super e y y -> GPTel
+      Super e y p -> prompt-lib browser
+
+    Repeated installation is idempotent.
+    """
+    keys = config_globals.get("keys")
+    if keys is None:
+        return False
+
+    mod = config_globals.get("mod", "mod4")
+    emacs_chord = next(
+        (
+            mapping
+            for mapping in keys
+            if isinstance(mapping, KeyChord) and _is_binding(mapping, [mod], "e")
+        ),
+        None,
+    )
+    if emacs_chord is None:
+        return False
+
+    submappings = list(getattr(emacs_chord, "submappings", ()))
+    y_index = next(
+        (index for index, mapping in enumerate(submappings) if _is_binding(mapping, [], "y")),
+        None,
+    )
+
+    if y_index is not None and isinstance(submappings[y_index], KeyChord):
+        ai_chord = submappings[y_index]
+        existing = {
+            (tuple(getattr(item, "modifiers", ())), getattr(item, "key", None))
+            for item in getattr(ai_chord, "submappings", ())
+        }
+        if ((), "p") not in existing:
+            ai_chord.submappings.append(
+                Key(
+                    [],
+                    "p",
+                    lazy.spawn(PROMPT_LIB_COMMAND),
+                    desc="Emacs prompt library",
+                )
+            )
+        return True
+
+    ai_chord = KeyChord(
+        [],
+        "y",
+        [
+            Key(
+                [],
+                "y",
+                lazy.spawn(GPTEL_COMMAND),
+                desc="Emacs AI chat (GPTel)",
+            ),
+            Key(
+                [],
+                "p",
+                lazy.spawn(PROMPT_LIB_COMMAND),
+                desc="Emacs prompt library",
+            ),
+        ],
+        name="AI",
+    )
+
+    if y_index is None:
+        submappings.append(ai_chord)
+    else:
+        submappings[y_index] = ai_chord
+    emacs_chord.submappings = submappings
+    return True
+#+end_src

--- a/.config/qtile/qtile-prompt-lib.org
+++ b/.config/qtile/qtile-prompt-lib.org
@@ -7,11 +7,12 @@ Prompt discovery, rendering, copying, editing, and sending remain Emacs/prompt-l
 responsibilities.
 
 The existing =Super e= Emacs chord keeps its meaning. Its former direct =y=
-GPTel action becomes an AI sub-chord:
+action becomes an AI sub-chord while preserving the exact existing key object
+and its commands:
 
 | Binding       | Action                       |
 |---------------+------------------------------|
-| =Super e y y= | Existing GPTel chat          |
+| =Super e y y= | Existing AI/GPTel action     |
 | =Super e y p= | Emacs prompt-library browser |
 
 The installer mutates the already-declared Emacs chord once, before keymap
@@ -27,7 +28,6 @@ PROMPT_LIB_COMMAND = (
     "emacsclient -c -a 'emacs' --eval "
     '"(progn (require \'prompt-lib) (ai/prompt-lib-browse))"'
 )
-GPTEL_COMMAND = "emacsclient -c -a 'emacs' --eval '(+gptel/here)'"
 
 
 def _is_binding(mapping, modifiers, key):
@@ -41,9 +41,10 @@ def install_prompt_lib_bindings(config_globals):
     """Install `Super e y p` without stealing the existing GPTel shortcut.
 
     The existing `Super e` Emacs KeyChord remains authoritative. Its former
-    direct `y` GPTel action becomes an `AI` sub-chord:
+    direct `y` action is preserved as the nested `y` action rather than being
+    reconstructed here:
 
-      Super e y y -> GPTel
+      Super e y y -> existing AI/GPTel action
       Super e y p -> prompt-lib browser
 
     Repeated installation is idempotent.
@@ -87,26 +88,21 @@ def install_prompt_lib_bindings(config_globals):
             )
         return True
 
-    ai_chord = KeyChord(
+    prompt_binding = Key(
         [],
-        "y",
-        [
-            Key(
-                [],
-                "y",
-                lazy.spawn(GPTEL_COMMAND),
-                desc="Emacs AI chat (GPTel)",
-            ),
-            Key(
-                [],
-                "p",
-                lazy.spawn(PROMPT_LIB_COMMAND),
-                desc="Emacs prompt library",
-            ),
-        ],
-        name="AI",
+        "p",
+        lazy.spawn(PROMPT_LIB_COMMAND),
+        desc="Emacs prompt library",
     )
+    if y_index is None:
+        # No existing AI action was declared. Add only the prompt browser; do
+        # not invent a replacement chat command.
+        ai_submappings = [prompt_binding]
+    else:
+        # Keep the exact existing `Super e y` Key object and its commands.
+        ai_submappings = [submappings[y_index], prompt_binding]
 
+    ai_chord = KeyChord([], "y", ai_submappings, name="AI")
     if y_index is None:
         submappings.append(ai_chord)
     else:

--- a/.config/qtile/qtile_capture.py
+++ b/.config/qtile/qtile_capture.py
@@ -3,7 +3,7 @@ from libqtile.lazy import lazy
 
 
 def install_capture_bindings(config_globals):
-    """Install the stable screen-capture bindings once per Qtile config load."""
+    """Install stable auxiliary Qtile bindings once per config load."""
     keys = config_globals.get("keys")
     if keys is None:
         return
@@ -45,3 +45,9 @@ def install_capture_bindings(config_globals):
         if signature not in existing:
             keys.append(binding)
             existing.add(signature)
+
+    # Auxiliary bindings are installed here because this function is already
+    # the single pre-telemetry keymap extension seam called by config.py.
+    from qtile_prompt_lib import install_prompt_lib_bindings
+
+    install_prompt_lib_bindings(config_globals)

--- a/.config/qtile/qtile_prompt_lib.py
+++ b/.config/qtile/qtile_prompt_lib.py
@@ -1,0 +1,94 @@
+from libqtile.config import Key, KeyChord
+from libqtile.lazy import lazy
+
+
+PROMPT_LIB_COMMAND = (
+    "emacsclient -c -a 'emacs' --eval "
+    '"(progn (require \'prompt-lib) (ai/prompt-lib-browse))"'
+)
+GPTEL_COMMAND = "emacsclient -c -a 'emacs' --eval '(+gptel/here)'"
+
+
+def _is_binding(mapping, modifiers, key):
+    return (
+        tuple(getattr(mapping, "modifiers", ())) == tuple(modifiers)
+        and getattr(mapping, "key", None) == key
+    )
+
+
+def install_prompt_lib_bindings(config_globals):
+    """Install `Super e y p` without stealing the existing GPTel shortcut.
+
+    The existing `Super e` Emacs KeyChord remains authoritative. Its former
+    direct `y` GPTel action becomes an `AI` sub-chord:
+
+      Super e y y -> GPTel
+      Super e y p -> prompt-lib browser
+
+    Repeated installation is idempotent.
+    """
+    keys = config_globals.get("keys")
+    if keys is None:
+        return False
+
+    mod = config_globals.get("mod", "mod4")
+    emacs_chord = next(
+        (
+            mapping
+            for mapping in keys
+            if isinstance(mapping, KeyChord) and _is_binding(mapping, [mod], "e")
+        ),
+        None,
+    )
+    if emacs_chord is None:
+        return False
+
+    submappings = list(getattr(emacs_chord, "submappings", ()))
+    y_index = next(
+        (index for index, mapping in enumerate(submappings) if _is_binding(mapping, [], "y")),
+        None,
+    )
+
+    if y_index is not None and isinstance(submappings[y_index], KeyChord):
+        ai_chord = submappings[y_index]
+        existing = {
+            (tuple(getattr(item, "modifiers", ())), getattr(item, "key", None))
+            for item in getattr(ai_chord, "submappings", ())
+        }
+        if ((), "p") not in existing:
+            ai_chord.submappings.append(
+                Key(
+                    [],
+                    "p",
+                    lazy.spawn(PROMPT_LIB_COMMAND),
+                    desc="Emacs prompt library",
+                )
+            )
+        return True
+
+    ai_chord = KeyChord(
+        [],
+        "y",
+        [
+            Key(
+                [],
+                "y",
+                lazy.spawn(GPTEL_COMMAND),
+                desc="Emacs AI chat (GPTel)",
+            ),
+            Key(
+                [],
+                "p",
+                lazy.spawn(PROMPT_LIB_COMMAND),
+                desc="Emacs prompt library",
+            ),
+        ],
+        name="AI",
+    )
+
+    if y_index is None:
+        submappings.append(ai_chord)
+    else:
+        submappings[y_index] = ai_chord
+    emacs_chord.submappings = submappings
+    return True

--- a/.config/qtile/qtile_prompt_lib.py
+++ b/.config/qtile/qtile_prompt_lib.py
@@ -6,7 +6,6 @@ PROMPT_LIB_COMMAND = (
     "emacsclient -c -a 'emacs' --eval "
     '"(progn (require \'prompt-lib) (ai/prompt-lib-browse))"'
 )
-GPTEL_COMMAND = "emacsclient -c -a 'emacs' --eval '(+gptel/here)'"
 
 
 def _is_binding(mapping, modifiers, key):
@@ -20,9 +19,10 @@ def install_prompt_lib_bindings(config_globals):
     """Install `Super e y p` without stealing the existing GPTel shortcut.
 
     The existing `Super e` Emacs KeyChord remains authoritative. Its former
-    direct `y` GPTel action becomes an `AI` sub-chord:
+    direct `y` action is preserved as the nested `y` action rather than being
+    reconstructed here:
 
-      Super e y y -> GPTel
+      Super e y y -> existing AI/GPTel action
       Super e y p -> prompt-lib browser
 
     Repeated installation is idempotent.
@@ -66,26 +66,21 @@ def install_prompt_lib_bindings(config_globals):
             )
         return True
 
-    ai_chord = KeyChord(
+    prompt_binding = Key(
         [],
-        "y",
-        [
-            Key(
-                [],
-                "y",
-                lazy.spawn(GPTEL_COMMAND),
-                desc="Emacs AI chat (GPTel)",
-            ),
-            Key(
-                [],
-                "p",
-                lazy.spawn(PROMPT_LIB_COMMAND),
-                desc="Emacs prompt library",
-            ),
-        ],
-        name="AI",
+        "p",
+        lazy.spawn(PROMPT_LIB_COMMAND),
+        desc="Emacs prompt library",
     )
+    if y_index is None:
+        # No existing AI action was declared. Add only the prompt browser; do
+        # not invent a replacement chat command.
+        ai_submappings = [prompt_binding]
+    else:
+        # Keep the exact existing `Super e y` Key object and its commands.
+        ai_submappings = [submappings[y_index], prompt_binding]
 
+    ai_chord = KeyChord([], "y", ai_submappings, name="AI")
     if y_index is None:
         submappings.append(ai_chord)
     else:

--- a/.config/qtile/tests/test_prompt_lib_binding.py
+++ b/.config/qtile/tests/test_prompt_lib_binding.py
@@ -2,6 +2,7 @@
 """Source-level contracts for Qtile -> Emacs prompt-lib integration."""
 
 from pathlib import Path
+import py_compile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -22,6 +23,9 @@ def single_python_block(path: Path) -> str:
 
 
 class PromptLibBindingTests(unittest.TestCase):
+    def test_prompt_binding_helper_compiles(self):
+        py_compile.compile(str(PROMPT_PY), doraise=True)
+
     def test_prompt_binding_literate_source_matches_runtime(self):
         self.assertEqual(
             single_python_block(PROMPT_ORG),

--- a/.config/qtile/tests/test_prompt_lib_binding.py
+++ b/.config/qtile/tests/test_prompt_lib_binding.py
@@ -11,6 +11,7 @@ PROMPT_ORG = QTILE / "qtile-prompt-lib.org"
 PROMPT_PY = QTILE / "qtile_prompt_lib.py"
 CAPTURE_ORG = QTILE / "qtile-capture.org"
 CAPTURE_PY = QTILE / "qtile_capture.py"
+QTILE_CONFIG = QTILE / "config.py"
 EMACS_CLIENT = ROOT / "lisp" / "llm" / "prompt-lib.el"
 AI_INIT = ROOT / "lisp" / "llm" / "ai-init.el"
 
@@ -38,13 +39,14 @@ class PromptLibBindingTests(unittest.TestCase):
             CAPTURE_PY.read_text(encoding="utf-8"),
         )
 
-    def test_super_e_y_p_opens_prompt_library_and_preserves_gptel(self):
+    def test_super_e_y_p_opens_prompt_library_and_preserves_existing_y_action(self):
         source = PROMPT_PY.read_text(encoding="utf-8")
+        base_config = QTILE_CONFIG.read_text(encoding="utf-8")
         self.assertIn('KeyChord(', source)
         self.assertIn('"p"', source)
         self.assertIn("ai/prompt-lib-browse", source)
-        self.assertIn('"y"', source)
-        self.assertIn("+gptel/here", source)
+        self.assertIn('ai_submappings = [submappings[y_index], prompt_binding]', source)
+        self.assertIn("+gptel/here", base_config)
         self.assertIn("Super e y p", source)
         self.assertIn("Super e y y", source)
 

--- a/.config/qtile/tests/test_prompt_lib_binding.py
+++ b/.config/qtile/tests/test_prompt_lib_binding.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Source-level contracts for Qtile -> Emacs prompt-lib integration."""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[3]
+QTILE = ROOT / ".config" / "qtile"
+PROMPT_ORG = QTILE / "qtile-prompt-lib.org"
+PROMPT_PY = QTILE / "qtile_prompt_lib.py"
+CAPTURE_ORG = QTILE / "qtile-capture.org"
+CAPTURE_PY = QTILE / "qtile_capture.py"
+EMACS_CLIENT = ROOT / "lisp" / "llm" / "prompt-lib.el"
+AI_INIT = ROOT / "lisp" / "llm" / "ai-init.el"
+
+
+def single_python_block(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = lines.index("#+begin_src python") + 1
+    end = lines.index("#+end_src", start)
+    return "\n".join(lines[start:end]) + "\n"
+
+
+class PromptLibBindingTests(unittest.TestCase):
+    def test_prompt_binding_literate_source_matches_runtime(self):
+        self.assertEqual(
+            single_python_block(PROMPT_ORG),
+            PROMPT_PY.read_text(encoding="utf-8"),
+        )
+
+    def test_capture_extension_source_matches_runtime(self):
+        self.assertEqual(
+            single_python_block(CAPTURE_ORG),
+            CAPTURE_PY.read_text(encoding="utf-8"),
+        )
+
+    def test_super_e_y_p_opens_prompt_library_and_preserves_gptel(self):
+        source = PROMPT_PY.read_text(encoding="utf-8")
+        self.assertIn('KeyChord(', source)
+        self.assertIn('"p"', source)
+        self.assertIn("ai/prompt-lib-browse", source)
+        self.assertIn('"y"', source)
+        self.assertIn("+gptel/here", source)
+        self.assertIn("Super e y p", source)
+        self.assertIn("Super e y y", source)
+
+    def test_auxiliary_installer_composes_prompt_binding_before_telemetry(self):
+        source = CAPTURE_PY.read_text(encoding="utf-8")
+        self.assertIn("from qtile_prompt_lib import install_prompt_lib_bindings", source)
+        self.assertIn("install_prompt_lib_bindings(config_globals)", source)
+
+    def test_emacs_client_is_loaded_and_exposes_copy_browser(self):
+        client = EMACS_CLIENT.read_text(encoding="utf-8")
+        init = AI_INIT.read_text(encoding="utf-8")
+        self.assertIn("(require 'prompt-lib)", init)
+        self.assertIn("(defun ai/prompt-lib-browse", client)
+        self.assertIn("(defun ai/prompt-lib-copy", client)
+        self.assertIn('(define-key map (kbd "c") #\'ai/prompt-lib-browser-copy)', client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository uses literate Org configuration. Treat the Org files as source c
 - `.config/qtile/qtile-ai-windows.org` is the source of truth for `.config/qtile/qtile_ai_windows.py`.
 - `.config/qtile/qtile-workflows.org` is the source of truth for `.config/qtile/qtile_workflows.py` and `.config/qtile/workflows.json`.
 - `.config/qtile/qtile-capture.org` is the source of truth for `.config/qtile/qtile_capture.py`.
+- `.config/qtile/qtile-prompt-lib.org` is the source of truth for `.config/qtile/qtile_prompt_lib.py`.
 - `.config/qtile/qtile-openrouter.org` is the source of truth for `.config/qtile/qtile_openrouter.py`.
 - `.doom.d/autoload/gpt-todos.org` is the source of truth for `.doom.d/autoload/gpt-todos.el`.
 - `scripts/gpt-todos-sync.org` is the source of truth for `scripts/gpt-todos-sync` and `scripts/install-gpt-todos-cron`.

--- a/docs/wiki/index.org
+++ b/docs/wiki/index.org
@@ -32,7 +32,8 @@ The configuration itself remains the source of truth.  In particular, literate O
 | Qtile | [[file:../../.config/qtile/qtile-ai.org][.config/qtile/qtile-ai.org]] | Main Qtile literate source; tangles to =config.py=. |
 | Qtile workflows | [[file:../../.config/qtile/qtile-workflows.org][.config/qtile/qtile-workflows.org]] | Desktop workflow lifecycle/actions and definitions; tangles to =qtile_workflows.py= and =workflows.json=. |
 | Qtile routing | [[file:../../.config/qtile/qtile-ai-windows.org][.config/qtile/qtile-ai-windows.org]] | Auto-mode window metadata classifiers; tangles to =qtile_ai_windows.py=. |
-| Qtile capture | [[file:../../.config/qtile/qtile-capture.org][.config/qtile/qtile-capture.org]] | Capture keybindings; tangles to =qtile_capture.py=. |
+| Qtile capture | [[file:../../.config/qtile/qtile-capture.org][.config/qtile/qtile-capture.org]] | Capture and auxiliary binding installer; tangles to =qtile_capture.py=. |
+| Qtile prompt library | [[file:../../.config/qtile/qtile-prompt-lib.org][.config/qtile/qtile-prompt-lib.org]] | Preserves the existing Emacs AI binding and adds =Super e y p= for the prompt browser; tangles to =qtile_prompt_lib.py=. |
 | OpenRouter widget | [[file:../../.config/qtile/qtile-openrouter.org][.config/qtile/qtile-openrouter.org]] | Telemetry/widget helper; tangles to =qtile_openrouter.py=. |
 | Nix flake | [[file:../../flake.nix][flake.nix]] | NixOS, Home Manager, installer, and package outputs. |
 | Home Manager | [[file:../../nix/home-manager/][nix/home-manager/]] | Shared modules/files and per-system profiles. |

--- a/lisp/llm/ai-init.el
+++ b/lisp/llm/ai-init.el
@@ -2,6 +2,7 @@
 
 (require 'ai)
 (require 'ai-prompts)
+(require 'prompt-lib)
 (require 'ai-image)
 (require 'meme)
 (require 'ai-agent)

--- a/lisp/llm/prompt-lib-test.el
+++ b/lisp/llm/prompt-lib-test.el
@@ -1,7 +1,6 @@
 ;;; prompt-lib-test.el --- Tests for prompt-lib -*- lexical-binding: t; -*-
 
 (require 'ert)
-(require 'cl-lib)
 (require 'prompt-lib)
 
 (defmacro ai/prompt-lib-test--with-library (&rest body)
@@ -11,7 +10,8 @@
           (ai/prompt-lib-directory (file-name-as-directory root))
           (ai/prompt-template-directory (expand-file-name "prompts/" root))
           (ai/prompt-lib--records-cache nil)
-          (ai/prompt-lib--active-directory nil))
+          (ai/prompt-lib--active-directory nil)
+          (ai/prompt-lib-formats '(org markdown lisp legacy)))
      (unwind-protect
          (progn
            (make-directory ai/prompt-template-directory t)
@@ -21,17 +21,53 @@
 (ert-deftest ai/prompt-lib-parses-org-metadata-and-body ()
   (ai/prompt-lib-test--with-library
     (write-region
-     "#+title: State worker\n#+prompt_id: engineering.state-worker\n#+description: Durable worker\n#+filetags: :engineering:worker:\n#+prompt_aliases: state worker | loop\n\n* Prompt\nMode {{MODE|REVIEW}}\n\n* Notes\nNot prompt text.\n"
-     nil (expand-file-name "prompts/state-worker.org" ai/prompt-lib-directory)
-     nil 'silent)
-    (ai/prompt-lib-activate)
+     "#+title: Hello prompt\n#+prompt_id: test.hello\n#+description: Test prompt\n#+filetags: :test:org:\n#+prompt_aliases: hi | hello\n\n* Prompt\nHello {{NAME}}\n\n* Notes\nNot prompt text.\n"
+     nil (expand-file-name "prompts/hello.org" ai/prompt-lib-directory) nil 'silent)
     (let ((record (car (ai/prompt-lib-records 'refresh))))
-      (should (equal (plist-get record :id) "engineering.state-worker"))
-      (should (equal (plist-get record :tags) '("engineering" "worker")))
-      (should (equal (plist-get record :aliases) '("state worker" "loop")))
-      (should (equal (plist-get record :body) "Mode {{MODE|REVIEW}}")))))
+      (should (equal (plist-get record :id) "test.hello"))
+      (should (equal (plist-get record :title) "Hello prompt"))
+      (should (equal (plist-get record :description) "Test prompt"))
+      (should (equal (plist-get record :tags) '("test" "org")))
+      (should (equal (plist-get record :aliases) '("hi" "hello")))
+      (should (equal (plist-get record :body) "Hello {{NAME}}"))
+      (should (eq (plist-get record :format) 'org)))))
 
-(ert-deftest ai/prompt-lib-external-directory-wins-over-legacy-fallback ()
+(ert-deftest ai/prompt-lib-parses-markdown-adapter ()
+  (ai/prompt-lib-test--with-library
+    (write-region
+     "---\nprompt_id: test.markdown\ntitle: Markdown prompt\ndescription: Markdown adapter\ntags: test, markdown\naliases: md | markdown test\n---\n\n# Prompt\nHello {{NAME}}\n\n# Notes\nNot prompt text.\n"
+     nil (expand-file-name "prompts/markdown.md" ai/prompt-lib-directory) nil 'silent)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "test.markdown"))
+      (should (equal (plist-get record :tags) '("test" "markdown")))
+      (should (equal (plist-get record :aliases) '("md" "markdown test")))
+      (should (equal (plist-get record :body) "Hello {{NAME}}"))
+      (should (eq (plist-get record :format) 'markdown)))))
+
+(ert-deftest ai/prompt-lib-parses-lisp-as-data-without-eval ()
+  (ai/prompt-lib-test--with-library
+    (let ((ai/prompt-lib-test--evaluated nil))
+      (write-region
+       "(:id \"test.lisp\" :title \"Lisp prompt\" :description \"Lisp adapter\" :tags (\"test\" \"lisp\") :aliases (\"el\") :prompt \"Hello {{NAME}}\")\n(setq ai/prompt-lib-test--evaluated t)\n"
+       nil (expand-file-name "prompts/lisp.el" ai/prompt-lib-directory) nil 'silent)
+      (let ((record (car (ai/prompt-lib-records 'refresh))))
+        (should-not ai/prompt-lib-test--evaluated)
+        (should (equal (plist-get record :id) "test.lisp"))
+        (should (equal (plist-get record :tags) '("test" "lisp")))
+        (should (equal (plist-get record :body) "Hello {{NAME}}"))
+        (should (eq (plist-get record :format) 'lisp))))))
+
+(ert-deftest ai/prompt-lib-keeps-legacy-raw-prompt-fallback ()
+  (ai/prompt-lib-test--with-library
+    (write-region "Plain {{PROMPT}}" nil
+                  (expand-file-name "prompts/plain.prompt" ai/prompt-lib-directory)
+                  nil 'silent)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "plain"))
+      (should (equal (plist-get record :body) "Plain {{PROMPT}}"))
+      (should (eq (plist-get record :format) 'legacy)))))
+
+(ert-deftest ai/prompt-lib-activate-selects-external-prompts-directory ()
   (ai/prompt-lib-test--with-library
     (let ((fallback (make-temp-file "prompt-lib-fallback-" t)))
       (unwind-protect
@@ -39,27 +75,41 @@
             (setq ai/prompt-template-directory fallback)
             (ai/prompt-lib-activate)
             (should (equal ai/prompt-lib--active-directory
+                           (expand-file-name "prompts/" ai/prompt-lib-directory)))
+            (should (equal ai/prompt-template-directory
                            (expand-file-name "prompts/" ai/prompt-lib-directory))))
         (delete-directory fallback t)))))
 
-(ert-deftest ai/prompt-lib-copy-updates-kill-ring-and-system-selection ()
-  (let (selection)
-    (cl-letf (((symbol-function 'gui-set-selection)
-               (lambda (type text)
-                 (setq selection (cons type text)))))
-      (ai/prompt-lib--system-copy "hello")
-      (should (equal (current-kill 0) "hello"))
-      (should (equal selection '(CLIPBOARD . "hello"))))))
+(ert-deftest ai/prompt-lib-new-defaults-to-org-mode ()
+  (ai/prompt-lib-test--with-library
+    (let ((ai/prompt-lib-default-format 'org)
+          buffer)
+      (unwind-protect
+          (progn
+            (ai/prompt-lib-activate)
+            (setq buffer (ai/prompt-lib-new "Hello Prompt" 'org))
+            (should (string-suffix-p ".org" buffer-file-name))
+            (should (eq major-mode 'org-mode))
+            (goto-char (point-min))
+            (should (search-forward "#+prompt_id: hello-prompt" nil t))
+            (should (search-forward "* Prompt" nil t)))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
 
-(ert-deftest ai/prompt-lib-template-compatibility-routes-through-records ()
+(ert-deftest ai/prompt-lib-template-compatibility-uses-normalized-record ()
   (ai/prompt-lib-test--with-library
     (write-region
-     "#+title: Render test\n#+prompt_id: test.render\n\n* Prompt\nRepo {{REPO}}\n"
-     nil (expand-file-name "prompts/render.org" ai/prompt-lib-directory)
-     nil 'silent)
+     "#+title: Render test\n#+prompt_id: test.render\n\n* Prompt\nRepo {{REPO}} task {{TASK|test}}\n"
+     nil (expand-file-name "prompts/render.org" ai/prompt-lib-directory) nil 'silent)
     (ai/prompt-lib-activate)
     (should (member "test.render" (ai/prompt-template-names)))
-    (should (equal (ai/prompt-template--read "test.render") "Repo {{REPO}}"))))
+    (should (equal (ai/prompt-template--read "test.render")
+                   "Repo {{REPO}} task {{TASK|test}}"))
+    (should (equal
+             (ai/prompt-template-render-string
+              (ai/prompt-template--read "test.render")
+              '(("REPO" . "lost-rob0t/test")))
+             "Repo lost-rob0t/test task test"))))
 
 (provide 'prompt-lib-test)
 ;;; prompt-lib-test.el ends here

--- a/lisp/llm/prompt-lib-test.el
+++ b/lisp/llm/prompt-lib-test.el
@@ -1,0 +1,65 @@
+;;; prompt-lib-test.el --- Tests for prompt-lib -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'prompt-lib)
+
+(defmacro ai/prompt-lib-test--with-library (&rest body)
+  "Run BODY with an isolated temporary prompt library."
+  (declare (indent 0) (debug t))
+  `(let* ((root (make-temp-file "prompt-lib-test-" t))
+          (ai/prompt-lib-directory (file-name-as-directory root))
+          (ai/prompt-template-directory (expand-file-name "prompts/" root))
+          (ai/prompt-lib--records-cache nil)
+          (ai/prompt-lib--active-directory nil))
+     (unwind-protect
+         (progn
+           (make-directory ai/prompt-template-directory t)
+           ,@body)
+       (delete-directory root t))))
+
+(ert-deftest ai/prompt-lib-parses-org-metadata-and-body ()
+  (ai/prompt-lib-test--with-library
+    (write-region
+     "#+title: State worker\n#+prompt_id: engineering.state-worker\n#+description: Durable worker\n#+filetags: :engineering:worker:\n#+prompt_aliases: state worker | loop\n\n* Prompt\nMode {{MODE|REVIEW}}\n\n* Notes\nNot prompt text.\n"
+     nil (expand-file-name "prompts/state-worker.org" ai/prompt-lib-directory)
+     nil 'silent)
+    (ai/prompt-lib-activate)
+    (let ((record (car (ai/prompt-lib-records 'refresh))))
+      (should (equal (plist-get record :id) "engineering.state-worker"))
+      (should (equal (plist-get record :tags) '("engineering" "worker")))
+      (should (equal (plist-get record :aliases) '("state worker" "loop")))
+      (should (equal (plist-get record :body) "Mode {{MODE|REVIEW}}")))))
+
+(ert-deftest ai/prompt-lib-external-directory-wins-over-legacy-fallback ()
+  (ai/prompt-lib-test--with-library
+    (let ((fallback (make-temp-file "prompt-lib-fallback-" t)))
+      (unwind-protect
+          (progn
+            (setq ai/prompt-template-directory fallback)
+            (ai/prompt-lib-activate)
+            (should (equal ai/prompt-lib--active-directory
+                           (expand-file-name "prompts/" ai/prompt-lib-directory))))
+        (delete-directory fallback t)))))
+
+(ert-deftest ai/prompt-lib-copy-updates-kill-ring-and-system-selection ()
+  (let (selection)
+    (cl-letf (((symbol-function 'gui-set-selection)
+               (lambda (type text)
+                 (setq selection (cons type text)))))
+      (ai/prompt-lib--system-copy "hello")
+      (should (equal (current-kill 0) "hello"))
+      (should (equal selection '(CLIPBOARD . "hello"))))))
+
+(ert-deftest ai/prompt-lib-template-compatibility-routes-through-records ()
+  (ai/prompt-lib-test--with-library
+    (write-region
+     "#+title: Render test\n#+prompt_id: test.render\n\n* Prompt\nRepo {{REPO}}\n"
+     nil (expand-file-name "prompts/render.org" ai/prompt-lib-directory)
+     nil 'silent)
+    (ai/prompt-lib-activate)
+    (should (member "test.render" (ai/prompt-template-names)))
+    (should (equal (ai/prompt-template--read "test.render") "Repo {{REPO}}"))))
+
+(provide 'prompt-lib-test)
+;;; prompt-lib-test.el ends here

--- a/lisp/llm/prompt-lib.el
+++ b/lisp/llm/prompt-lib.el
@@ -1,0 +1,434 @@
+;;; prompt-lib.el --- Org-first prompt library client -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'subr-x)
+(require 'tabulated-list)
+(require 'transient)
+(require 'ai-prompts)
+
+(defgroup ai/prompt-lib nil
+  "Client for lost-rob0t/prompts-lib."
+  :group 'ai/prompts
+  :prefix "ai/prompt-lib-")
+
+(defcustom ai/prompt-lib-directory
+  (file-name-as-directory
+   (expand-file-name
+    (or (getenv "PROMPTS_LIB_DIR") "~/Documents/Projects/prompts-lib")))
+  "Local checkout of the prompts-lib repository."
+  :type 'directory
+  :group 'ai/prompt-lib)
+
+(defcustom ai/prompt-lib-default-format 'org
+  "Default format for newly created prompts."
+  :type '(choice (const org) (const markdown) (const lisp))
+  :group 'ai/prompt-lib)
+
+(defvar ai/prompt-lib--records-cache nil)
+(defvar ai/prompt-lib--active-directory nil)
+
+(defun ai/prompt-lib--external-directory ()
+  "Return the canonical external prompt directory."
+  (expand-file-name "prompts/" ai/prompt-lib-directory))
+
+(defun ai/prompt-lib--root ()
+  "Return the active prompt directory."
+  (or ai/prompt-lib--active-directory ai/prompt-template-directory))
+
+(defun ai/prompt-lib--format (path)
+  "Return the prompt format represented by PATH."
+  (pcase (downcase (or (file-name-extension path) ""))
+    ("org" 'org)
+    ((or "md" "markdown") 'markdown)
+    ("el" 'lisp)
+    ("prompt" 'legacy)
+    (_ nil)))
+
+(defun ai/prompt-lib--files ()
+  "Return supported prompt files beneath the active root."
+  (let (files)
+    (when (file-directory-p (ai/prompt-lib--root))
+      (dolist (path (directory-files-recursively (ai/prompt-lib--root) "." nil))
+        (when (ai/prompt-lib--format path)
+          (push path files))))
+    (nreverse files)))
+
+(defun ai/prompt-lib--title-from-path (path)
+  "Return a readable title for PATH."
+  (capitalize (replace-regexp-in-string "[-_.]+" " " (file-name-base path))))
+
+(defun ai/prompt-lib--split (value separator)
+  "Split VALUE on SEPARATOR, trimming empty entries."
+  (when value
+    (cl-remove-if #'string-empty-p
+                  (mapcar #'string-trim (split-string value separator)))))
+
+(defun ai/prompt-lib--org-keyword (name)
+  "Read Org keyword NAME from the current buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward
+           (format "^#\\+%s:[ \t]*\\(.*\\)$" (regexp-quote name)) nil t)
+      (string-trim (match-string-no-properties 1)))))
+
+(defun ai/prompt-lib--org-body ()
+  "Return the top-level `Prompt' subtree body from the current buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (unless (re-search-forward "^\\* Prompt[ \t]*$" nil t)
+      (user-error "Prompt file has no top-level * Prompt heading: %s"
+                  (or buffer-file-name (buffer-name))))
+    (forward-line 1)
+    (let ((start (point)))
+      (if (re-search-forward "^\\* [^*]" nil t)
+          (string-trim-right
+           (buffer-substring-no-properties start (match-beginning 0)))
+        (string-trim-right
+         (buffer-substring-no-properties start (point-max)))))))
+
+(defun ai/prompt-lib--parse-org (path)
+  "Parse canonical Org prompt PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (let ((filetags (ai/prompt-lib--org-keyword "filetags")))
+      (list :id (or (ai/prompt-lib--org-keyword "prompt_id")
+                    (file-name-base path))
+            :title (or (ai/prompt-lib--org-keyword "title")
+                       (ai/prompt-lib--title-from-path path))
+            :description (or (ai/prompt-lib--org-keyword "description") "")
+            :tags (ai/prompt-lib--split
+                   (string-trim (or filetags "") ":" ":") ":")
+            :aliases (ai/prompt-lib--split
+                      (ai/prompt-lib--org-keyword "prompt_aliases") "|")
+            :body (ai/prompt-lib--org-body)
+            :path path
+            :format 'org))))
+
+(defun ai/prompt-lib--markdown-metadata ()
+  "Return supported flat Markdown frontmatter as an alist."
+  (save-excursion
+    (goto-char (point-min))
+    (let (result)
+      (when (looking-at-p "---[ \t]*$")
+        (forward-line 1)
+        (while (and (not (eobp)) (not (looking-at-p "---[ \t]*$")))
+          (when (looking-at "\\([^:#\n]+\\):[ \t]*\\(.*\\)$")
+            (push (cons (downcase (string-trim (match-string-no-properties 1)))
+                        (string-trim (match-string-no-properties 2)))
+                  result))
+          (forward-line 1)))
+      result)))
+
+(defun ai/prompt-lib--markdown-body ()
+  "Return body below a Markdown `# Prompt' heading."
+  (save-excursion
+    (goto-char (point-min))
+    (unless (re-search-forward "^# Prompt[ \t]*$" nil t)
+      (user-error "Markdown prompt has no # Prompt heading"))
+    (forward-line 1)
+    (let ((start (point)))
+      (if (re-search-forward "^# [^#]" nil t)
+          (string-trim-right
+           (buffer-substring-no-properties start (match-beginning 0)))
+        (string-trim-right
+         (buffer-substring-no-properties start (point-max)))))))
+
+(defun ai/prompt-lib--parse-markdown (path)
+  "Parse Markdown prompt PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (let* ((metadata (ai/prompt-lib--markdown-metadata))
+           (get (lambda (key) (cdr (assoc key metadata)))))
+      (list :id (or (funcall get "prompt_id") (file-name-base path))
+            :title (or (funcall get "title") (ai/prompt-lib--title-from-path path))
+            :description (or (funcall get "description") "")
+            :tags (ai/prompt-lib--split (funcall get "tags") ",")
+            :aliases (ai/prompt-lib--split (funcall get "aliases") "|")
+            :body (ai/prompt-lib--markdown-body)
+            :path path
+            :format 'markdown))))
+
+(defun ai/prompt-lib--parse-lisp (path)
+  "Parse declarative Lisp prompt PATH without evaluating it."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (goto-char (point-min))
+    (let ((data (read (current-buffer))))
+      (unless (and (listp data) (plist-get data :prompt))
+        (user-error "Lisp prompt must be a plist containing :prompt: %s" path))
+      (list :id (or (plist-get data :id) (file-name-base path))
+            :title (or (plist-get data :title) (ai/prompt-lib--title-from-path path))
+            :description (or (plist-get data :description) "")
+            :tags (mapcar #'format "%s" (plist-get data :tags))
+            :aliases (mapcar #'format "%s" (plist-get data :aliases))
+            :body (format "%s" (plist-get data :prompt))
+            :path path
+            :format 'lisp))))
+
+(defun ai/prompt-lib--parse-legacy (path)
+  "Parse legacy raw prompt PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (list :id (file-name-base path)
+          :title (ai/prompt-lib--title-from-path path)
+          :description "Legacy prompt"
+          :tags '("legacy")
+          :aliases nil
+          :body (buffer-string)
+          :path path
+          :format 'legacy)))
+
+(defun ai/prompt-lib--parse (path)
+  "Parse PATH into a normalized prompt record."
+  (pcase (ai/prompt-lib--format path)
+    ('org (ai/prompt-lib--parse-org path))
+    ('markdown (ai/prompt-lib--parse-markdown path))
+    ('lisp (ai/prompt-lib--parse-lisp path))
+    ('legacy (ai/prompt-lib--parse-legacy path))))
+
+(defun ai/prompt-lib-records (&optional refresh)
+  "Return normalized records; REFRESH invalidates the cache."
+  (when refresh
+    (setq ai/prompt-lib--records-cache nil))
+  (or ai/prompt-lib--records-cache
+      (setq ai/prompt-lib--records-cache
+            (delq nil (mapcar #'ai/prompt-lib--parse (ai/prompt-lib--files))))))
+
+(defun ai/prompt-lib-activate ()
+  "Activate external prompts-lib when present, otherwise use legacy prompts."
+  (interactive)
+  (let ((external (ai/prompt-lib--external-directory)))
+    (setq ai/prompt-lib--active-directory
+          (if (file-directory-p external) external ai/prompt-template-directory))
+    (ai/prompt-lib-records 'refresh)
+    (when (called-interactively-p 'interactive)
+      (message "Prompt library: %s (%d prompts)"
+               ai/prompt-lib--active-directory
+               (length (ai/prompt-lib-records))))))
+
+(defun ai/prompt-lib-refresh ()
+  "Refresh prompt records from disk."
+  (interactive)
+  (ai/prompt-lib-activate))
+
+(defun ai/prompt-lib--by-name (name)
+  "Find prompt NAME by id, title, basename, or alias."
+  (cl-find-if
+   (lambda (record)
+     (or (equal name (plist-get record :id))
+         (equal name (plist-get record :title))
+         (equal name (file-name-base (plist-get record :path)))
+         (member name (plist-get record :aliases))))
+   (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-read-record (&optional label)
+  "Select a prompt record using completion with LABEL."
+  (let* ((records (ai/prompt-lib-records))
+         (candidates
+          (mapcar (lambda (record)
+                    (cons (format "%s  [%s]  %s"
+                                  (plist-get record :title)
+                                  (plist-get record :id)
+                                  (string-join (plist-get record :tags) ","))
+                          record))
+                  records)))
+    (unless candidates
+      (user-error "No prompts found in %s" (ai/prompt-lib--root)))
+    (cdr (assoc (completing-read (or label "Prompt: ") candidates nil t)
+                candidates))))
+
+(defun ai/prompt-lib-template-names ()
+  "Return prompt IDs for ai-prompts compatibility."
+  (mapcar (lambda (record) (plist-get record :id)) (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-template-read (name)
+  "Return prompt body for NAME."
+  (let ((record (ai/prompt-lib--by-name name)))
+    (unless record (user-error "Unknown prompt: %s" name))
+    (plist-get record :body)))
+
+(defun ai/prompt-lib-template-path (name)
+  "Return prompt path for NAME."
+  (let ((record (ai/prompt-lib--by-name name)))
+    (unless record (user-error "Unknown prompt: %s" name))
+    (plist-get record :path)))
+
+(defun ai/prompt-lib-render-record (record)
+  "Render RECORD, prompting for placeholders."
+  (let ((body (plist-get record :body)))
+    (ai/prompt-template-render-string body (ai/prompt-template--ask-values body))))
+
+(defun ai/prompt-lib--system-copy (text)
+  "Put TEXT in the kill ring and GUI/system clipboard when available."
+  (kill-new text)
+  (condition-case nil
+      (when (fboundp 'gui-set-selection)
+        (gui-set-selection 'CLIPBOARD text))
+    (error nil))
+  text)
+
+(defun ai/prompt-lib-copy (&optional record)
+  "Render RECORD and copy it to the system clipboard."
+  (interactive)
+  (let ((rendered (ai/prompt-lib-render-record
+                   (or record (ai/prompt-lib-read-record "Copy prompt: ")))))
+    (ai/prompt-lib--system-copy rendered)
+    (message "Prompt copied (%d chars)" (length rendered))
+    rendered))
+
+(defun ai/prompt-lib-preview (&optional record)
+  "Render RECORD and show a preview buffer."
+  (interactive)
+  (let ((rendered (ai/prompt-lib-render-record
+                   (or record (ai/prompt-lib-read-record "Preview prompt: ")))))
+    (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert rendered)
+        (goto-char (point-min))
+        (text-mode))
+      (pop-to-buffer (current-buffer)))
+    rendered))
+
+(defun ai/prompt-lib-insert (&optional record)
+  "Render RECORD and insert it at point."
+  (interactive)
+  (insert (ai/prompt-lib-render-record
+           (or record (ai/prompt-lib-read-record "Insert prompt: ")))))
+
+(defun ai/prompt-lib-send (&optional record)
+  "Render RECORD and send it through gptel."
+  (interactive)
+  (require 'gptel)
+  (gptel-send
+   (ai/prompt-lib-render-record
+    (or record (ai/prompt-lib-read-record "Send prompt: ")))))
+
+(defun ai/prompt-lib-edit (&optional record)
+  "Open RECORD for editing."
+  (interactive)
+  (find-file (plist-get (or record (ai/prompt-lib-read-record "Edit prompt: "))
+                        :path)))
+
+(defun ai/prompt-lib-open-repository ()
+  "Open the local prompts-lib checkout."
+  (interactive)
+  (unless (file-directory-p ai/prompt-lib-directory)
+    (user-error "prompts-lib checkout missing: %s" ai/prompt-lib-directory))
+  (dired ai/prompt-lib-directory))
+
+(defun ai/prompt-lib--slug (name)
+  "Return a safe slug for NAME."
+  (let ((slug (downcase (string-trim name))))
+    (setq slug (replace-regexp-in-string "[^[:alnum:]._-]+" "-" slug))
+    (replace-regexp-in-string "^-+\\|-+$" "" slug)))
+
+(defun ai/prompt-lib-new (name)
+  "Create a canonical Org prompt called NAME."
+  (interactive "sNew prompt name: ")
+  (let* ((root (ai/prompt-lib--root))
+         (slug (ai/prompt-lib--slug name))
+         (path (expand-file-name (concat slug ".org") root)))
+    (make-directory root t)
+    (when (file-exists-p path)
+      (user-error "Prompt already exists: %s" path))
+    (write-region
+     (format "#+title: %s\n#+prompt_id: %s\n#+description: \n#+filetags: :prompt:\n#+prompt_aliases: \n\n* Prompt\n\n"
+             name slug)
+     nil path nil 'silent)
+    (ai/prompt-lib-records 'refresh)
+    (find-file path)))
+
+(defun ai/prompt-lib--record-at-point ()
+  "Return browser record at point."
+  (or (ai/prompt-lib--by-name (tabulated-list-get-id))
+      (user-error "No prompt on this row")))
+
+(defun ai/prompt-lib-browser-preview ()
+  (interactive)
+  (ai/prompt-lib-preview (ai/prompt-lib--record-at-point)))
+
+(defun ai/prompt-lib-browser-copy ()
+  (interactive)
+  (ai/prompt-lib-copy (ai/prompt-lib--record-at-point)))
+
+(defun ai/prompt-lib-browser-edit ()
+  (interactive)
+  (ai/prompt-lib-edit (ai/prompt-lib--record-at-point)))
+
+(defun ai/prompt-lib-browser-refresh ()
+  (interactive)
+  (ai/prompt-lib-refresh)
+  (ai/prompt-lib--browser-entries)
+  (tabulated-list-print t))
+
+(defun ai/prompt-lib--browser-entries ()
+  "Populate browser rows."
+  (setq tabulated-list-entries
+        (mapcar
+         (lambda (record)
+           (list (plist-get record :id)
+                 (vector (plist-get record :id)
+                         (plist-get record :title)
+                         (string-join (plist-get record :tags) ", ")
+                         (symbol-name (plist-get record :format)))))
+         (ai/prompt-lib-records))))
+
+(defvar ai/prompt-lib-browser-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "RET") #'ai/prompt-lib-browser-preview)
+    (define-key map (kbd "c") #'ai/prompt-lib-browser-copy)
+    (define-key map (kbd "e") #'ai/prompt-lib-browser-edit)
+    (define-key map (kbd "g") #'ai/prompt-lib-browser-refresh)
+    map))
+
+(define-derived-mode ai/prompt-lib-browser-mode tabulated-list-mode "Prompt-Lib"
+  "Browse reusable prompts."
+  (setq tabulated-list-format
+        [("ID" 38 t) ("Title" 34 t) ("Tags" 42 t) ("Format" 10 t)]
+        tabulated-list-padding 2
+        tabulated-list-sort-key (cons "Title" nil))
+  (ai/prompt-lib--browser-entries)
+  (tabulated-list-init-header))
+
+(defun ai/prompt-lib-browse ()
+  "Open the prompt library browser."
+  (interactive)
+  (ai/prompt-lib-refresh)
+  (let ((buffer (get-buffer-create "*Prompt Library*")))
+    (with-current-buffer buffer
+      (ai/prompt-lib-browser-mode)
+      (tabulated-list-print t))
+    (pop-to-buffer buffer)))
+
+(declare-function ai/image-generate "ai-image")
+(declare-function ai/image-generate-template "ai-image")
+(declare-function ai/image-edit "ai-image")
+
+(transient-define-prefix ai/prompt-lib-menu ()
+  "Prompt library and image-generation commands."
+  [["Prompt library"
+    ("b" "Browse" ai/prompt-lib-browse)
+    ("c" "Copy" ai/prompt-lib-copy)
+    ("i" "Insert" ai/prompt-lib-insert)
+    ("s" "Send to gptel" ai/prompt-lib-send)
+    ("p" "Preview" ai/prompt-lib-preview)
+    ("e" "Edit" ai/prompt-lib-edit)
+    ("n" "New Org prompt" ai/prompt-lib-new)
+    ("g" "Refresh" ai/prompt-lib-refresh)
+    ("o" "Open repo" ai/prompt-lib-open-repository)]
+   ["Image tools"
+    ("G" "Generate from prompt" ai/image-generate)
+    ("T" "Generate from template" ai/image-generate-template)
+    ("X" "Edit image" ai/image-edit)]])
+
+(defalias 'ai/prompt-template-names #'ai/prompt-lib-template-names)
+(defalias 'ai/prompt-template--read #'ai/prompt-lib-template-read)
+(defalias 'ai/prompt-template-path #'ai/prompt-lib-template-path)
+(defalias 'ai/prompt-menu #'ai/prompt-lib-menu)
+
+(ai/prompt-lib-activate)
+
+(provide 'prompt-lib)
+;;; prompt-lib.el ends here

--- a/lisp/llm/prompt-lib.el
+++ b/lisp/llm/prompt-lib.el
@@ -1,4 +1,4 @@
-;;; prompt-lib.el --- Org-first prompt library client -*- lexical-binding: t; -*-
+;;; prompt-lib.el --- Org-first versioned prompt library client -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
 (require 'subr-x)
@@ -7,7 +7,7 @@
 (require 'ai-prompts)
 
 (defgroup ai/prompt-lib nil
-  "Client for lost-rob0t/prompts-lib."
+  "Client for the external prompts-lib repository."
   :group 'ai/prompts
   :prefix "ai/prompt-lib-")
 
@@ -20,23 +20,39 @@
   :group 'ai/prompt-lib)
 
 (defcustom ai/prompt-lib-default-format 'org
-  "Default format for newly created prompts."
-  :type '(choice (const org) (const markdown) (const lisp))
+  "Default file format for newly created prompts."
+  :type '(choice (const :tag "Org" org)
+                 (const :tag "Markdown" markdown)
+                 (const :tag "Lisp data" lisp))
+  :group 'ai/prompt-lib)
+
+(defcustom ai/prompt-lib-formats '(org markdown lisp legacy)
+  "Prompt formats discovered by the library client."
+  :type '(set (const org) (const markdown) (const lisp) (const legacy))
   :group 'ai/prompt-lib)
 
 (defvar ai/prompt-lib--records-cache nil)
 (defvar ai/prompt-lib--active-directory nil)
 
-(defun ai/prompt-lib--external-directory ()
-  "Return the canonical external prompt directory."
+(defun ai/prompt-lib--prompts-directory ()
+  "Return the external prompt directory."
   (expand-file-name "prompts/" ai/prompt-lib-directory))
 
-(defun ai/prompt-lib--root ()
+(defun ai/prompt-lib--library-root ()
   "Return the active prompt directory."
   (or ai/prompt-lib--active-directory ai/prompt-template-directory))
 
-(defun ai/prompt-lib--format (path)
-  "Return the prompt format represented by PATH."
+(defun ai/prompt-lib--format-extension (format)
+  "Return filename extension for FORMAT."
+  (pcase format
+    ('org "org")
+    ('markdown "md")
+    ('lisp "el")
+    ('legacy "prompt")
+    (_ (user-error "Unsupported prompt format: %S" format))))
+
+(defun ai/prompt-lib--path-format (path)
+  "Return prompt format for PATH or nil."
   (pcase (downcase (or (file-name-extension path) ""))
     ("org" 'org)
     ((or "md" "markdown") 'markdown)
@@ -44,21 +60,24 @@
     ("prompt" 'legacy)
     (_ nil)))
 
-(defun ai/prompt-lib--files ()
-  "Return supported prompt files beneath the active root."
-  (let (files)
-    (when (file-directory-p (ai/prompt-lib--root))
-      (dolist (path (directory-files-recursively (ai/prompt-lib--root) "." nil))
-        (when (ai/prompt-lib--format path)
-          (push path files))))
+(defun ai/prompt-lib--prompt-files ()
+  "Return prompt files below the active library root."
+  (let ((root (ai/prompt-lib--library-root))
+        files)
+    (when (file-directory-p root)
+      (dolist (path (directory-files-recursively root "." nil))
+        (let ((format (ai/prompt-lib--path-format path)))
+          (when (and format (memq format ai/prompt-lib-formats))
+            (push path files)))))
     (nreverse files)))
 
 (defun ai/prompt-lib--title-from-path (path)
-  "Return a readable title for PATH."
-  (capitalize (replace-regexp-in-string "[-_.]+" " " (file-name-base path))))
+  "Build a readable title from PATH."
+  (capitalize
+   (replace-regexp-in-string "[-_.]+" " " (file-name-base path))))
 
-(defun ai/prompt-lib--split (value separator)
-  "Split VALUE on SEPARATOR, trimming empty entries."
+(defun ai/prompt-lib--split-list (value separator)
+  "Split VALUE by SEPARATOR and trim empty items."
   (when value
     (cl-remove-if #'string-empty-p
                   (mapcar #'string-trim (split-string value separator)))))
@@ -72,11 +91,11 @@
       (string-trim (match-string-no-properties 1)))))
 
 (defun ai/prompt-lib--org-body ()
-  "Return the top-level `Prompt' subtree body from the current buffer."
+  "Return the body of the top-level Org `Prompt' heading."
   (save-excursion
     (goto-char (point-min))
     (unless (re-search-forward "^\\* Prompt[ \t]*$" nil t)
-      (user-error "Prompt file has no top-level * Prompt heading: %s"
+      (user-error "Org prompt has no top-level `* Prompt' heading: %s"
                   (or buffer-file-name (buffer-name))))
     (forward-line 1)
     (let ((start (point)))
@@ -87,44 +106,50 @@
          (buffer-substring-no-properties start (point-max)))))))
 
 (defun ai/prompt-lib--parse-org (path)
-  "Parse canonical Org prompt PATH."
+  "Parse Org prompt PATH into a normalized record."
   (with-temp-buffer
     (insert-file-contents path)
-    (let ((filetags (ai/prompt-lib--org-keyword "filetags")))
-      (list :id (or (ai/prompt-lib--org-keyword "prompt_id")
-                    (file-name-base path))
-            :title (or (ai/prompt-lib--org-keyword "title")
-                       (ai/prompt-lib--title-from-path path))
-            :description (or (ai/prompt-lib--org-keyword "description") "")
-            :tags (ai/prompt-lib--split
+    (let* ((id (or (ai/prompt-lib--org-keyword "prompt_id")
+                   (file-name-base path)))
+           (title (or (ai/prompt-lib--org-keyword "title")
+                      (ai/prompt-lib--title-from-path path)))
+           (description (or (ai/prompt-lib--org-keyword "description") ""))
+           (filetags (ai/prompt-lib--org-keyword "filetags"))
+           (aliases (ai/prompt-lib--org-keyword "prompt_aliases")))
+      (list :id id
+            :title title
+            :description description
+            :tags (ai/prompt-lib--split-list
                    (string-trim (or filetags "") ":" ":") ":")
-            :aliases (ai/prompt-lib--split
-                      (ai/prompt-lib--org-keyword "prompt_aliases") "|")
+            :aliases (ai/prompt-lib--split-list aliases "|")
             :body (ai/prompt-lib--org-body)
             :path path
             :format 'org))))
 
-(defun ai/prompt-lib--markdown-metadata ()
-  "Return supported flat Markdown frontmatter as an alist."
+(defun ai/prompt-lib--markdown-frontmatter ()
+  "Return flat Markdown frontmatter as an alist.
+The supported syntax is deliberately limited to `key: value' lines between
+opening and closing `---' delimiters."
   (save-excursion
     (goto-char (point-min))
-    (let (result)
+    (let (metadata)
       (when (looking-at-p "---[ \t]*$")
         (forward-line 1)
         (while (and (not (eobp)) (not (looking-at-p "---[ \t]*$")))
           (when (looking-at "\\([^:#\n]+\\):[ \t]*\\(.*\\)$")
             (push (cons (downcase (string-trim (match-string-no-properties 1)))
                         (string-trim (match-string-no-properties 2)))
-                  result))
+                  metadata))
           (forward-line 1)))
-      result)))
+      metadata)))
 
 (defun ai/prompt-lib--markdown-body ()
   "Return body below a Markdown `# Prompt' heading."
   (save-excursion
     (goto-char (point-min))
     (unless (re-search-forward "^# Prompt[ \t]*$" nil t)
-      (user-error "Markdown prompt has no # Prompt heading"))
+      (user-error "Markdown prompt has no `# Prompt' heading: %s"
+                  (or buffer-file-name (buffer-name))))
     (forward-line 1)
     (let ((start (point)))
       (if (re-search-forward "^# [^#]" nil t)
@@ -134,16 +159,18 @@
          (buffer-substring-no-properties start (point-max)))))))
 
 (defun ai/prompt-lib--parse-markdown (path)
-  "Parse Markdown prompt PATH."
+  "Parse Markdown prompt PATH into a normalized record."
   (with-temp-buffer
     (insert-file-contents path)
-    (let* ((metadata (ai/prompt-lib--markdown-metadata))
-           (get (lambda (key) (cdr (assoc key metadata)))))
-      (list :id (or (funcall get "prompt_id") (file-name-base path))
-            :title (or (funcall get "title") (ai/prompt-lib--title-from-path path))
+    (let* ((metadata (ai/prompt-lib--markdown-frontmatter))
+           (get (lambda (key) (cdr (assoc key metadata))))
+           (id (or (funcall get "prompt_id") (file-name-base path)))
+           (title (or (funcall get "title") (ai/prompt-lib--title-from-path path))))
+      (list :id id
+            :title title
             :description (or (funcall get "description") "")
-            :tags (ai/prompt-lib--split (funcall get "tags") ",")
-            :aliases (ai/prompt-lib--split (funcall get "aliases") "|")
+            :tags (ai/prompt-lib--split-list (funcall get "tags") ",")
+            :aliases (ai/prompt-lib--split-list (funcall get "aliases") "|")
             :body (ai/prompt-lib--markdown-body)
             :path path
             :format 'markdown))))
@@ -153,53 +180,63 @@
   (with-temp-buffer
     (insert-file-contents path)
     (goto-char (point-min))
-    (let ((data (read (current-buffer))))
+    (let ((data (condition-case error
+                    (read (current-buffer))
+                  (error (user-error "Invalid Lisp prompt %s: %s"
+                                     path (error-message-string error))))))
       (unless (and (listp data) (plist-get data :prompt))
         (user-error "Lisp prompt must be a plist containing :prompt: %s" path))
       (list :id (or (plist-get data :id) (file-name-base path))
             :title (or (plist-get data :title) (ai/prompt-lib--title-from-path path))
             :description (or (plist-get data :description) "")
-            :tags (mapcar #'format "%s" (plist-get data :tags))
-            :aliases (mapcar #'format "%s" (plist-get data :aliases))
+            :tags (mapcar (lambda (tag) (format "%s" tag)) (plist-get data :tags))
+            :aliases (mapcar (lambda (alias) (format "%s" alias))
+                             (plist-get data :aliases))
             :body (format "%s" (plist-get data :prompt))
             :path path
             :format 'lisp))))
 
 (defun ai/prompt-lib--parse-legacy (path)
-  "Parse legacy raw prompt PATH."
+  "Parse legacy raw `.prompt' PATH."
   (with-temp-buffer
     (insert-file-contents path)
     (list :id (file-name-base path)
           :title (ai/prompt-lib--title-from-path path)
-          :description "Legacy prompt"
+          :description "Legacy raw prompt"
           :tags '("legacy")
           :aliases nil
           :body (buffer-string)
           :path path
           :format 'legacy)))
 
-(defun ai/prompt-lib--parse (path)
-  "Parse PATH into a normalized prompt record."
-  (pcase (ai/prompt-lib--format path)
+(defun ai/prompt-lib--parse-file (path)
+  "Parse prompt PATH according to its extension."
+  (pcase (ai/prompt-lib--path-format path)
     ('org (ai/prompt-lib--parse-org path))
     ('markdown (ai/prompt-lib--parse-markdown path))
     ('lisp (ai/prompt-lib--parse-lisp path))
-    ('legacy (ai/prompt-lib--parse-legacy path))))
+    ('legacy (ai/prompt-lib--parse-legacy path))
+    (_ nil)))
 
 (defun ai/prompt-lib-records (&optional refresh)
-  "Return normalized records; REFRESH invalidates the cache."
+  "Return normalized prompt records, optionally forcing REFRESH."
   (when refresh
     (setq ai/prompt-lib--records-cache nil))
   (or ai/prompt-lib--records-cache
       (setq ai/prompt-lib--records-cache
-            (delq nil (mapcar #'ai/prompt-lib--parse (ai/prompt-lib--files))))))
+            (delq nil (mapcar #'ai/prompt-lib--parse-file
+                              (ai/prompt-lib--prompt-files))))))
 
 (defun ai/prompt-lib-activate ()
-  "Activate external prompts-lib when present, otherwise use legacy prompts."
+  "Activate external prompts-lib when its prompt directory is available."
   (interactive)
-  (let ((external (ai/prompt-lib--external-directory)))
+  (let ((external (ai/prompt-lib--prompts-directory)))
     (setq ai/prompt-lib--active-directory
-          (if (file-directory-p external) external ai/prompt-template-directory))
+          (if (file-directory-p external)
+              external
+            ai/prompt-template-directory))
+    (when (file-directory-p external)
+      (setq ai/prompt-template-directory external))
     (ai/prompt-lib-records 'refresh)
     (when (called-interactively-p 'interactive)
       (message "Prompt library: %s (%d prompts)"
@@ -211,84 +248,92 @@
   (interactive)
   (ai/prompt-lib-activate))
 
-(defun ai/prompt-lib--by-name (name)
-  "Find prompt NAME by id, title, basename, or alias."
+(defun ai/prompt-lib--completion-candidates ()
+  "Return completion candidates paired with prompt records."
+  (mapcar
+   (lambda (record)
+     (let* ((aliases (string-join (plist-get record :aliases) ", "))
+            (description (plist-get record :description))
+            (label (format "%s  [%s]  %s%s"
+                           (plist-get record :title)
+                           (plist-get record :id)
+                           (string-join (plist-get record :tags) ",")
+                           (if (string-empty-p aliases) ""
+                             (format "  {%s}" aliases)))))
+       (cons (propertize label 'ai/prompt-description description) record)))
+   (ai/prompt-lib-records)))
+
+(defun ai/prompt-lib-read-record (&optional prompt)
+  "Read and return a prompt record using PROMPT."
+  (let ((candidates (ai/prompt-lib--completion-candidates)))
+    (unless candidates
+      (user-error "No prompts found in %s" (ai/prompt-lib--library-root)))
+    (cdr (assoc (completing-read (or prompt "Prompt: ") candidates nil t)
+                candidates))))
+
+(defun ai/prompt-lib--record-by-name (name)
+  "Find a prompt record by ID, file base name, title, or alias NAME."
   (cl-find-if
    (lambda (record)
      (or (equal name (plist-get record :id))
-         (equal name (plist-get record :title))
          (equal name (file-name-base (plist-get record :path)))
+         (equal name (plist-get record :title))
          (member name (plist-get record :aliases))))
    (ai/prompt-lib-records)))
 
-(defun ai/prompt-lib-read-record (&optional label)
-  "Select a prompt record using completion with LABEL."
-  (let* ((records (ai/prompt-lib-records))
-         (candidates
-          (mapcar (lambda (record)
-                    (cons (format "%s  [%s]  %s"
-                                  (plist-get record :title)
-                                  (plist-get record :id)
-                                  (string-join (plist-get record :tags) ","))
-                          record))
-                  records)))
-    (unless candidates
-      (user-error "No prompts found in %s" (ai/prompt-lib--root)))
-    (cdr (assoc (completing-read (or label "Prompt: ") candidates nil t)
-                candidates))))
-
 (defun ai/prompt-lib-template-names ()
-  "Return prompt IDs for ai-prompts compatibility."
+  "Return prompt IDs for compatibility with `ai-prompts'."
   (mapcar (lambda (record) (plist-get record :id)) (ai/prompt-lib-records)))
 
 (defun ai/prompt-lib-template-read (name)
-  "Return prompt body for NAME."
-  (let ((record (ai/prompt-lib--by-name name)))
-    (unless record (user-error "Unknown prompt: %s" name))
+  "Return raw prompt body for NAME."
+  (let ((record (ai/prompt-lib--record-by-name name)))
+    (unless record
+      (user-error "Unknown prompt: %s" name))
     (plist-get record :body)))
 
 (defun ai/prompt-lib-template-path (name)
   "Return prompt path for NAME."
-  (let ((record (ai/prompt-lib--by-name name)))
-    (unless record (user-error "Unknown prompt: %s" name))
+  (let ((record (ai/prompt-lib--record-by-name name)))
+    (unless record
+      (user-error "Unknown prompt: %s" name))
     (plist-get record :path)))
 
 (defun ai/prompt-lib-render-record (record)
-  "Render RECORD, prompting for placeholders."
-  (let ((body (plist-get record :body)))
-    (ai/prompt-template-render-string body (ai/prompt-template--ask-values body))))
+  "Fill placeholders and return rendered prompt RECORD."
+  (let ((template (plist-get record :body)))
+    (ai/prompt-template-render-string
+     template (ai/prompt-template--ask-values template))))
 
-(defun ai/prompt-lib--system-copy (text)
-  "Put TEXT in the kill ring and GUI/system clipboard when available."
-  (kill-new text)
-  (condition-case nil
-      (when (fboundp 'gui-set-selection)
-        (gui-set-selection 'CLIPBOARD text))
-    (error nil))
-  text)
+(defun ai/prompt-lib--preview-string (rendered format)
+  "Show RENDERED prompt using FORMAT-appropriate major mode."
+  (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (insert rendered)
+      (goto-char (point-min))
+      (pcase format
+        ('org (org-mode))
+        ('markdown (if (fboundp 'markdown-mode) (markdown-mode) (text-mode)))
+        ('lisp (emacs-lisp-mode))
+        (_ (text-mode))))
+    (pop-to-buffer (current-buffer))))
+
+(defun ai/prompt-lib-render (&optional record)
+  "Render RECORD or read one interactively and preview it."
+  (interactive)
+  (let* ((record (or record (ai/prompt-lib-read-record)))
+         (rendered (ai/prompt-lib-render-record record)))
+    (ai/prompt-lib--preview-string rendered (plist-get record :format))
+    rendered))
 
 (defun ai/prompt-lib-copy (&optional record)
-  "Render RECORD and copy it to the system clipboard."
+  "Render RECORD and copy it to the kill ring."
   (interactive)
   (let ((rendered (ai/prompt-lib-render-record
                    (or record (ai/prompt-lib-read-record "Copy prompt: ")))))
-    (ai/prompt-lib--system-copy rendered)
-    (message "Prompt copied (%d chars)" (length rendered))
-    rendered))
-
-(defun ai/prompt-lib-preview (&optional record)
-  "Render RECORD and show a preview buffer."
-  (interactive)
-  (let ((rendered (ai/prompt-lib-render-record
-                   (or record (ai/prompt-lib-read-record "Preview prompt: ")))))
-    (with-current-buffer (get-buffer-create "*Prompt Library Preview*")
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert rendered)
-        (goto-char (point-min))
-        (text-mode))
-      (pop-to-buffer (current-buffer)))
-    rendered))
+    (kill-new rendered)
+    (message "Prompt copied (%d chars)" (length rendered))))
 
 (defun ai/prompt-lib-insert (&optional record)
   "Render RECORD and insert it at point."
@@ -297,7 +342,7 @@
            (or record (ai/prompt-lib-read-record "Insert prompt: ")))))
 
 (defun ai/prompt-lib-send (&optional record)
-  "Render RECORD and send it through gptel."
+  "Render RECORD and submit it through gptel."
   (interactive)
   (require 'gptel)
   (gptel-send
@@ -305,65 +350,110 @@
     (or record (ai/prompt-lib-read-record "Send prompt: ")))))
 
 (defun ai/prompt-lib-edit (&optional record)
-  "Open RECORD for editing."
+  "Open prompt RECORD for editing in its native major mode."
   (interactive)
-  (find-file (plist-get (or record (ai/prompt-lib-read-record "Edit prompt: "))
-                        :path)))
+  (find-file
+   (plist-get (or record (ai/prompt-lib-read-record "Edit prompt: ")) :path)))
 
 (defun ai/prompt-lib-open-repository ()
-  "Open the local prompts-lib checkout."
+  "Open the prompt library repository in Dired."
   (interactive)
   (unless (file-directory-p ai/prompt-lib-directory)
-    (user-error "prompts-lib checkout missing: %s" ai/prompt-lib-directory))
+    (user-error "Prompt library checkout does not exist: %s" ai/prompt-lib-directory))
   (dired ai/prompt-lib-directory))
 
 (defun ai/prompt-lib--slug (name)
-  "Return a safe slug for NAME."
+  "Return filesystem-safe slug derived from NAME."
   (let ((slug (downcase (string-trim name))))
     (setq slug (replace-regexp-in-string "[^[:alnum:]._-]+" "-" slug))
     (replace-regexp-in-string "^-+\\|-+$" "" slug)))
 
-(defun ai/prompt-lib-new (name)
-  "Create a canonical Org prompt called NAME."
-  (interactive "sNew prompt name: ")
-  (let* ((root (ai/prompt-lib--root))
+(defun ai/prompt-lib--new-org (path id title)
+  "Create Org prompt PATH with ID and TITLE."
+  (write-region
+   (format "#+title: %s\n#+prompt_id: %s\n#+description: \n#+filetags: :prompt:\n#+prompt_aliases: \n\n* Prompt\n\n"
+           title id)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib--new-markdown (path id title)
+  "Create Markdown prompt PATH with ID and TITLE."
+  (write-region
+   (format "---\nprompt_id: %s\ntitle: %s\ndescription: \ntags: prompt\naliases: \n---\n\n# Prompt\n\n"
+           id title)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib--new-lisp (path id title)
+  "Create declarative Lisp prompt PATH with ID and TITLE."
+  (write-region
+   (format "(:id %S\n :title %S\n :description \"\"\n :tags (\"prompt\")\n :aliases ()\n :prompt \"\")\n"
+           id title)
+   nil path nil 'silent))
+
+(defun ai/prompt-lib-new (name &optional format)
+  "Create prompt NAME using FORMAT.
+Org is the default.  With a prefix argument, choose Markdown or Lisp instead."
+  (interactive
+   (list (read-string "New prompt name: ")
+         (when current-prefix-arg
+           (intern (completing-read "Format: " '("org" "markdown" "lisp") nil t)))))
+  (let* ((format (or format ai/prompt-lib-default-format))
+         (root (ai/prompt-lib--library-root))
          (slug (ai/prompt-lib--slug name))
-         (path (expand-file-name (concat slug ".org") root)))
-    (make-directory root t)
+         (id slug)
+         (path (expand-file-name
+                (format "%s.%s" slug (ai/prompt-lib--format-extension format)) root)))
+    (unless (file-directory-p root)
+      (make-directory root t))
     (when (file-exists-p path)
       (user-error "Prompt already exists: %s" path))
-    (write-region
-     (format "#+title: %s\n#+prompt_id: %s\n#+description: \n#+filetags: :prompt:\n#+prompt_aliases: \n\n* Prompt\n\n"
-             name slug)
-     nil path nil 'silent)
+    (pcase format
+      ('org (ai/prompt-lib--new-org path id name))
+      ('markdown (ai/prompt-lib--new-markdown path id name))
+      ('lisp (ai/prompt-lib--new-lisp path id name)))
     (ai/prompt-lib-records 'refresh)
     (find-file path)))
 
-(defun ai/prompt-lib--record-at-point ()
-  "Return browser record at point."
-  (or (ai/prompt-lib--by-name (tabulated-list-get-id))
-      (user-error "No prompt on this row")))
+(defun ai/prompt-lib--record-by-id (id)
+  "Return prompt record matching ID."
+  (cl-find id (ai/prompt-lib-records)
+           :key (lambda (record) (plist-get record :id)) :test #'equal))
+
+(defun ai/prompt-lib--entry-record ()
+  "Return prompt record at point in the browser."
+  (or (ai/prompt-lib--record-by-id (tabulated-list-get-id))
+      (user-error "No prompt on this line")))
 
 (defun ai/prompt-lib-browser-preview ()
+  "Preview prompt at point."
   (interactive)
-  (ai/prompt-lib-preview (ai/prompt-lib--record-at-point)))
+  (ai/prompt-lib-render (ai/prompt-lib--entry-record)))
 
 (defun ai/prompt-lib-browser-copy ()
+  "Copy prompt at point."
   (interactive)
-  (ai/prompt-lib-copy (ai/prompt-lib--record-at-point)))
+  (ai/prompt-lib-copy (ai/prompt-lib--entry-record)))
+
+(defun ai/prompt-lib-browser-insert ()
+  "Insert prompt at point in the previously selected window."
+  (interactive)
+  (let ((record (ai/prompt-lib--entry-record)))
+    (quit-window)
+    (ai/prompt-lib-insert record)))
 
 (defun ai/prompt-lib-browser-edit ()
+  "Edit prompt at point."
   (interactive)
-  (ai/prompt-lib-edit (ai/prompt-lib--record-at-point)))
+  (ai/prompt-lib-edit (ai/prompt-lib--entry-record)))
 
 (defun ai/prompt-lib-browser-refresh ()
+  "Refresh records shown in the prompt browser."
   (interactive)
   (ai/prompt-lib-refresh)
   (ai/prompt-lib--browser-entries)
   (tabulated-list-print t))
 
 (defun ai/prompt-lib--browser-entries ()
-  "Populate browser rows."
+  "Populate `tabulated-list-entries' from prompt records."
   (setq tabulated-list-entries
         (mapcar
          (lambda (record)
@@ -379,21 +469,26 @@
     (set-keymap-parent map tabulated-list-mode-map)
     (define-key map (kbd "RET") #'ai/prompt-lib-browser-preview)
     (define-key map (kbd "c") #'ai/prompt-lib-browser-copy)
+    (define-key map (kbd "i") #'ai/prompt-lib-browser-insert)
     (define-key map (kbd "e") #'ai/prompt-lib-browser-edit)
     (define-key map (kbd "g") #'ai/prompt-lib-browser-refresh)
-    map))
+    map)
+  "Keymap for `ai/prompt-lib-browser-mode'.")
 
 (define-derived-mode ai/prompt-lib-browser-mode tabulated-list-mode "Prompt-Lib"
   "Browse reusable prompts."
   (setq tabulated-list-format
-        [("ID" 38 t) ("Title" 34 t) ("Tags" 42 t) ("Format" 10 t)]
+        [("ID" 34 t)
+         ("Title" 30 t)
+         ("Tags" 36 t)
+         ("Format" 10 t)]
         tabulated-list-padding 2
         tabulated-list-sort-key (cons "Title" nil))
   (ai/prompt-lib--browser-entries)
   (tabulated-list-init-header))
 
 (defun ai/prompt-lib-browse ()
-  "Open the prompt library browser."
+  "Open the reusable prompt library browser."
   (interactive)
   (ai/prompt-lib-refresh)
   (let ((buffer (get-buffer-create "*Prompt Library*")))
@@ -413,7 +508,7 @@
     ("c" "Copy" ai/prompt-lib-copy)
     ("i" "Insert" ai/prompt-lib-insert)
     ("s" "Send to gptel" ai/prompt-lib-send)
-    ("p" "Preview" ai/prompt-lib-preview)
+    ("p" "Preview" ai/prompt-lib-render)
     ("e" "Edit" ai/prompt-lib-edit)
     ("n" "New Org prompt" ai/prompt-lib-new)
     ("g" "Refresh" ai/prompt-lib-refresh)
@@ -423,6 +518,9 @@
     ("T" "Generate from template" ai/image-generate-template)
     ("X" "Edit image" ai/image-edit)]])
 
+;; Existing image/chat integrations call these ai-prompts functions.  Route
+;; their lookup through the normalized multi-format library without changing
+;; the existing placeholder renderer.
 (defalias 'ai/prompt-template-names #'ai/prompt-lib-template-names)
 (defalias 'ai/prompt-template--read #'ai/prompt-lib-template-read)
 (defalias 'ai/prompt-template-path #'ai/prompt-lib-template-path)


### PR DESCRIPTION
## Summary

Restores the previously merged Org-first prompt-lib Emacs client and wires it back into the current Qtile/Emacs workflow.

- restore the proven `lisp/llm/prompt-lib.el` implementation from the earlier merged prompt-lib interface
- load it again from `ai-init.el`
- keep prompt browser/copy/insert/preview/edit/send/new/refresh actions and `SPC y p` compatibility
- add a literate `qtile-prompt-lib.org` -> `qtile_prompt_lib.py` binding extension
- route `Super e y p` to `(ai/prompt-lib-browse)`
- preserve the exact existing `Super e y` action as `Super e y y` instead of reconstructing or replacing its command
- install the extension through the existing pre-telemetry auxiliary-keybinding seam
- keep `qtile-capture.org` and generated `qtile_capture.py` in exact parity
- add source/parity/compile regression coverage

The prompt content itself remains owned by `lost-rob0t/prompts-lib`; this PR only owns the Emacs/Qtile client surface.