### PR TITLE
feat(research): support local checkout sources

### DIFF
--- a/.doom.d/autoload/research-dashboard-local-defaults.el
+++ b/.doom.d/autoload/research-dashboard-local-defaults.el
@@ -1,0 +1,16 @@
+;;; research-dashboard-local-defaults.el --- Local research roots -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Machine-local research roots tracked by the research dashboard.  This form
+;; is emitted into Doom's generated autoloads so the values are bound before
+;; `research-dashboard-local' is loaded; its `defcustom' then preserves them.
+
+;;; Code:
+
+;;;###autoload
+(setq nsa/research-dashboard-local-checkouts
+      (list (expand-file-name "~/starintel")
+            (expand-file-name "~/Documents/Projects/prolog-rlm")))
+
+(provide 'research-dashboard-local-defaults)
+;;; research-dashboard-local-defaults.el ends here

--- a/.doom.d/autoload/research-dashboard-local-defaults.el
+++ b/.doom.d/autoload/research-dashboard-local-defaults.el
@@ -1,9 +1,9 @@
 ;;; research-dashboard-local-defaults.el --- Local research roots -*- lexical-binding: t; -*-
 
 ;;; Commentary:
-;; Machine-local research roots tracked by the research dashboard.  This form
-;; is emitted into Doom's generated autoloads so the values are bound before
-;; `research-dashboard-local' is loaded; its `defcustom' then preserves them.
+;; Machine-local research roots tracked by the research dashboard.  These
+;; forms are emitted into Doom's generated autoloads so the roots and local
+;; DWIM adapter are available whenever the dashboard is opened.
 
 ;;; Code:
 
@@ -11,6 +11,11 @@
 (setq nsa/research-dashboard-local-checkouts
       (list (expand-file-name "~/starintel")
             (expand-file-name "~/Documents/Projects/prolog-rlm")))
+
+;;;###autoload
+(with-eval-after-load 'research-dashboard
+  (require 'research-dashboard-local)
+  (require 'research-dashboard-local-dwim))
 
 (provide 'research-dashboard-local-defaults)
 ;;; research-dashboard-local-defaults.el ends here

--- a/.doom.d/autoload/research-dashboard-local-dwim.el
+++ b/.doom.d/autoload/research-dashboard-local-dwim.el
@@ -1,0 +1,171 @@
+;;; research-dashboard-local-dwim.el --- DWIM forge identity for research dashboard -*- lexical-binding: t; -*-
+
+(require 'json)
+(require 'subr-x)
+(require 'research-dashboard-local)
+
+(defvar-local nsa/research-dashboard-local-dwim--identities nil
+  "Map local research item ids to forge/provider identity metadata.")
+
+(defun nsa/research-dashboard-local-dwim--command (directory program &rest args)
+  "Run PROGRAM ARGS in DIRECTORY and return trimmed stdout on success."
+  (when (executable-find program)
+    (let ((default-directory (file-name-as-directory directory)))
+      (with-temp-buffer
+        (when (zerop (apply #'process-file program nil t nil args))
+          (string-trim (buffer-string)))))))
+
+(defun nsa/research-dashboard-local-dwim--parse-remote (remote)
+  "Parse REMOTE into a plist with :host, :slug and :ssh-user when available."
+  (cond
+   ((and remote
+         (string-match
+          "\\`\\([^/@:]+\\)@\\([^/:]+\\):\\(.+\\)\\'" remote))
+    (list :ssh-user (match-string 1 remote)
+          :host (downcase (match-string 2 remote))
+          :slug (string-remove-suffix ".git" (match-string 3 remote))))
+   ((and remote
+         (string-match
+          "\\`ssh://\\(?:\\([^/@]+\\)@\\)?\\([^/:]+\\)\\(?::[0-9]+\\)?/\\(.+\\)\\'"
+          remote))
+    (list :ssh-user (match-string 1 remote)
+          :host (downcase (match-string 2 remote))
+          :slug (string-remove-suffix ".git" (match-string 3 remote))))
+   ((and remote
+         (string-match
+          "\\`https?://\\([^/]+\\)/\\(.+\\)\\'" remote))
+    (list :host (downcase (match-string 1 remote))
+          :slug (string-remove-suffix ".git" (match-string 2 remote))))
+   (t nil)))
+
+(defun nsa/research-dashboard-local-dwim--json-login (text)
+  "Return a forge login from JSON TEXT, tolerating login/username/user keys."
+  (when (and text (not (string-empty-p text)))
+    (condition-case nil
+        (let ((object (json-parse-string text :object-type 'alist)))
+          (or (alist-get "login" object nil nil #'string=)
+              (alist-get "username" object nil nil #'string=)
+              (alist-get "user" object nil nil #'string=)))
+      (error nil))))
+
+(defun nsa/research-dashboard-local-dwim--github-info (repo-root parsed)
+  "Resolve GitHub repository and actor metadata for REPO-ROOT and PARSED remote."
+  (let* ((slug (or (nsa/research-dashboard-local-dwim--command
+                    repo-root "gh" "repo" "view" "--json" "nameWithOwner"
+                    "--jq" ".nameWithOwner")
+                   (plist-get parsed :slug)))
+         (actor (nsa/research-dashboard-local-dwim--command
+                 repo-root "gh" "api" "user" "--jq" ".login")))
+    (list :provider 'github :host "github.com" :repo slug :actor actor)))
+
+(defun nsa/research-dashboard-local-dwim--tea-info (repo-root parsed)
+  "Resolve Forgejo/Gitea actor metadata for REPO-ROOT using tea context."
+  (let* ((raw (nsa/research-dashboard-local-dwim--command
+               repo-root "tea" "api" "/user"))
+         (actor (nsa/research-dashboard-local-dwim--json-login raw))
+         (host (plist-get parsed :host))
+         (slug (plist-get parsed :slug)))
+    (when actor
+      (list :provider 'forgejo
+            :host host
+            :repo (and slug host (format "%s/%s" host slug))
+            :actor actor))))
+
+(defun nsa/research-dashboard-local-dwim--forge-info (repo-root remote)
+  "DWIM forge metadata for REPO-ROOT from REMOTE.
+
+GitHub is resolved through `gh'.  Other remotes are offered to `tea', which
+uses the checkout's Git remote context to select the matching Forgejo/Gitea
+login.  Plain Git parsing remains the final fallback."
+  (let* ((parsed (nsa/research-dashboard-local-dwim--parse-remote remote))
+         (host (plist-get parsed :host))
+         (slug (plist-get parsed :slug)))
+    (cond
+     ((string= host "github.com")
+      (nsa/research-dashboard-local-dwim--github-info repo-root parsed))
+     ((and parsed
+           (nsa/research-dashboard-local-dwim--tea-info repo-root parsed)))
+     (parsed
+      (list :provider 'git
+            :host host
+            :repo (if (and host slug) (format "%s/%s" host slug) slug)
+            :actor nil))
+     (t nil))))
+
+(defun nsa/research-dashboard-local-dwim--checkout-info-advice
+    (original directory)
+  "Augment checkout info with DWIM provider and authenticated actor identity."
+  (let* ((info (funcall original directory))
+         (repo-root (plist-get info :repo-root))
+         (remote (nsa/research-dashboard-local--git
+                  repo-root "remote" "get-url" "origin"))
+         (forge (and remote
+                     (nsa/research-dashboard-local-dwim--forge-info
+                      repo-root remote))))
+    (when forge
+      (let ((repo (plist-get forge :repo)))
+        (when (and repo (not (string-empty-p repo)))
+          (setq info (plist-put info :repo repo))))
+      (setq info (plist-put info :provider (plist-get forge :provider))
+            info (plist-put info :host (plist-get forge :host))
+            info (plist-put info :actor (plist-get forge :actor))
+            info (plist-put info :remote remote)))
+    info))
+
+(defun nsa/research-dashboard-local-dwim--item-advice (original info file)
+  "Remember forge identity metadata for the item built from INFO and FILE."
+  (let ((item (funcall original info file)))
+    (when item
+      (unless (hash-table-p nsa/research-dashboard-local-dwim--identities)
+        (setq nsa/research-dashboard-local-dwim--identities
+              (make-hash-table :test #'equal)))
+      (puthash
+       (nsa/research-dashboard-local--id item)
+       (list :provider (plist-get info :provider)
+             :host (plist-get info :host)
+             :actor (plist-get info :actor)
+             :remote (plist-get info :remote))
+       nsa/research-dashboard-local-dwim--identities))
+    item))
+
+(defun nsa/research-dashboard-local-dwim--scan-advice (original &rest args)
+  "Reset identity metadata before rescanning local sources."
+  (setq nsa/research-dashboard-local-dwim--identities
+        (make-hash-table :test #'equal))
+  (apply original args))
+
+(defun nsa/research-dashboard-local-dwim--identity (item)
+  "Return DWIM forge identity metadata for ITEM."
+  (and (hash-table-p nsa/research-dashboard-local-dwim--identities)
+       (gethash (nsa/research-dashboard-local--id item)
+                nsa/research-dashboard-local-dwim--identities)))
+
+(defun nsa/research-dashboard-local-dwim--decide-advice
+    (original state item file)
+  "Use the forge-authenticated actor as the local decision prompt default."
+  (let* ((identity (nsa/research-dashboard-local-dwim--identity item))
+         (actor (plist-get identity :actor))
+         (nsa/research-dashboard--login
+          (or actor nsa/research-dashboard--login)))
+    (funcall original state item file)))
+
+(defun nsa/research-dashboard-local-dwim--install ()
+  "Install DWIM provider/identity behavior once."
+  (unless (advice-member-p
+           #'nsa/research-dashboard-local-dwim--checkout-info-advice
+           'nsa/research-dashboard-local--checkout-info)
+    (advice-add 'nsa/research-dashboard-local--checkout-info :around
+                #'nsa/research-dashboard-local-dwim--checkout-info-advice)
+    (advice-add 'nsa/research-dashboard-local--item :around
+                #'nsa/research-dashboard-local-dwim--item-advice)
+    (advice-add 'nsa/research-dashboard-local--scan-current-buffer :around
+                #'nsa/research-dashboard-local-dwim--scan-advice)
+    (advice-add 'nsa/research-dashboard-local--decide :around
+                #'nsa/research-dashboard-local-dwim--decide-advice)))
+
+;;;###autoload
+(add-hook 'nsa/research-dashboard-mode-hook
+          #'nsa/research-dashboard-local-dwim--install)
+
+(provide 'research-dashboard-local-dwim)
+;;; research-dashboard-local-dwim.el ends here

--- a/.doom.d/autoload/research-dashboard-local.el
+++ b/.doom.d/autoload/research-dashboard-local.el
@@ -63,7 +63,9 @@ approval operate on the checkout copy instead of stale remote content."
 
 (defun nsa/research-dashboard-local--blob (file repo-root)
   (or (nsa/research-dashboard-local--git repo-root "hash-object" file)
-      (concat "local:" (secure-hash 'sha256 file))))
+      (concat "local:"
+              (secure-hash 'sha256
+                           (nsa/research-dashboard-local--read file)))))
 
 (defun nsa/research-dashboard-local--eligible-file-p (file)
   (and (string-suffix-p ".org" file t)
@@ -179,7 +181,7 @@ approval operate on the checkout copy instead of stale remote content."
 (defun nsa/research-dashboard-local--assert-writable (file expected)
   (let ((visiting (get-file-buffer file)))
     (when (and visiting
-               (buffer-local-value 'buffer-modified-p visiting))
+               (with-current-buffer visiting (buffer-modified-p)))
       (user-error "Local research buffer has unsaved changes: %s" file)))
   (unless (string= expected (nsa/research-dashboard-local--read file))
     (user-error "Research changed since refresh; refresh first")))
@@ -189,7 +191,7 @@ approval operate on the checkout copy instead of stale remote content."
   (let ((coding-system-for-write 'utf-8-unix))
     (write-region updated nil file nil 'silent))
   (let ((visiting (get-file-buffer file)))
-    (when (and visiting (not (buffer-modified-p visiting)))
+    (when (and visiting (not (with-current-buffer visiting (buffer-modified-p))))
       (with-current-buffer visiting
         (revert-buffer :ignore-auto :noconfirm)))))
 

--- a/.doom.d/autoload/research-dashboard-local.el
+++ b/.doom.d/autoload/research-dashboard-local.el
@@ -1,0 +1,312 @@
+;;; research-dashboard-local.el --- Local checkout support for research dashboard -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'seq)
+(require 'subr-x)
+(require 'research-dashboard)
+
+(defcustom nsa/research-dashboard-local-checkouts nil
+  "Local Git checkouts or directories to scan for research Org files.
+
+Git checkouts infer repository identity from `remote.origin.url'.  A local
+item shadows the same repository/path discovered from GitHub, so review and
+approval operate on the checkout copy instead of stale remote content."
+  :type '(repeat directory)
+  :group 'nsa/research-dashboard)
+
+(defvar nsa/research-dashboard-local--installed nil)
+(defvar-local nsa/research-dashboard-local--files nil)
+
+(defun nsa/research-dashboard-local--id (item)
+  (concat (nsa/research-item-repo item) ":" (nsa/research-item-path item)))
+
+(defun nsa/research-dashboard-local--git (directory &rest args)
+  (when (executable-find "git")
+    (with-temp-buffer
+      (when (zerop (apply #'process-file "git" nil t nil
+                          "-C" directory args))
+        (string-trim (buffer-string))))))
+
+(defun nsa/research-dashboard-local--git-root (directory)
+  (let ((root (nsa/research-dashboard-local--git
+               directory "rev-parse" "--show-toplevel")))
+    (and root (file-directory-p root) (file-truename root))))
+
+(defun nsa/research-dashboard-local--github-slug (remote)
+  (when (and remote
+             (string-match "github\\.com[:/]\\(.+\\)\\'" remote))
+    (string-remove-suffix ".git" (match-string 1 remote))))
+
+(defun nsa/research-dashboard-local--checkout-info (directory)
+  (let* ((scan-root (file-truename directory))
+         (repo-root (or (nsa/research-dashboard-local--git-root scan-root)
+                        scan-root))
+         (remote (nsa/research-dashboard-local--git
+                  repo-root "config" "--get" "remote.origin.url"))
+         (slug (nsa/research-dashboard-local--github-slug remote))
+         (branch (or (nsa/research-dashboard-local--git
+                      repo-root "symbolic-ref" "--quiet" "--short" "HEAD")
+                     "local"))
+         (commit (or (nsa/research-dashboard-local--git
+                      repo-root "rev-parse" "HEAD")
+                     "LOCAL")))
+    (list :scan-root scan-root
+          :repo-root repo-root
+          :repo (or slug (concat "local:" (file-name-nondirectory repo-root)))
+          :branch branch
+          :commit commit)))
+
+(defun nsa/research-dashboard-local--read (file)
+  (with-temp-buffer
+    (insert-file-contents file)
+    (buffer-string)))
+
+(defun nsa/research-dashboard-local--blob (file repo-root)
+  (or (nsa/research-dashboard-local--git repo-root "hash-object" file)
+      (concat "local:" (secure-hash 'sha256 file))))
+
+(defun nsa/research-dashboard-local--eligible-file-p (file)
+  (and (string-suffix-p ".org" file t)
+       (not (member (downcase (file-name-nondirectory file))
+                    nsa/research-dashboard--auxiliary-files))))
+
+(defun nsa/research-dashboard-local--item (info file)
+  (when (nsa/research-dashboard-local--eligible-file-p file)
+    (let* ((content (nsa/research-dashboard-local--read file))
+           (title (or (nsa/research-dashboard--keyword content "title")
+                      (file-name-base file)))
+           (lifecycle (or (nsa/research-dashboard--keyword content "status")
+                          "MISSING"))
+           (approval
+            (upcase (or (nsa/research-dashboard--keyword content "approval_state")
+                        "LEGACY"))))
+      (when (or (string= approval "PENDING")
+                (and (string= approval "LEGACY")
+                     (nsa/research-dashboard--legacy-reviewable-p lifecycle)))
+        (let* ((repo-root (plist-get info :repo-root))
+               (path (file-relative-name file repo-root)))
+          (nsa/research-item-create
+           :repo (plist-get info :repo)
+           :branch (plist-get info :branch)
+           :path path
+           :blob (nsa/research-dashboard-local--blob file repo-root)
+           :title title
+           :lifecycle lifecycle
+           :approval approval
+           :content content))))))
+
+(defun nsa/research-dashboard-local--register (item file)
+  (let ((id (nsa/research-dashboard-local--id item)))
+    (puthash id file nsa/research-dashboard-local--files)
+    (when (hash-table-p nsa/research-dashboard--seen)
+      (puthash id t nsa/research-dashboard--seen))
+    (setq nsa/research-dashboard--items
+          (cons item
+                (seq-remove
+                 (lambda (existing)
+                   (string= id (nsa/research-dashboard-local--id existing)))
+                 nsa/research-dashboard--items)))))
+
+(defun nsa/research-dashboard-local--scan-directory (directory)
+  (condition-case error-data
+      (let* ((info (nsa/research-dashboard-local--checkout-info directory))
+             (scan-root (plist-get info :scan-root)))
+        (dolist (file (directory-files-recursively scan-root "\\.org\\'"))
+          (let ((item (nsa/research-dashboard-local--item info file)))
+            (when item
+              (nsa/research-dashboard-local--register item file)))))
+    (error
+     (push (format "Local research %s: %s"
+                   directory (error-message-string error-data))
+           nsa/research-dashboard--errors))))
+
+(defun nsa/research-dashboard-local--scan-current-buffer ()
+  (unless (hash-table-p nsa/research-dashboard-local--files)
+    (setq nsa/research-dashboard-local--files (make-hash-table :test #'equal)))
+  (clrhash nsa/research-dashboard-local--files)
+  (dolist (directory nsa/research-dashboard-local-checkouts)
+    (let ((expanded (expand-file-name directory)))
+      (if (file-directory-p expanded)
+          (nsa/research-dashboard-local--scan-directory expanded)
+        (push (format "Local research directory missing: %s" expanded)
+              nsa/research-dashboard--errors))))
+  (nsa/research-dashboard--schedule-render))
+
+(defun nsa/research-dashboard-local--file-for-item (item)
+  (and (hash-table-p nsa/research-dashboard-local--files)
+       (gethash (nsa/research-dashboard-local--id item)
+                nsa/research-dashboard-local--files)))
+
+(defun nsa/research-dashboard-local--refresh-advice (original &rest args)
+  (prog1 (apply original args)
+    (when (derived-mode-p 'nsa/research-dashboard-mode)
+      (nsa/research-dashboard-local--scan-current-buffer))))
+
+(defun nsa/research-dashboard-local--job-done-advice
+    (original generation &optional item error-text)
+  (if (and item (nsa/research-dashboard-local--file-for-item item))
+      (funcall original generation nil error-text)
+    (funcall original generation item error-text)))
+
+(defun nsa/research-dashboard-local--render-advice (original &rest args)
+  (prog1 (apply original args)
+    (when (and (derived-mode-p 'nsa/research-dashboard-mode)
+               nsa/research-dashboard-local-checkouts)
+      (setq header-line-format
+            (concat header-line-format
+                    (format "   local:%d [d add dir] [D remove dir]"
+                            (hash-table-count
+                             nsa/research-dashboard-local--files)))))))
+
+(defun nsa/research-dashboard-local--view-advice (original &rest args)
+  (let* ((item (nsa/research-dashboard--at-point))
+         (file (nsa/research-dashboard-local--file-for-item item)))
+    (if (not file)
+        (apply original args)
+      (unless (file-exists-p file)
+        (user-error "Local research file disappeared: %s" file))
+      (pop-to-buffer (find-file-noselect file)))))
+
+(defun nsa/research-dashboard-local--checkout-metadata (file)
+  (let* ((directory (file-name-directory file))
+         (repo-root (or (nsa/research-dashboard-local--git-root directory)
+                        directory))
+         (commit (or (nsa/research-dashboard-local--git
+                      repo-root "rev-parse" "HEAD")
+                     "LOCAL")))
+    (cons commit (nsa/research-dashboard-local--blob file repo-root))))
+
+(defun nsa/research-dashboard-local--assert-writable (file expected)
+  (let ((visiting (get-file-buffer file)))
+    (when (and visiting
+               (buffer-local-value 'buffer-modified-p visiting))
+      (user-error "Local research buffer has unsaved changes: %s" file)))
+  (unless (string= expected (nsa/research-dashboard-local--read file))
+    (user-error "Research changed since refresh; refresh first")))
+
+(defun nsa/research-dashboard-local--write (file expected updated)
+  (nsa/research-dashboard-local--assert-writable file expected)
+  (let ((coding-system-for-write 'utf-8-unix))
+    (write-region updated nil file nil 'silent))
+  (let ((visiting (get-file-buffer file)))
+    (when (and visiting (not (buffer-modified-p visiting)))
+      (with-current-buffer visiting
+        (revert-buffer :ignore-auto :noconfirm)))))
+
+(defun nsa/research-dashboard-local--preview (item file state updated)
+  (let ((buffer (get-buffer-create "*Research Approval Preview*")))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "%s\n%s\n%s\n\n"
+                        (nsa/research-item-repo item)
+                        (nsa/research-item-path item)
+                        file))
+        (dolist (field nsa/research-dashboard--fields)
+          (insert (format "#+%s: %s\n" field
+                          (nsa/research-dashboard--keyword updated field))))
+        (insert "\nDelivery: direct local checkout write; Git is left dirty for review/commit.\n")
+        (special-mode)))
+    (display-buffer buffer)
+    (yes-or-no-p
+     (format "%s local %s? " state (file-name-nondirectory file)))))
+
+(defun nsa/research-dashboard-local--decide (state item file)
+  (when (nsa/research-item-busy item)
+    (user-error "Decision already running"))
+  (let* ((actor (read-string "Human decision-maker: "
+                             (or nsa/research-dashboard--login user-login-name)))
+         (evidence (read-string "Durable approval evidence: "
+                                "human:emacs-research-dashboard-local")))
+    (when (or (string-empty-p (string-trim actor))
+              (string-empty-p (string-trim evidence)))
+      (user-error "Actor and evidence must be nonempty"))
+    (setf (nsa/research-item-busy item) t)
+    (nsa/research-dashboard--render)
+    (condition-case error-data
+        (let* ((content (nsa/research-dashboard-local--read file))
+               (metadata (nsa/research-dashboard-local--checkout-metadata file))
+               (commit (car metadata))
+               (blob (cdr metadata))
+               (updated
+                (nsa/research-dashboard--decision-content
+                 content state actor evidence commit blob
+                 (format-time-string "%Y-%m-%dT%H:%M:%S%:z"))))
+          (unless (string= content (nsa/research-item-content item))
+            (user-error "Research changed since refresh; refresh first"))
+          (if (not (nsa/research-dashboard-local--preview
+                    item file state updated))
+              (progn
+                (setf (nsa/research-item-busy item) nil)
+                (nsa/research-dashboard--render))
+            (nsa/research-dashboard-local--write file content updated)
+            (message "%s %s — updated local checkout; Git left dirty"
+                     state file)
+            (nsa/research-dashboard-refresh)))
+      (error
+       (setf (nsa/research-item-busy item) nil)
+       (nsa/research-dashboard--render)
+       (signal (car error-data) (cdr error-data))))))
+
+(defun nsa/research-dashboard-local--decide-advice (original state)
+  (let* ((item (nsa/research-dashboard--at-point))
+         (file (nsa/research-dashboard-local--file-for-item item)))
+    (if file
+        (nsa/research-dashboard-local--decide state item file)
+      (funcall original state))))
+
+;;;###autoload
+(defun nsa/research-dashboard-local-add-directory (directory)
+  "Add DIRECTORY to the research dashboard's local sources and refresh."
+  (interactive (list (read-directory-name "Add research checkout/directory: ")))
+  (let ((directory (file-truename (expand-file-name directory))))
+    (unless (file-directory-p directory)
+      (user-error "Not a directory: %s" directory))
+    (cl-pushnew directory nsa/research-dashboard-local-checkouts :test #'string=)
+    (when (derived-mode-p 'nsa/research-dashboard-mode)
+      (nsa/research-dashboard-refresh))
+    (message "Research local source added: %s" directory)))
+
+;;;###autoload
+(defun nsa/research-dashboard-local-remove-directory (directory)
+  "Remove DIRECTORY from the research dashboard's local sources and refresh."
+  (interactive
+   (list
+    (completing-read "Remove research checkout/directory: "
+                     nsa/research-dashboard-local-checkouts nil t)))
+  (setq nsa/research-dashboard-local-checkouts
+        (delete directory nsa/research-dashboard-local-checkouts))
+  (when (derived-mode-p 'nsa/research-dashboard-mode)
+    (nsa/research-dashboard-refresh))
+  (message "Research local source removed: %s" directory))
+
+(defun nsa/research-dashboard-local--install ()
+  (unless nsa/research-dashboard-local--installed
+    (advice-add 'nsa/research-dashboard-refresh :around
+                #'nsa/research-dashboard-local--refresh-advice)
+    (advice-add 'nsa/research-dashboard--job-done :around
+                #'nsa/research-dashboard-local--job-done-advice)
+    (advice-add 'nsa/research-dashboard--render :around
+                #'nsa/research-dashboard-local--render-advice)
+    (advice-add 'nsa/research-dashboard-view :around
+                #'nsa/research-dashboard-local--view-advice)
+    (advice-add 'nsa/research-dashboard--decide :around
+                #'nsa/research-dashboard-local--decide-advice)
+    (define-key nsa/research-dashboard-mode-map (kbd "d")
+                #'nsa/research-dashboard-local-add-directory)
+    (define-key nsa/research-dashboard-mode-map (kbd "D")
+                #'nsa/research-dashboard-local-remove-directory)
+    (setq nsa/research-dashboard-local--installed t)))
+
+;;;###autoload
+(defun nsa/research-dashboard-local-setup ()
+  "Install local checkout support in the current research dashboard buffer."
+  (nsa/research-dashboard-local--install)
+  (setq-local nsa/research-dashboard-local--files
+              (make-hash-table :test #'equal)))
+
+;;;###autoload
+(add-hook 'nsa/research-dashboard-mode-hook #'nsa/research-dashboard-local-setup)
+
+(provide 'research-dashboard-local)
+;;; research-dashboard-local.el ends here

--- a/.doom.d/tests/research-dashboard-local-dwim-test.el
+++ b/.doom.d/tests/research-dashboard-local-dwim-test.el
@@ -1,0 +1,112 @@
+;;; research-dashboard-local-dwim-test.el --- DWIM forge tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'research-dashboard)
+(require 'research-dashboard-local)
+(require 'research-dashboard-local-dwim)
+
+(ert-deftest nsa/research-dashboard-local-dwim-parses-github-scp-ssh ()
+  (let ((parsed
+         (nsa/research-dashboard-local-dwim--parse-remote
+          "git@github.com:lost-rob0t/prolog-rlm.git")))
+    (should (equal (plist-get parsed :ssh-user) "git"))
+    (should (equal (plist-get parsed :host) "github.com"))
+    (should (equal (plist-get parsed :slug) "lost-rob0t/prolog-rlm"))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-parses-forgejo-scp-ssh ()
+  (let ((parsed
+         (nsa/research-dashboard-local-dwim--parse-remote
+          "git@git.starintel.actor:nsaspy/dotfiles.git")))
+    (should (equal (plist-get parsed :ssh-user) "git"))
+    (should (equal (plist-get parsed :host) "git.starintel.actor"))
+    (should (equal (plist-get parsed :slug) "nsaspy/dotfiles"))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-parses-ssh-url-with-port ()
+  (let ((parsed
+         (nsa/research-dashboard-local-dwim--parse-remote
+          "ssh://git@git.starintel.actor:2222/nsaspy/star-kb.git")))
+    (should (equal (plist-get parsed :ssh-user) "git"))
+    (should (equal (plist-get parsed :host) "git.starintel.actor"))
+    (should (equal (plist-get parsed :slug) "nsaspy/star-kb"))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-github-uses-gh-not-ssh-user ()
+  (let (calls)
+    (cl-letf (((symbol-function 'nsa/research-dashboard-local-dwim--command)
+               (lambda (_directory program &rest args)
+                 (push (cons program args) calls)
+                 (cond
+                  ((equal args '("repo" "view" "--json" "nameWithOwner"
+                                 "--jq" ".nameWithOwner"))
+                   "lost-rob0t/prolog-rlm")
+                  ((equal args '("api" "user" "--jq" ".login"))
+                   "lost-rob0t"))))))
+      (let ((info
+             (nsa/research-dashboard-local-dwim--forge-info
+              "/tmp/repo" "git@github.com:lost-rob0t/prolog-rlm.git")))
+        (should (eq (plist-get info :provider) 'github))
+        (should (equal (plist-get info :repo) "lost-rob0t/prolog-rlm"))
+        (should (equal (plist-get info :actor) "lost-rob0t"))
+        (should (seq-some (lambda (call) (equal (car call) "gh")) calls))
+        (should-not (equal (plist-get info :actor) "git"))))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-forgejo-uses-tea-context ()
+  (let (calls)
+    (cl-letf (((symbol-function 'nsa/research-dashboard-local-dwim--command)
+               (lambda (_directory program &rest args)
+                 (push (cons program args) calls)
+                 (when (and (equal program "tea")
+                            (equal args '("api" "/user")))
+                   "{\"login\":\"nsaspy\"}")))))
+      (let ((info
+             (nsa/research-dashboard-local-dwim--forge-info
+              "/tmp/repo"
+              "git@git.starintel.actor:nsaspy/starintel-auto-research.git")))
+        (should (eq (plist-get info :provider) 'forgejo))
+        (should (equal (plist-get info :host) "git.starintel.actor"))
+        (should
+         (equal (plist-get info :repo)
+                "git.starintel.actor/nsaspy/starintel-auto-research"))
+        (should (equal (plist-get info :actor) "nsaspy"))
+        (should (seq-some (lambda (call) (equal (car call) "tea")) calls))))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-plain-git-falls-back-cleanly ()
+  (cl-letf (((symbol-function 'nsa/research-dashboard-local-dwim--command)
+             (lambda (&rest _args) nil)))
+    (let ((info
+           (nsa/research-dashboard-local-dwim--forge-info
+            "/tmp/repo" "git@git.example.net:team/research.git")))
+      (should (eq (plist-get info :provider) 'git))
+      (should (equal (plist-get info :repo)
+                     "git.example.net/team/research"))
+      (should-not (plist-get info :actor)))))
+
+(ert-deftest nsa/research-dashboard-local-dwim-decision-defaults-to-forge-user ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (setq nsa/research-dashboard-local-dwim--identities
+          (make-hash-table :test #'equal))
+    (let ((item
+           (nsa/research-item-create
+            :repo "git.starintel.actor/nsaspy/research"
+            :branch "main"
+            :path "research/example.org"
+            :blob "blob"
+            :title "Example"
+            :lifecycle "RESEARCHED"
+            :approval "PENDING"
+            :content "body"))
+          seen-login)
+      (puthash
+       "git.starintel.actor/nsaspy/research:research/example.org"
+       '(:provider forgejo :actor "nsaspy")
+       nsa/research-dashboard-local-dwim--identities)
+      (let ((nsa/research-dashboard--login "lost-rob0t"))
+        (nsa/research-dashboard-local-dwim--decide-advice
+         (lambda (_state _item _file)
+           (setq seen-login nsa/research-dashboard--login))
+         "APPROVED" item "/tmp/example.org"))
+      (should (equal seen-login "nsaspy")))))
+
+(provide 'research-dashboard-local-dwim-test)
+;;; research-dashboard-local-dwim-test.el ends here

--- a/.doom.d/tests/research-dashboard-local-dwim-test.el
+++ b/.doom.d/tests/research-dashboard-local-dwim-test.el
@@ -40,7 +40,7 @@
                                  "--jq" ".nameWithOwner"))
                    "lost-rob0t/prolog-rlm")
                   ((equal args '("api" "user" "--jq" ".login"))
-                   "lost-rob0t"))))))
+                   "lost-rob0t")))))
       (let ((info
              (nsa/research-dashboard-local-dwim--forge-info
               "/tmp/repo" "git@github.com:lost-rob0t/prolog-rlm.git")))
@@ -57,7 +57,7 @@
                  (push (cons program args) calls)
                  (when (and (equal program "tea")
                             (equal args '("api" "/user")))
-                   "{\"login\":\"nsaspy\"}")))))
+                   "{\"login\":\"nsaspy\"}"))))
       (let ((info
              (nsa/research-dashboard-local-dwim--forge-info
               "/tmp/repo"

--- a/.doom.d/tests/research-dashboard-local-test.el
+++ b/.doom.d/tests/research-dashboard-local-test.el
@@ -1,0 +1,114 @@
+;;; research-dashboard-local-test.el --- Tests for local research sources -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'research-dashboard)
+(require 'research-dashboard-local)
+
+(defconst nsa/research-dashboard-local-test--canonical
+  "#+title: Local research\n#+status: RESEARCHED\n#+approval_schema: prolog-rlm.research-approval.v1\n#+approval_state: PENDING\n#+approval_actor: NONE\n#+approval_evidence: NONE\n#+approval_base_commit: NONE\n#+approval_base_blob: NONE\n#+approval_decided_at: NONE\n\n* Findings\nLocal body\n")
+
+(defun nsa/research-dashboard-local-test--read (file)
+  (with-temp-buffer
+    (insert-file-contents file)
+    (buffer-string)))
+
+(ert-deftest nsa/research-dashboard-local-parses-github-remotes ()
+  (should (equal (nsa/research-dashboard-local--github-slug
+                  "git@github.com:lost-rob0t/prolog-rlm.git")
+                 "lost-rob0t/prolog-rlm"))
+  (should (equal (nsa/research-dashboard-local--github-slug
+                  "https://github.com/lost-rob0t/starintel-auto-research.git")
+                 "lost-rob0t/starintel-auto-research")))
+
+(ert-deftest nsa/research-dashboard-local-scans-explicit-arbitrary-directory ()
+  (let* ((root (make-temp-file "research-dashboard-local-" t))
+         (notes (expand-file-name "notes" root))
+         (file (expand-file-name "example.org" notes))
+         (nsa/research-dashboard-local-checkouts (list root)))
+    (unwind-protect
+        (progn
+          (make-directory notes t)
+          (with-temp-file file
+            (insert nsa/research-dashboard-local-test--canonical))
+          (with-temp-buffer
+            (nsa/research-dashboard-mode)
+            (setq nsa/research-dashboard--items nil
+                  nsa/research-dashboard--errors nil
+                  nsa/research-dashboard--seen (make-hash-table :test #'equal))
+            (nsa/research-dashboard-local--scan-current-buffer)
+            (should (= (length nsa/research-dashboard--items) 1))
+            (let* ((item (car nsa/research-dashboard--items))
+                   (id (nsa/research-dashboard-local--id item)))
+              (should (string-prefix-p "local:" (nsa/research-item-repo item)))
+              (should (equal (nsa/research-item-path item) "notes/example.org"))
+              (should (equal (gethash id nsa/research-dashboard-local--files)
+                             file)))))
+      (delete-directory root t))))
+
+(ert-deftest nsa/research-dashboard-local-register-shadows-remote-item ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (setq nsa/research-dashboard--seen (make-hash-table :test #'equal))
+    (let* ((remote (nsa/research-item-create
+                    :repo "lost-rob0t/prolog-rlm"
+                    :branch "main"
+                    :path "research/example.org"
+                    :blob "remote"
+                    :title "Remote"
+                    :lifecycle "RESEARCHED"
+                    :approval "PENDING"
+                    :content "remote"))
+           (local (nsa/research-item-create
+                   :repo "lost-rob0t/prolog-rlm"
+                   :branch "main"
+                   :path "research/example.org"
+                   :blob "local"
+                   :title "Local"
+                   :lifecycle "RESEARCHED"
+                   :approval "PENDING"
+                   :content "local")))
+      (setq nsa/research-dashboard--items (list remote))
+      (nsa/research-dashboard-local--register local "/tmp/example.org")
+      (should (equal nsa/research-dashboard--items (list local)))
+      (should (gethash "lost-rob0t/prolog-rlm:research/example.org"
+                       nsa/research-dashboard--seen)))))
+
+(ert-deftest nsa/research-dashboard-local-write-updates-checkout-file ()
+  (let ((file (make-temp-file "research-dashboard-local-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert nsa/research-dashboard-local-test--canonical))
+          (let* ((before (nsa/research-dashboard-local-test--read file))
+                 (updated
+                  (nsa/research-dashboard--decision-content
+                   before "APPROVED" "operator" "human:test"
+                   "local-head" "local-blob"
+                   "2026-09-10T23:59:00-04:00")))
+            (nsa/research-dashboard-local--write file before updated)
+            (let ((after (nsa/research-dashboard-local-test--read file)))
+              (should (string-match-p "^#\\+approval_state: APPROVED$" after))
+              (should (string-match-p "^#\\+approval_base_commit: local-head$" after)))))
+      (delete-file file))))
+
+(ert-deftest nsa/research-dashboard-local-write-refuses-stale-content ()
+  (let ((file (make-temp-file "research-dashboard-local-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file (insert "new content\n"))
+          (should-error
+           (nsa/research-dashboard-local--write
+            file "old content\n" "replacement\n")
+           :type 'user-error))
+      (delete-file file))))
+
+(ert-deftest nsa/research-dashboard-local-installs-pane-controls ()
+  (with-temp-buffer
+    (nsa/research-dashboard-mode)
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "d"))
+                #'nsa/research-dashboard-local-add-directory))
+    (should (eq (lookup-key nsa/research-dashboard-mode-map (kbd "D"))
+                #'nsa/research-dashboard-local-remove-directory))))
+
+(provide 'research-dashboard-local-test)
+;;; research-dashboard-local-test.el ends here

--- a/.github/workflows/research-dashboard.yml
+++ b/.github/workflows/research-dashboard.yml
@@ -6,8 +6,10 @@ on:
       - '.doom.d/autoload/research-dashboard.el'
       - '.doom.d/autoload/research-dashboard-evil.org'
       - '.doom.d/autoload/research-dashboard-evil.el'
+      - '.doom.d/autoload/research-dashboard-local.el'
       - '.doom.d/tests/research-dashboard-test.el'
       - '.doom.d/tests/research-dashboard-evil-test.el'
+      - '.doom.d/tests/research-dashboard-local-test.el'
       - '.github/workflows/research-dashboard.yml'
   push:
     branches: [master]
@@ -15,8 +17,10 @@ on:
       - '.doom.d/autoload/research-dashboard.el'
       - '.doom.d/autoload/research-dashboard-evil.org'
       - '.doom.d/autoload/research-dashboard-evil.el'
+      - '.doom.d/autoload/research-dashboard-local.el'
       - '.doom.d/tests/research-dashboard-test.el'
       - '.doom.d/tests/research-dashboard-evil-test.el'
+      - '.doom.d/tests/research-dashboard-local-test.el'
       - '.github/workflows/research-dashboard.yml'
 
 permissions:
@@ -35,4 +39,5 @@ jobs:
           -L .doom.d/autoload
           -l .doom.d/tests/research-dashboard-test.el
           -l .doom.d/tests/research-dashboard-evil-test.el
+          -l .doom.d/tests/research-dashboard-local-test.el
           -f ert-run-tests-batch-and-exit

--- a/.github/workflows/research-dashboard.yml
+++ b/.github/workflows/research-dashboard.yml
@@ -7,9 +7,12 @@ on:
       - '.doom.d/autoload/research-dashboard-evil.org'
       - '.doom.d/autoload/research-dashboard-evil.el'
       - '.doom.d/autoload/research-dashboard-local.el'
+      - '.doom.d/autoload/research-dashboard-local-defaults.el'
+      - '.doom.d/autoload/research-dashboard-local-dwim.el'
       - '.doom.d/tests/research-dashboard-test.el'
       - '.doom.d/tests/research-dashboard-evil-test.el'
       - '.doom.d/tests/research-dashboard-local-test.el'
+      - '.doom.d/tests/research-dashboard-local-dwim-test.el'
       - '.github/workflows/research-dashboard.yml'
   push:
     branches: [master]
@@ -18,9 +21,12 @@ on:
       - '.doom.d/autoload/research-dashboard-evil.org'
       - '.doom.d/autoload/research-dashboard-evil.el'
       - '.doom.d/autoload/research-dashboard-local.el'
+      - '.doom.d/autoload/research-dashboard-local-defaults.el'
+      - '.doom.d/autoload/research-dashboard-local-dwim.el'
       - '.doom.d/tests/research-dashboard-test.el'
       - '.doom.d/tests/research-dashboard-evil-test.el'
       - '.doom.d/tests/research-dashboard-local-test.el'
+      - '.doom.d/tests/research-dashboard-local-dwim-test.el'
       - '.github/workflows/research-dashboard.yml'
 
 permissions:
@@ -40,4 +46,5 @@ jobs:
           -l .doom.d/tests/research-dashboard-test.el
           -l .doom.d/tests/research-dashboard-evil-test.el
           -l .doom.d/tests/research-dashboard-local-test.el
+          -l .doom.d/tests/research-dashboard-local-dwim-test.el
           -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
Adds local checkout/directory sources to the Emacs research dashboard without changing the existing GitHub-backed behavior.

- Defaults local research roots to `~/starintel` and `~/Documents/Projects/prolog-rlm`.
- `d` adds a local checkout or arbitrary directory; `D` removes one.
- Git checkouts infer repository identity, branch, HEAD, and blob locally.
- DWIM forge identity: GitHub remotes use `gh` for canonical repo/user identity; Forgejo/Gitea remotes use `tea` from the checkout context.
- SSH remotes such as `git@github.com:owner/repo.git` and `git@git.starintel.actor:owner/repo.git` treat `git` as the transport account, never as the human actor.
- Local repo/path rows shadow remote duplicates.
- `RET` opens the real local file for editing.
- Approve/reject writes approval metadata through the local checkout and leaves Git dirty for explicit review/commit instead of creating a remote approval PR.
- Arbitrary non-Git directories and generic Git remotes fall back cleanly.
- Adds ERT coverage and includes all local/DWIM files in the research-dashboard workflow.