### PR TITLE
feat(zara): deploy Qwen3-TTS and Vulkan voice ingress

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789088058,
-        "narHash": "sha256-vRpaVhOzjSJw4uSLMwksCNtdb4onjEFJGzuoUWPkXm4=",
+        "lastModified": 1789194838,
+        "narHash": "sha256-18FWjkzyFsSJ6mCbTbqCQHSm2cY5zQt1gjQhwMduCHo=",
         "owner": "lost-rob0t",
         "repo": "Qwen3-TTS_server",
-        "rev": "71a15ff6024920b0c1924a4cc50f6a715861094d",
+        "rev": "eca273f5e8e1211b1bbf0f5623c90a67295604a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- deploy Qwen3-TTS as a loopback-only ROCm Home Manager service
- pin Zara to merged daemon Vulkan support and Qwen to its stereo prompt repair
- preserve the approved Home Manager revision
- repair the updated Qtile package's advertised desktop session filenames

## Verification
-  (36 checks)
- zara-workflows: ok
- actionlint, shell syntax, and shellcheck
- Zara PR #865 CI passed before deployment
- Qwen3-TTS PR #3 CI passed before deployment

Forgejo's general Nix workflow currently fails before dependent Nix jobs run; its dedicated Zara contract workflow passes. This GitHub PR is the configured CI fallback.