### PR TITLE
fix(starintel): package and validate tunnel helper

### DIFF
--- a/.config/starintel/tunnels.conf
+++ b/.config/starintel/tunnels.conf
@@ -1,0 +1,65 @@
+# ~/.config/starintel/tunnels.conf
+#
+# NAME              LOCAL_PORT  REMOTE_HOST  REMOTE_PORT  SSH_TARGET
+#
+# SSH_TARGET should be an alias from ~/.ssh/config.
+# Keep actual infrastructure IPs out of this file when the SSH alias already
+# knows how to reach the machine.
+
+# ---------------------------------------------------------------------------
+# starintel
+# Core StarIntel service host
+# ---------------------------------------------------------------------------
+
+# CouchDB + Fauxton
+couchdb             5984        127.0.0.1    5984         starintel
+
+# RabbitMQ AMQP
+rabbitmq-amqp       5672        127.0.0.1    5672         starintel
+
+# RabbitMQ management UI / HTTP API
+rabbitmq-ui         15672       127.0.0.1    15672        starintel
+
+# Valkey
+valkey              6379        127.0.0.1    6379         starintel
+
+
+# ---------------------------------------------------------------------------
+# StarIntel application services
+# ---------------------------------------------------------------------------
+#
+# Enable these once their listening ports are fixed in the deployment config.
+# Deliberately not inventing ports here. That is how config files become
+# archaeological sites.
+#
+# starintel-api     <local>     127.0.0.1    <remote>     starintel
+# quasar-api        <local>     127.0.0.1    <remote>     starintel
+# quasar-ui         <local>     127.0.0.1    <remote>     starintel
+# auto-dig          <local>     127.0.0.1    <remote>     starintel
+
+
+# ---------------------------------------------------------------------------
+# CouchDB search
+# ---------------------------------------------------------------------------
+#
+# Clouseau normally talks to CouchDB internally. Do not expose/tunnel it by
+# default unless you specifically need to debug the search service itself.
+#
+# clouseau          <local>     127.0.0.1    <remote>     starintel
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure hosts
+# ---------------------------------------------------------------------------
+#
+# Add services on other machines by changing only SSH_TARGET. This lets
+# `starintel-tunnel all` become the single entry point across the whole infra.
+#
+# Example:
+#
+# proxmox-ui        18006       127.0.0.1    8006         proxmox
+# ingest-api        18080       127.0.0.1    8080         ingest
+# hydra-ui          13000       127.0.0.1    3000         hydra
+#
+# Prefer alternate LOCAL_PORT values when the remote service uses a port that
+# conflicts with something already running locally.

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Check shell scripts
         run: |
           set -euo pipefail
