### PR TITLE
fix(qtile): preserve typing keys in editable popups

### DIFF
--- a/lisp/qtile/qtile-ui-test.el
+++ b/lisp/qtile/qtile-ui-test.el
@@ -80,16 +80,31 @@
       (qtile-ui-prepare-buffer)
       (should (null mode-line-format))
       (should (string-match-p "Qtile" (car header-line-format)))
+      (should (string-match-p "C-c C-q close" (cadr header-line-format)))
       (when doom-hide-mode-line
         (should (bound-and-true-p hide-mode-line-mode))))))
 
-(ert-deftest qtile-ui-dismissal-keys-are-installed ()
+(ert-deftest qtile-ui-read-only-dismissal-keys-are-installed ()
   (with-temp-buffer
-    (text-mode)
+    (special-mode)
     (qtile-ui-bind-dismiss)
     (should (eq (key-binding (kbd "q")) #'qtile-ui-close-current))
     (should (eq (key-binding (kbd "ESC")) #'qtile-ui-close-current))
-    (should (eq (key-binding (kbd "<escape>")) #'qtile-ui-close-current))))
+    (should (eq (key-binding (kbd "<escape>")) #'qtile-ui-close-current))
+    (should (eq (key-binding (kbd "C-c C-q")) #'qtile-ui-close-current))))
+
+(ert-deftest qtile-ui-editable-popups-preserve-typing-keys ()
+  (with-temp-buffer
+    (text-mode)
+    ;; Simulate a reused chat buffer that still has the old popup bindings.
+    (local-set-key (kbd "q") #'qtile-ui-close-current)
+    (local-set-key (kbd "ESC") #'qtile-ui-close-current)
+    (local-set-key (kbd "<escape>") #'qtile-ui-close-current)
+    (qtile-ui-bind-dismiss)
+    (should-not (eq (key-binding (kbd "q")) #'qtile-ui-close-current))
+    (should-not (eq (key-binding (kbd "ESC")) #'qtile-ui-close-current))
+    (should-not (eq (key-binding (kbd "<escape>")) #'qtile-ui-close-current))
+    (should (eq (key-binding (kbd "C-c C-q")) #'qtile-ui-close-current))))
 
 (ert-deftest qtile-notifications-preserves-all-normalized-records ()
   (let ((payload (json-read-from-string

--- a/lisp/qtile/qtile-ui.el
+++ b/lisp/qtile/qtile-ui.el
@@ -117,9 +117,12 @@
 (defun qtile-ui--header-line ()
   "Return the compact top line shared by Qtile popup buffers."
   (let* ((popup-id (frame-parameter nil 'qtile-ui-popup-id))
-         (title (if popup-id (format "Qtile %s" popup-id) "Qtile")))
+         (title (if popup-id (format "Qtile %s" popup-id) "Qtile"))
+         (hint (if buffer-read-only
+                   "  q/Escape close "
+                 "  C-c C-q close ")))
     (list (propertize (format " %s " title) 'face 'mode-line)
-          (propertize "  q/Escape close " 'face 'shadow))))
+          (propertize hint 'face 'shadow))))
 
 (defun qtile-ui--apply-frame-theme (frame)
   "Apply the configured Emacs theme to a newly-created daemon frame."
@@ -159,10 +162,19 @@
     (display-line-numbers-mode -1)))
 
 (defun qtile-ui-bind-dismiss ()
-  "Bind the common keyboard dismissal keys in the current popup buffer."
-  (local-set-key (kbd "q") #'qtile-ui-close-current)
-  (local-set-key (kbd "ESC") #'qtile-ui-close-current)
-  (local-set-key (kbd "<escape>") #'qtile-ui-close-current))
+  "Install popup dismissal keys without stealing typing keys from editable buffers."
+  (local-set-key (kbd "C-c C-q") #'qtile-ui-close-current)
+  (if buffer-read-only
+      (progn
+        (local-set-key (kbd "q") #'qtile-ui-close-current)
+        (local-set-key (kbd "ESC") #'qtile-ui-close-current)
+        (local-set-key (kbd "<escape>") #'qtile-ui-close-current))
+    ;; A reused chat buffer may still carry bindings installed by an older
+    ;; qtile-ui version, so explicitly clear them rather than merely declining
+    ;; to add them again.
+    (local-unset-key (kbd "q"))
+    (local-unset-key (kbd "ESC"))
+    (local-unset-key (kbd "<escape>"))))
 
 (defun qtile-ui-close (popup-id)
   "Close the popup identified by POPUP-ID, if it is still live."


### PR DESCRIPTION
## What
- stop the shared Qtile popup layer from binding plain `q`/Escape in editable buffers
- keep `q`/Escape quick-close behavior for read-only dashboards
- add `C-c C-q` as the universal explicit close binding
- explicitly clear stale old dismiss bindings from reused editable chat buffers
- add regression coverage for both read-only and editable popup behavior

## Why
`qtile-ui-toggle` applied dismissal bindings after every renderer. That meant Mara's writable chat buffer inherited `q -> qtile-ui-close-current`, so typing any word containing `q` closed the popup. The same shared bug could affect the editable Agent Zero chat.

## Verification
- branch is based on current `master`
- diff is limited to the shared Qtile popup lifecycle and its ERT tests
- exact-head CI is the merge gate
