### PR TITLE
fix(zara): deploy the configured client endpoint and current Core

### DIFF
--- a/docs/wiki/zara.org
+++ b/docs/wiki/zara.org
@@ -27,6 +27,13 @@ persistent CURVE/ZAP security state under
 =~/.local/state/zarathushtra/security=.  The listener remains authenticated;
 there is no unauthenticated TCP fallback.
 
+Local command and desktop clients use =tcp://127.0.0.1:7731= as their default
+service target.  Home Manager exports that target as =ZARA_DAEMON_ENDPOINT= to
+interactive sessions and Zara client user services instead of rewriting the
+user's mutable =config.toml=.  An explicit =zara --connect ENDPOINT ...= still
+overrides the deployment default, while Zara Core falls back to its private IPC
+endpoint on profiles that do not configure a client target.
+
 Apply the desktop user-service configuration with:
 
 #+begin_src shell

--- a/nix/home-manager/mods/zara.nix
+++ b/nix/home-manager/mods/zara.nix
@@ -95,6 +95,19 @@ in
       '';
     };
 
+    client = {
+      endpoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "tcp://127.0.0.1:7731";
+        description = ''
+          Default ZARA/1 endpoint exported to interactive Zara clients and
+          client-side user services as ZARA_DAEMON_ENDPOINT. This selects the
+          deployment endpoint without making Nix own mutable config.toml.
+        '';
+      };
+    };
+
     server = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -225,9 +238,17 @@ in
           zara.server.environmentFile or another out-of-store secret source.
         '';
       }
+      {
+        assertion = cfg.client.endpoint == null || lib.strings.trim cfg.client.endpoint != "";
+        message = "zara.client.endpoint must be null or a non-empty endpoint.";
+      }
     ];
 
     home.packages = [ cfg.package ] ++ registryPackages ++ cfg.plugins.packages;
+
+    home.sessionVariables = lib.mkIf (cfg.client.endpoint != null) {
+      ZARA_DAEMON_ENDPOINT = cfg.client.endpoint;
+    };
 
     home.file = discoveryFiles // pluginConfigFiles // {
       ".config/zarathushtra/config.toml" = lib.mkIf cfg.nixManaged {
@@ -259,6 +280,8 @@ in
       };
       Service = {
         ExecStart = "${cfg.package}/bin/zara-desktop";
+        Environment = lib.optional (cfg.client.endpoint != null)
+          "ZARA_DAEMON_ENDPOINT=${cfg.client.endpoint}";
         Restart = "on-failure";
         RestartSec = 3;
         UMask = "0077";
@@ -274,6 +297,8 @@ in
       };
       Service = {
         ExecStart = "${cfg.wake.package}/bin/zara-wake";
+        Environment = lib.optional (cfg.client.endpoint != null)
+          "ZARA_DAEMON_ENDPOINT=${cfg.client.endpoint}";
         Restart = "on-failure";
         RestartSec = 5;
         UMask = "0077";

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -25,6 +25,7 @@
   zara = {
     enable = true;
     workflows.enable = true;
+    client.endpoint = "tcp://127.0.0.1:7731";
 
     server = {
       enable = true;
@@ -106,7 +107,7 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value in your configuration without breakage.
+  # You can update this value for a new home-manager release.
   # See the Home Manager release notes for a list of state version
   # changes.
 

--- a/nix/home-manager/systems/desktop/home.nix
+++ b/nix/home-manager/systems/desktop/home.nix
@@ -107,7 +107,7 @@
   # when a new Home Manager release introduces backwards
   # incompatible changes.
   #
-  # You can update this value for a new home-manager release.
+  # You can update this value in your configuration without breakage.
   # See the Home Manager release notes for a list of state version
   # changes.
 

--- a/tests/zara-workflows.sh
+++ b/tests/zara-workflows.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 config="$repo_root/nix/home-manager/files/zarathushtra/config.pl"
 workflow_module="$repo_root/nix/home-manager/mods/zara-workflows.nix"
+zara_module="$repo_root/nix/home-manager/mods/zara.nix"
 default_module="$repo_root/nix/home-manager/mods/default.nix"
 desktop="$repo_root/nix/home-manager/systems/desktop/home.nix"
 nixos_networking="$repo_root/nix/nixos/systems/flake/networking.nix"
@@ -16,6 +17,7 @@ fail() {
 
 [[ -f "$config" ]] || fail "missing Home Manager-owned Zara base config"
 [[ -f "$workflow_module" ]] || fail "missing Zara workflow Home Manager module"
+[[ -f "$zara_module" ]] || fail "missing Zara Home Manager module"
 [[ -f "$updater" ]] || fail "missing structured Zara system-update helper"
 
 grep -Fq './zara-workflows.nix' "$default_module" || fail "workflow module is not imported"
@@ -24,6 +26,9 @@ grep -Fq '".config/zarathushtra/config.pl"' "$workflow_module" || fail "workflow
 ! grep -Fq '".config/zarathushtra/config.local.pl"' "$workflow_module" || fail "Home Manager must not own mutable config.local.pl"
 
 grep -Fq -- '--endpoint tcp://0.0.0.0:7731' "$desktop" || fail "Arch desktop Zara listener is not exposed on TCP 7731"
+grep -Fq 'client.endpoint = "tcp://127.0.0.1:7731";' "$desktop" || fail "local Zara clients do not default to the deployed TCP listener"
+grep -Fq 'ZARA_DAEMON_ENDPOINT = cfg.client.endpoint;' "$zara_module" || fail "Zara client endpoint is not exported to interactive sessions"
+grep -Fq '"ZARA_DAEMON_ENDPOINT=${cfg.client.endpoint}"' "$zara_module" || fail "Zara client endpoint is not exported to client user services"
 grep -Fq -- '--security-dir %h/.local/state/zarathushtra/security' "$desktop" || fail "Arch desktop Zara listener has no persistent security state"
 grep -Fq -- '--security-init' "$desktop" || fail "Arch desktop Zara security state is not initialized"
 ! grep -Fq '7731 # Zara authenticated ZARA/1 listener' "$nixos_networking" || fail "Arch Zara listener must not be modeled as NixOS firewall state"


### PR DESCRIPTION
## Problem
The Arch/Home Manager profile binds `zara-server` to authenticated `tcp://0.0.0.0:7731`, while local Zara clients have no declarative default target. The pinned Zara input is also stale and predates the idle server CPU-spin fix.

## Changes
- add `zara.client.endpoint` without taking ownership of mutable `config.toml`;
- export `ZARA_DAEMON_ENDPOINT` to interactive sessions;
- export the same endpoint to Zara desktop/wake user services;
- configure the desktop profile's local client target as `tcp://127.0.0.1:7731`;
- extend the Zara workflow contract and docs.

## Core pin
This PR will pin the Zara flake input to the merged Core endpoint fix, which also contains #660's idle server CPU-spin fix, before merge.

## Security
The server listener remains CURVE/ZAP-authenticated. No keys or credentials are placed in the Nix store; endpoint selection and secret material remain separate.

## Validation
Fresh exact-head CI plus the Home Manager/Nix evaluation are the merge gate.