-          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
-          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh
+          bash -n .bashrc scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets scripts/starintel-tunnel tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh tests/starintel-tunnel.sh
+          shellcheck --severity=warning scripts/*.sh tests/home-manager-updater.sh tests/gpt-todos-sync.sh tests/llm-log-expert-consumer.sh tests/skill-sync.sh tests/variety-home-manager.sh .bash_profile .config/bash/git-sync.sh .local/bin/screen-capture tests/screen-capture.sh scripts/agent-zero-tunnel scripts/remote-gui-launch scripts/install-termux-widgets scripts/starintel-tunnel tests/agent-zero-tunnel.sh tests/remote-gui-launch.sh tests/starintel-tunnel.sh
+      - name: Run StarIntel tunnel tests
+        run: bash tests/starintel-tunnel.sh
       - name: Run llm-log expert consumer contract
         run: bash tests/llm-log-expert-consumer.sh
       - name: Verify bash.org and .bashrc are tangled in sync

--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -10,6 +10,7 @@
     ./agent-verification.nix
     ./chatgpt-desktop.nix
     ./base.nix
+    ./starintel-tunnel.nix
     ./desktop.nix
     ./gnome.nix
     ./fonts.nix

--- a/nix/home-manager/mods/starintel-tunnel.nix
+++ b/nix/home-manager/mods/starintel-tunnel.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.starintelTunnel;
+
+  starintelTunnel = pkgs.writeShellApplication {
+    name = "starintel-tunnel";
+    runtimeInputs = [ pkgs.openssh ];
+    text = builtins.readFile ../../../scripts/starintel-tunnel;
+  };
+in
+{
+  options.programs.starintelTunnel.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = "Install the StarIntel SSH tunnel helper and its tunnel map.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ starintelTunnel ];
+
+    xdg.configFile."starintel/tunnels.conf".source =
+      ../../../.config/starintel/tunnels.conf;
+  };
+}

--- a/nix/home-manager/mods/starintel-tunnel.nix
+++ b/nix/home-manager/mods/starintel-tunnel.nix
@@ -19,7 +19,9 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ starintelTunnel ];
 
-    xdg.configFile."starintel/tunnels.conf".source =
-      ../../../.config/starintel/tunnels.conf;
+    xdg.configFile."starintel/tunnels.conf" = {
+      source = ../../../.config/starintel/tunnels.conf;
+      force = true;
+    };
   };
 }

--- a/scripts/starintel-tunnel
+++ b/scripts/starintel-tunnel
@@ -111,7 +111,7 @@ run_tunnel() {
 }
 
 run_all() {
-  local i pid status
+  local i status
   local -a pids=()
 
   cleanup() {

--- a/scripts/starintel-tunnel
+++ b/scripts/starintel-tunnel
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_file="${STARINTEL_TUNNELS_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/starintel/tunnels.conf}"
+
+die() {
+  printf 'starintel-tunnel: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: starintel-tunnel <command|name>
+
+Commands:
+  list          List configured tunnels.
+  all           Open every configured tunnel and keep them attached.
+  help          Show this help.
+
+A tunnel name opens one foreground SSH forward, for example:
+  starintel-tunnel couchdb
+
+Configuration defaults to:
+  $XDG_CONFIG_HOME/starintel/tunnels.conf
+or:
+  ~/.config/starintel/tunnels.conf
+
+Override it with STARINTEL_TUNNELS_CONFIG.
+EOF
+}
+
+declare -a tunnel_names=()
+declare -a local_ports=()
+declare -a remote_hosts=()
+declare -a remote_ports=()
+declare -a ssh_targets=()
+declare -A seen_names=()
+
+load_config() {
+  local line line_no name local_port remote_host remote_port ssh_target extra
+  line_no=0
+
+  [[ -r "$config_file" ]] || die "config is not readable: $config_file"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    ((line_no += 1))
+
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+    name=''
+    local_port=''
+    remote_host=''
+    remote_port=''
+    ssh_target=''
+    extra=''
+    read -r name local_port remote_host remote_port ssh_target extra <<<"$line"
+
+    if [[ -n "$extra" || -z "$name" || -z "$local_port" || -z "$remote_host" || -z "$remote_port" || -z "$ssh_target" ]]; then
+      die "invalid config row at $config_file:$line_no; expected NAME LOCAL_PORT REMOTE_HOST REMOTE_PORT SSH_TARGET"
+    fi
+
+    if [[ ! "$local_port" =~ ^[0-9]+$ ]] || ((local_port < 1 || local_port > 65535)); then
+      die "invalid local port '$local_port' at $config_file:$line_no"
+    fi
+
+    if [[ ! "$remote_port" =~ ^[0-9]+$ ]] || ((remote_port < 1 || remote_port > 65535)); then
+      die "invalid remote port '$remote_port' at $config_file:$line_no"
+    fi
+
+    if [[ -n "${seen_names[$name]+x}" ]]; then
+      die "duplicate tunnel name '$name' at $config_file:$line_no"
+    fi
+
+    seen_names["$name"]=1
+    tunnel_names+=("$name")
+    local_ports+=("$local_port")
+    remote_hosts+=("$remote_host")
+    remote_ports+=("$remote_port")
+    ssh_targets+=("$ssh_target")
+  done <"$config_file"
+
+  ((${#tunnel_names[@]} > 0)) || die "no tunnels configured in $config_file"
+}
+
+find_tunnel_index() {
+  local wanted="$1" i
+
+  for i in "${!tunnel_names[@]}"; do
+    if [[ "${tunnel_names[$i]}" == "$wanted" ]]; then
+      printf '%s\n' "$i"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+run_tunnel() {
+  local i="$1"
+  local forward="${local_ports[$i]}:${remote_hosts[$i]}:${remote_ports[$i]}"
+
+  printf 'starintel-tunnel: %s -> %s via %s\n' \
+    "${tunnel_names[$i]}" "$forward" "${ssh_targets[$i]}" >&2
+
+  exec ssh \
+    -o ExitOnForwardFailure=yes \
+    -N \
+    -L "$forward" \
+    "${ssh_targets[$i]}"
+}
+
+run_all() {
+  local i pid status
+  local -a pids=()
+
+  cleanup() {
+    local child
+    for child in "${pids[@]}"; do
+      kill "$child" 2>/dev/null || true
+    done
+  }
+
+  trap 'cleanup; exit 130' INT TERM
+
+  for i in "${!tunnel_names[@]}"; do
+    printf 'starintel-tunnel: opening %s -> %s:%s via %s\n' \
+      "${tunnel_names[$i]}" "${remote_hosts[$i]}" "${remote_ports[$i]}" "${ssh_targets[$i]}" >&2
+    ssh \
+      -o ExitOnForwardFailure=yes \
+      -N \
+      -L "${local_ports[$i]}:${remote_hosts[$i]}:${remote_ports[$i]}" \
+      "${ssh_targets[$i]}" &
+    pids+=("$!")
+  done
+
+  set +e
+  wait -n "${pids[@]}"
+  status=$?
+  set -e
+
+  cleanup
+  trap - INT TERM
+  return "$status"
+}
+
+main() {
+  local command index
+
+  if (($# != 1)); then
+    usage >&2
+    exit 2
+  fi
+
+  command="$1"
+
+  case "$command" in
+    help | -h | --help)
+      usage
+      return 0
+      ;;
+  esac
+
+  load_config
+
+  case "$command" in
+    list)
+      printf '%-20s %-10s %-20s %-11s %s\n' NAME LOCAL_PORT REMOTE_HOST REMOTE_PORT SSH_TARGET
+      for index in "${!tunnel_names[@]}"; do
+        printf '%-20s %-10s %-20s %-11s %s\n' \
+          "${tunnel_names[$index]}" \
+          "${local_ports[$index]}" \
+          "${remote_hosts[$index]}" \
+          "${remote_ports[$index]}" \
+          "${ssh_targets[$index]}"
+      done
+      ;;
+    all)
+      run_all
+      ;;
+    *)
+      if ! index="$(find_tunnel_index "$command")"; then
+        die "unknown tunnel '$command'; run 'starintel-tunnel list'"
+      fi
+      run_tunnel "$index"
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/starintel-tunnel.sh
+++ b/tests/starintel-tunnel.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+config="$tmpdir/tunnels.conf"
+log="$tmpdir/ssh.log"
+mkdir -p "$tmpdir/bin"
+
+cat >"$config" <<'EOF'
+# NAME LOCAL_PORT REMOTE_HOST REMOTE_PORT SSH_TARGET
+couchdb 5984 127.0.0.1 5984 starintel
+rabbitmq-ui 15672 127.0.0.1 15672 starintel
+EOF
+
+cat >"$tmpdir/bin/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$STARINTEL_TUNNEL_TEST_LOG"
+EOF
+chmod +x "$tmpdir/bin/ssh"
+
+list_output="$({
+  PATH="$tmpdir/bin:$PATH" \
+    STARINTEL_TUNNELS_CONFIG="$config" \
+    "$repo_root/scripts/starintel-tunnel" list
+})"
+
+grep -q '^couchdb' <<<"$list_output"
+grep -q '^rabbitmq-ui' <<<"$list_output"
+
+: >"$log"
+PATH="$tmpdir/bin:$PATH" \
+  STARINTEL_TUNNELS_CONFIG="$config" \
+  STARINTEL_TUNNEL_TEST_LOG="$log" \
+  "$repo_root/scripts/starintel-tunnel" couchdb
+
+grep -Fq -- '-o ExitOnForwardFailure=yes -N -L 5984:127.0.0.1:5984 starintel' "$log"
+
+cat >"$config" <<'EOF'
+couchdb 5984 127.0.0.1 5984 starintel
+couchdb 15984 127.0.0.1 5984 starintel
+EOF
+
+if PATH="$tmpdir/bin:$PATH" \
+  STARINTEL_TUNNELS_CONFIG="$config" \
+  "$repo_root/scripts/starintel-tunnel" list >"$tmpdir/duplicate.out" 2>"$tmpdir/duplicate.err"; then
+  printf 'expected duplicate tunnel config to fail\n' >&2
+  exit 1
+fi
+
+grep -Fq "duplicate tunnel name 'couchdb'" "$tmpdir/duplicate.err"
+
+duplicates="$(
+  awk 'NF && $1 !~ /^#/ { print $1 }' "$repo_root/.config/starintel/tunnels.conf" \
+    | sort \
+    | uniq -d
+)"
+
+if [[ -n "$duplicates" ]]; then
+  printf 'duplicate tunnel names in repo config:\n%s\n' "$duplicates" >&2
+  exit 1
+fi
+
+printf 'starintel-tunnel tests passed\n'

--- a/tests/starintel-tunnel.sh
+++ b/tests/starintel-tunnel.sh
@@ -25,7 +25,7 @@ chmod +x "$tmpdir/bin/ssh"
 list_output="$({
   PATH="$tmpdir/bin:$PATH" \
     STARINTEL_TUNNELS_CONFIG="$config" \
-    "$repo_root/scripts/starintel-tunnel" list
+    bash "$repo_root/scripts/starintel-tunnel" list
 })"
 
 grep -q '^couchdb' <<<"$list_output"
@@ -35,7 +35,7 @@ grep -q '^rabbitmq-ui' <<<"$list_output"
 PATH="$tmpdir/bin:$PATH" \
   STARINTEL_TUNNELS_CONFIG="$config" \
   STARINTEL_TUNNEL_TEST_LOG="$log" \
-  "$repo_root/scripts/starintel-tunnel" couchdb
+  bash "$repo_root/scripts/starintel-tunnel" couchdb
 
 grep -Fq -- '-o ExitOnForwardFailure=yes -N -L 5984:127.0.0.1:5984 starintel' "$log"
 
@@ -46,7 +46,7 @@ EOF
 
 if PATH="$tmpdir/bin:$PATH" \
   STARINTEL_TUNNELS_CONFIG="$config" \
-  "$repo_root/scripts/starintel-tunnel" list >"$tmpdir/duplicate.out" 2>"$tmpdir/duplicate.err"; then
+  bash "$repo_root/scripts/starintel-tunnel" list >"$tmpdir/duplicate.out" 2>"$tmpdir/duplicate.err"; then
   printf 'expected duplicate tunnel config to fail\n' >&2
   exit 1
 fi


### PR DESCRIPTION
## What changed

- adds a real `starintel-tunnel` CLI backed by `~/.config/starintel/tunnels.conf`;
- packages it through Home Manager so the command is on PATH after switch;
- manages the StarIntel tunnel config declaratively and removes the duplicated service rows;
- supports `list`, a named foreground tunnel, and `all`;
- rejects malformed rows, invalid ports, and duplicate tunnel names;
- adds CI coverage for command parsing, SSH forwarding arguments, and duplicate detection;
- keeps application-service ports commented until deployment assigns real ports.

## Expected use

```sh
home-manager switch --flake .#"unseen@desktop"
starintel-tunnel list
starintel-tunnel couchdb
# or
starintel-tunnel all
```

`SSH_TARGET` continues to resolve through `~/.ssh/config`; no infrastructure IPs are added here.