### PR TITLE
feat: install and refresh Agent Zero StarIntel skills hourly

### DIFF
--- a/nix/home-manager/mods/default.nix
+++ b/nix/home-manager/mods/default.nix
@@ -11,6 +11,7 @@
     ./chatgpt-desktop.nix
     ./base.nix
     ./starintel-tunnel.nix
+    ./starintel-agent-flow.nix
     ./desktop.nix
     ./gnome.nix
     ./fonts.nix

--- a/nix/home-manager/mods/starintel-agent-flow.nix
+++ b/nix/home-manager/mods/starintel-agent-flow.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  hourlyUpdater = pkgs.writeShellApplication {
+    name = "starintel-hourly-update";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.git
+      pkgs.openssh
+      pkgs.util-linux
+      config.programs.home-manager.package
+    ];
+    text = ''
+      exec ${pkgs.bash}/bin/bash ${../../../scripts/starintel-hourly-update.sh} "$@"
+    '';
+  };
+
+  installer = pkgs.writeShellApplication {
+    name = "install-starintel-hourly-update";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.nix
+    ];
+    text = ''
+      export STARINTEL_HOURLY_COMMAND="${config.home.profileDirectory}/bin/starintel-hourly-update"
+      exec ${pkgs.bash}/bin/bash ${../../../scripts/install-starintel-hourly-update.sh} "$@"
+    '';
+  };
+in
+{
+  home.packages = [
+    hourlyUpdater
+    installer
+  ];
+
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    persistent = true;
+    randomizedDelaySec = "30m";
+  };
+}

