### PR TITLE
chore(deps): pin zara 8c32d45 (transport fix) + llm-log 92c6062 (websocket NameError fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789082443,
-        "narHash": "sha256-qRXqmam0LFRStW56Rtc79jImhc+vbg4TctaHo1NsM9w=",
+        "lastModified": 1789093242,
+        "narHash": "sha256-K5ZWBTjbHYaK0R7be/BAYp2BImuo/t7UhmgQskUZCzI=",
         "owner": "lost-rob0t",
         "repo": "zara",
-        "rev": "23ad58013f8590a88e3514165c39318d1a641b29",
+        "rev": "8c32d458c8781063950e9d5d18dffc6a13482092",
         "type": "github"
       },
       "original": {

--- a/nix/home-manager/mods/llm.nix
+++ b/nix/home-manager/mods/llm.nix
@@ -2,7 +2,7 @@
 
 let
   comfyui = pkgs.comfyui.override { withManager = true; };
-  llmLogRevision = "6a78b436346659550178c3a1f39b56e567469eb0";
+  llmLogRevision = "92c6062148fe3b5213043d65136ac0521742691a";
   llmLogFlake = builtins.getFlake "github:lost-rob0t/llm-log/${llmLogRevision}";
   llmLogPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
   llmLogExpertPackage = llmLogFlake.packages.${pkgs.stdenv.hostPlatform.system}.llm-log-expert;


### PR DESCRIPTION
## Summary

- `inputs.zara` → `8c32d458c8781063950e9d5d18dffc6a13482092` (zara PR #859: transport tolerates loaded hosts, surface silent route drops — root cause of the recurring `daemon turn timed out` hangs).
- `llmLogRevision` → `92c6062148fe3b5213043d65136ac0521742691a` (llm-log PR #69: websocket capture ingest no longer raises `NameError: expert_plane`; this was failing the `llm-log-0.1.0` build and blocking home-manager activation).

## Validation

- `home-manager build` from the bumped pins succeeds (previously failed on `llm-log-0.1.0` test errors).
- Generated `zara-server.service` ExecStart points at the `zarathushtra-full` built from `8c32d45`.