### PR TITLE
fix(qtile): repair Agent Zero API and add Mara launcher

### DIFF
--- a/.config/qtile/qtile-desktop.el
+++ b/.config/qtile/qtile-desktop.el
@@ -15,6 +15,7 @@
 
 (defconst qtile-desktop-private-env
   (expand-file-name "~/.config/qtile/private.env"))
+(defconst qtile-agent-zero-api-path "/api/api_message")
 (defvar-local qtile-agent-zero-context-id nil)
 (defvar-local qtile-agent-zero-prompt-start nil)
 
@@ -57,6 +58,16 @@
   (delete-other-windows)
   (qtile-ui-prepare-buffer)
   (qtile-ui-bind-dismiss))
+
+(defun qtile-mara-open (&optional _params)
+  "Open Mara in the current Qtile-managed Emacs frame."
+  (interactive)
+  (qtile-desktop--title "qtile-mara")
+  (unless (fboundp 'mara)
+    (unless (require 'mara nil t)
+      (user-error "Mara is not available in this Emacs")))
+  (mara)
+  (delete-other-windows))
 
 (defvar qtile-agent-zero-mode-map
   (let ((map (make-sparse-keymap)))
@@ -179,7 +190,7 @@
                         payload))
              (url-request-data (encode-coding-string (json-encode payload) 'utf-8)))
         (url-retrieve
-         (concat host "/api_message")
+         (concat host qtile-agent-zero-api-path)
          #'qtile-agent-zero--finish
          (list target-buffer)
          t

--- a/.config/qtile/qtile_control.py
+++ b/.config/qtile/qtile_control.py
@@ -44,6 +44,7 @@ EMACS_NOTIFICATIONS_HELPER = Path("~/.dotfiles/lisp/qtile/qtile-notifications.el
 EMACS_SERVICES_HELPER = Path("~/.dotfiles/lisp/qtile/qtile-services.el").expanduser()
 EMACS_POPUP_TITLES = (
     "qtile-agent-zero",
+    "qtile-mara",
     "qtile-org-todos",
     "qtile-org-agenda-day",
     "qtile-workflow",
@@ -912,6 +913,23 @@ def build_screen_widgets(
                             "agent-zero",
                             "agent_zero_button",
                             "qtile-agent-zero-open",
+                            720,
+                            560,
+                            "left",
+                        )
+                    },
+                ),
+                widget.TextBox(
+                    name="mara_button",
+                    text=" Mara ",
+                    foreground=palette["pink"],
+                    background=background,
+                    mouse_callbacks={
+                        "Button1": lazy.function(
+                            _toggle_emacs_popup,
+                            "mara",
+                            "mara_button",
+                            "qtile-mara-open",
                             720,
                             560,
                             "left",

--- a/.config/qtile/tests/test_qtile_control.py
+++ b/.config/qtile/tests/test_qtile_control.py
@@ -156,6 +156,16 @@ class QtileControlTests(unittest.TestCase):
         self.assertIn("widget.MemoryGraph", SOURCE_TEXT)
         self.assertIn('format="{Available:.1f}{mm} free"', SOURCE_TEXT)
 
+    def test_center_has_mara_button_next_to_agent_zero(self):
+        center = SOURCE_TEXT.index('if role == "center":')
+        left = SOURCE_TEXT.index('elif role == "left":')
+        center_text = SOURCE_TEXT[center:left]
+        self.assertIn('name="agent_zero_button"', center_text)
+        self.assertIn('name="mara_button"', center_text)
+        self.assertIn('text=" Mara "', center_text)
+        self.assertIn('"qtile-mara-open"', center_text)
+        self.assertLess(center_text.index('name="agent_zero_button"'), center_text.index('name="mara_button"'))
+
     def test_system_telemetry_keeps_order_and_uses_fixed_icon_cells(self):
         self.assertIn("from qtile_system import DiskIOGraph, RootFree, telemetry_icon_cell", SOURCE_TEXT)
         self.assertLess(SOURCE_TEXT.index('name="cpu_icon"'), SOURCE_TEXT.index('name="memory_icon"'))
@@ -258,6 +268,7 @@ class QtileControlTests(unittest.TestCase):
     def test_shared_emacs_popups_are_floating_windows(self):
         for title in (
             "qtile-agent-zero",
+            "qtile-mara",
             "qtile-org-todos",
             "qtile-org-agenda-day",
             "qtile-workflow",
@@ -284,9 +295,10 @@ class QtileControlTests(unittest.TestCase):
         titles = [rule._rules.get("title") for rule in floating_layout.float_rules]
         self.assertEqual(titles.count("qtile-services"), 1)
         self.assertIn("qtile-agent-zero", titles)
+        self.assertIn("qtile-mara", titles)
 
     def test_named_emacs_popups_use_shared_geometry_launcher(self):
-        self.assertEqual(SOURCE_TEXT.count("_toggle_emacs_popup,"), 3)
+        self.assertEqual(SOURCE_TEXT.count("_toggle_emacs_popup,"), 4)
         self.assertIn("import emacs_ui", SOURCE_TEXT)
         self.assertIn("emacs_ui.toggle_emacs_dropdown", SOURCE_TEXT)
 

--- a/.config/qtile/tests/test_qtile_emacs_control.py
+++ b/.config/qtile/tests/test_qtile_emacs_control.py
@@ -14,7 +14,9 @@ WORKFLOW_TEXT = WORKFLOW_SOURCE.read_text(encoding="utf-8")
 
 class QtileEmacsControlTests(unittest.TestCase):
     def test_agent_zero_uses_documented_external_api(self):
-        self.assertIn('(concat host "/api_message")', TEXT)
+        self.assertIn('(defconst qtile-agent-zero-api-path "/api/api_message")', TEXT)
+        self.assertIn("(concat host qtile-agent-zero-api-path)", TEXT)
+        self.assertNotIn('(concat host "/api_message")', TEXT)
         self.assertIn('("X-API-KEY" . ,key)', TEXT)
         self.assertIn('(message . ,prompt)', TEXT)
         self.assertIn('(context_id . ,qtile-agent-zero-context-id)', TEXT)
@@ -34,9 +36,17 @@ class QtileEmacsControlTests(unittest.TestCase):
         self.assertIn('completing-read "Workflow: " picker-choices nil t', WORKFLOW_TEXT)
         self.assertNotIn('completing-read "Qtile workflow: "', TEXT)
 
+    def test_mara_renderer_opens_native_mara_ui(self):
+        self.assertIn("(defun qtile-mara-open (&optional _params)", TEXT)
+        self.assertIn('(qtile-desktop--title "qtile-mara")', TEXT)
+        self.assertIn("(require 'mara nil t)", TEXT)
+        self.assertIn("(mara)", TEXT)
+        self.assertIn("(delete-other-windows)", TEXT)
+
     def test_shared_renderer_arguments_are_accepted_by_legacy_popups(self):
         self.assertIn("(defun qtile-org-todos-open (&optional _params)", TEXT)
         self.assertIn("(defun qtile-agent-zero-open (&optional _params)", TEXT)
+        self.assertIn("(defun qtile-mara-open (&optional _params)", TEXT)
 
 
 if __name__ == "__main__":

--- a/docs/qtile-emacs-ui.org
+++ b/docs/qtile-emacs-ui.org
@@ -28,7 +28,7 @@ lisp/qtile/qtile-ui.el
     |
     v
 feature renderer: qtile-desktop, qtile-workflow, qtile-notifications,
-qtile-services
+qtile-services, Mara
 #+end_example
 
 * Named Emacs server
@@ -132,9 +132,19 @@ these primitives instead of duplicating frame boilerplate.
 
 =qtile-agent-zero-open= remains in the existing =qtile-desktop.el= helper.
 Agent Zero still uses asynchronous =url-retrieve=, the conversation context
-ID, reset/new-context behavior, and private environment/API-key handling.  Its
-Qtile button now calls =toggle_emacs_dropdown= using the =agent_zero_button=
-geometry.  Credentials never enter the structured popup arguments.
+ID, reset/new-context behavior, and private environment/API-key handling.  The
+external API request targets Agent Zero's current =POST /api/api_message=
+endpoint under =AGENT_ZERO_HOST= and sends =X-API-KEY=.  The Qtile button calls
+=toggle_emacs_dropdown= using the =agent_zero_button= geometry.  Credentials
+never enter the structured popup arguments.
+
+** Mara
+
+The center bar exposes =mara_button= beside Agent Zero.  It uses the same
+widget-anchored =toggle_emacs_dropdown= path and =qtile-mara= floating frame,
+then calls Mara's native =mara= Emacs entry point through
+=qtile-mara-open=.  Qtile owns only launch geometry and frame lifecycle; Mara
+continues to own its persistent Org/gptel chat buffer and runtime state.
 
 ** Org TODO and date agenda
 
@@ -328,8 +338,8 @@ python3 -m py_compile .config/qtile/*.py .config/qtile/scripts/*.py
 scripts/check-literate-sync
 #+end_src
 
-When a graphical X11 session is available, verify A0, TODO, date, workflow,
-SERVICES, and both notification backends on each physical screen.  Verify the
-existing network contract separately: cyan/blue is RX/download and pink/red
-is TX/upload.  This slice deliberately does not alter that working graph or
-the truthful OpenRouter bucket renderer.
+When a graphical X11 session is available, verify A0, Mara, TODO, date,
+workflow, SERVICES, and both notification backends on each physical screen.
+Verify the existing network contract separately: cyan/blue is RX/download and
+pink/red is TX/upload.  This slice deliberately does not alter that working
+graph or the truthful OpenRouter bucket renderer.


### PR DESCRIPTION
## What
- fix the Qtile Agent Zero client to use the current external API route: `POST /api/api_message`
- preserve the existing `X-API-KEY`, `message`, and `context_id` contract
- add a `Mara` button beside `A0` on the center bar
- launch Mara through the existing widget-anchored Qtile → Emacs popup UI using `qtile-mara-open`
- add `qtile-mara` to the shared floating popup titles
- update Qtile regression coverage and popup documentation

## Why
The existing Qtile A0 client still posted to the obsolete `/api_message` path, which Agent Zero rejects as a bad API URL. Mara already exposes a native Emacs `mara` entry point, so Qtile only needs to own popup launch geometry/frame lifecycle rather than duplicate Mara UI logic.

## Verification
- branch diff is limited to the A0/Mara Qtile implementation, tests, and `docs/qtile-emacs-ui.org`
- regression tests now assert the current A0 route and Mara popup wiring
- exact-head CI is the merge gate