--- a/scripts/install-starintel-hourly-update.sh
+++ b/scripts/install-starintel-hourly-update.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[install-starintel-hourly-update] %s\n' "$*"
+}
+
+die() {
+  printf '[install-starintel-hourly-update] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in crontab nix-collect-garbage; do
+  command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+done
+
+agent_zero_root="${AGENT_ZERO_ROOT:-}"
+skills_repo="${STARINTEL_SKILLS_REPO:-$HOME/skills}"
+dotfiles_repo="${STARINTEL_DOTFILES_REPO:-$HOME/.dotfiles}"
+hm_configuration="${STARINTEL_HM_CONFIGURATION:-$(id -un)@$(hostname -s)}"
+hourly_command="${STARINTEL_HOURLY_COMMAND:-$HOME/.nix-profile/bin/starintel-hourly-update}"
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/starintel"
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/starintel"
+wrapper="$config_dir/starintel-hourly-update-cron"
+log_file="$state_dir/hourly-update.log"
+marker="# starintel-hourly-update"
+
+[[ -n "$agent_zero_root" ]] || die "AGENT_ZERO_ROOT is required"
+if [[ ! -x "$hourly_command" ]]; then
+  hourly_command="$(command -v starintel-hourly-update || true)"
+fi
+[[ -n "$hourly_command" && -x "$hourly_command" ]] || die "starintel-hourly-update is not installed"
+
+mkdir -p "$config_dir" "$state_dir"
+
+log "running one Nix garbage-collection pass"
+nix-collect-garbage
+
+log "running initial skills install and Home Manager update"
+AGENT_ZERO_ROOT="$agent_zero_root" \
+STARINTEL_SKILLS_REPO="$skills_repo" \
+STARINTEL_DOTFILES_REPO="$dotfiles_repo" \
+STARINTEL_HM_CONFIGURATION="$hm_configuration" \
+  "$hourly_command"
+
+printf '#!/usr/bin/env bash\nset -euo pipefail\nexport AGENT_ZERO_ROOT=%q\nexport STARINTEL_SKILLS_REPO=%q\nexport STARINTEL_DOTFILES_REPO=%q\nexport STARINTEL_HM_CONFIGURATION=%q\nexec %q\n' \
+  "$agent_zero_root" "$skills_repo" "$dotfiles_repo" "$hm_configuration" "$hourly_command" >"$wrapper"
+chmod 700 "$wrapper"
+
+existing="$(crontab -l 2>/dev/null || true)"
+filtered="$(printf '%s\n' "$existing" | grep -Fv "$marker" || true)"
+{
+  [[ -z "$filtered" ]] || printf '%s\n' "$filtered"
+  printf '0 * * * * %q >> %q 2>&1 %s\n' "$wrapper" "$log_file" "$marker"
+} | crontab -
+
+log "installed hourly cron entry"
+log "cron wrapper: $wrapper"
+log "log file: $log_file"

--- a/scripts/starintel-hourly-update.sh
+++ b/scripts/starintel-hourly-update.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[starintel-hourly-update] %s\n' "$*"
+}
+
+die() {
+  printf '[starintel-hourly-update] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+skills_repo="${STARINTEL_SKILLS_REPO:-$HOME/skills}"
+dotfiles_repo="${STARINTEL_DOTFILES_REPO:-$HOME/.dotfiles}"
+agent_zero_root="${AGENT_ZERO_ROOT:-}"
+hm_configuration="${STARINTEL_HM_CONFIGURATION:-$(id -un)@$(hostname -s)}"
+lock_file="${XDG_RUNTIME_DIR:-/tmp}/starintel-hourly-update.lock"
+
+for tool in git home-manager flock; do
+  command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+done
+[[ -n "$agent_zero_root" ]] || die "AGENT_ZERO_ROOT is required"
+[[ -d "$skills_repo/.git" ]] || die "skills checkout not found: $skills_repo"
+[[ -d "$dotfiles_repo/.git" ]] || die "dotfiles checkout not found: $dotfiles_repo"
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  log "another update is running; exiting"
+  exit 0
+fi
+
+ff_update() {
+  local repo="$1"
+  local label="$2"
+  local branch
+
+  if [[ -n "$(git -C "$repo" status --porcelain)" ]]; then
+    die "$label checkout is dirty; refusing to overwrite local work: $repo"
+  fi
+
+  branch="$(git -C "$repo" branch --show-current)"
+  [[ -n "$branch" ]] || die "$label checkout is detached: $repo"
+
+  log "updating $label ($branch)"
+  git -C "$repo" fetch --prune origin
+  git -C "$repo" merge --ff-only "origin/$branch"
+}
+
+install_agent_zero_skills() {
+  local source_root="$skills_repo/skills"
+  local target_root="$agent_zero_root/usr/skills"
+  local source name target existing
+
+  [[ -d "$source_root" ]] || die "canonical skills directory missing: $source_root"
+  mkdir -p "$target_root"
+
+  for source in "$source_root"/*; do
+    [[ -d "$source" && -f "$source/SKILL.md" ]] || continue
+    name="$(basename "$source")"
+    target="$target_root/$name"
+
+    if [[ -L "$target" ]]; then
+      existing="$(readlink -f "$target" || true)"
+      if [[ "$existing" == "$(readlink -f "$source")" ]]; then
+        continue
+      fi
+      rm -- "$target"
+    elif [[ -e "$target" ]]; then
+      die "refusing to replace non-symlink Agent Zero skill: $target"
+    fi
+
+    ln -s "$source" "$target"
+    log "installed Agent Zero skill: $name"
+  done
+}
+
+ff_update "$skills_repo" "skills"
+install_agent_zero_skills
+ff_update "$dotfiles_repo" "dotfiles"
+
+log "activating Home Manager configuration $hm_configuration"
+home-manager switch --flake "$dotfiles_repo#$hm_configuration" --show-trace
+log "complete"


### PR DESCRIPTION
## Summary
- add a dumb hourly updater that fast-forward updates `~/skills` and dotfiles, refreshes Agent Zero skill symlinks, then runs the current Home Manager configuration
- add an idempotent cron installer that runs one immediate `nix-collect-garbage`, performs the initial skill/Home Manager update, and installs the hourly cron entry
- install both commands through Home Manager
- enable Home Manager's user-profile Nix GC weekly with persistence and randomized delay

## Safety
- requires `AGENT_ZERO_ROOT` instead of guessing the Agent Zero installation root
- refuses dirty or detached Git checkouts
- uses `git merge --ff-only`
- refuses to replace non-symlink Agent Zero skill paths
- uses a lock to prevent overlapping hourly runs

## Usage after merge
Activate Home Manager once so the commands exist, then run:

```sh
AGENT_ZERO_ROOT=/path/to/agent-zero install-starintel-hourly-update
```

The installer performs the requested one-time GC and initial update before writing the hourly cron entry.

## Dependency
The new StarIntel coding-flow skills themselves are added by lost-rob0t/skills#46.