### PR TITLE
fix(home-manager): pin zara to merged master and quote hyphenated config atom

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788889258,
-        "narHash": "sha256-w8BfO0qJdTLxwkvdCfPJfFIoR+BmbQl9naGUZPF/AJc=",
+        "lastModified": 1789082443,
+        "narHash": "sha256-qRXqmam0LFRStW56Rtc79jImhc+vbg4TctaHo1NsM9w=",
         "owner": "lost-rob0t",
         "repo": "zara",
-        "rev": "291f5e3474c33911dfd1ead833230fa8c4c71e4b",
+        "rev": "23ad58013f8590a88e3514165c39318d1a641b29",
         "type": "github"
       },
       "original": {

--- a/nix/home-manager/files/zarathushtra/config.pl
+++ b/nix/home-manager/files/zarathushtra/config.pl
@@ -46,7 +46,7 @@ direct_app(thunderbird).
 
 app_mapping(tor, ["torbrowser-launcher"]).
 app_mapping(tor_browser, ["torbrowser-launcher"]).
-direct_app(torbrowser-launcher).
+direct_app('torbrowser-launcher').
 
 app_mapping(music, ["feishin"]).
 app_mapping(feishin, ["feishin"]).


### PR DESCRIPTION
## Summary

- Bump `inputs.zara` `f8394af` → `23ad580` (zara PR #670, merged: actionable config-loader diagnostic for hyphenated user config atoms) so the HM-built `zara-server`/CLI run the merged fix.
- Quote `direct_app('torbrowser-launcher')` in the provisioned `config.pl`: unquoted, SWI-Prolog parses the hyphenated token as `-(torbrowser, launcher)`, the config loader rejects it, and one invalid fact failed the whole Prolog engine load at daemon startup (zara#668).

## Validation

- `home-manager build` from the bumped pin succeeds; generated `zara-server.service` ExecStart points at the `zarathushtra-full` built from `23ad580`.
- Activated on the live host: service restarts clean, `Loaded Prolog program` from the new store path, no config loader errors.
- `~/.config/zarathushtra/config.toml` is deliberately untracked (holds CURVE/API secrets; mutable operator state).